### PR TITLE
chore: add open_pr.sh helper for auto-merge workflow

### DIFF
--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/open_pr.sh "PR title" "PR body"
+# Opens a PR from the current branch to main and enables auto-merge.
+# Requires: gh CLI authenticated, branch already pushed to origin.
+
+set -euo pipefail
+
+TITLE="${1:-}"
+BODY="${2:-}"
+
+if [[ -z "$TITLE" ]]; then
+  echo "Usage: $0 \"PR title\" \"PR body\"" >&2
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "Opening PR: $TITLE ($BRANCH -> main)"
+PR_URL=$(gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "$TITLE" \
+  --body "$BODY")
+
+echo "PR created: $PR_URL"
+
+echo "Enabling auto-merge..."
+gh pr merge "$PR_URL" --auto --merge
+
+echo "Done. Will merge automatically when CI passes."


### PR DESCRIPTION
Helper that pushes the current branch, opens a PR to main, and enables auto-merge. Used to complete a feature branch with one command after commit. Requires gh CLI + branch already pushed to origin.