### PR TITLE
fix(tasks): match reminder phrasing with time qualifiers and polite wrappers

### DIFF
--- a/src/tasks/task_handler.py
+++ b/src/tasks/task_handler.py
@@ -44,8 +44,12 @@ EXPLICIT_TASK_PATTERNS = (
     r"track (.+?) as (?:a )?tasks?",
     # "add X to my task list" / "put X on my task list"
     r"(?:add|put) (.+?) (?:to|on) my task list",
-    # "remind me to X" / "I need to remember to X"
-    r"remind me to (.+)",
+    # "remind me to X" / "remind me at/in/tomorrow to X" / polite wrappers
+    # The optional non-greedy group absorbs time qualifiers like "at 5pm",
+    # "in 10 minutes", "tomorrow", "on Monday", etc. Polite prefixes like
+    # "can you", "could you", "i'd love it if you could" are matched via
+    # pattern.search() and stripped by _clean_title().
+    r"remind me(?:\s+[^,]*?)? to (.+)",
     r"i need to remember to (.+)",
 )
 

--- a/tests/test_task_handler.py
+++ b/tests/test_task_handler.py
@@ -77,6 +77,31 @@ class TestExplicitTaskDetection:
         titles = detect_explicit_task_request("I need to remember to call the dentist")
         assert titles == ["Call the dentist"]
 
+    # --- Time-qualified and polite-wrapped reminder phrasings ---
+
+    def test_remind_me_at_time(self):
+        titles = detect_explicit_task_request("Remind me at 5pm to stop working")
+        assert titles == ["Stop working"]
+
+    def test_remind_me_tomorrow(self):
+        titles = detect_explicit_task_request("Remind me tomorrow to call the dentist")
+        assert titles == ["Call the dentist"]
+
+    def test_could_you_remind_me_at_time(self):
+        titles = detect_explicit_task_request("Could you remind me at 5pm to stop working")
+        assert titles == ["Stop working"]
+
+    def test_polite_wrapper_remind_me_at_time(self):
+        # Verbatim reproduction of the reported bug prompt.
+        titles = detect_explicit_task_request(
+            "I'd love it if you could remind me at 5pm to stop working"
+        )
+        assert titles == ["Stop working"]
+
+    def test_remind_me_in_duration(self):
+        titles = detect_explicit_task_request("Remind me in 10 minutes to check the oven")
+        assert titles == ["Check the oven"]
+
     # --- Multi-item lists ---
 
     def test_comma_separated_list(self):


### PR DESCRIPTION
## Summary

Fixes a silent-fail in the explicit task creation path. Phrasings like `remind me at 5pm to stop working` or `I'd love it if you could remind me to X` did not match the regex, so no task record was written even though Ember responded as if one had been created.

## Root cause

`src/tasks/task_handler.py:48` required the literal substring `remind me to`, which is broken by any words between `remind me` and `to` (time qualifiers, polite wrappers, etc.).

## Fix

Broadens the pattern to accept optional non-comma content between `remind me` and `to`:

```python
# before
r"remind me to (.+)",
# after
r"remind me(?:\s+[^,]*?)? to (.+)",
```

Polite wrappers work automatically via `pattern.search()`. `_clean_title()` already strips residual filler prefixes, so captured titles stay imperative.

## Test plan

- [x] 5 new tests in `TestExplicitTaskDetection` cover time qualifiers (`at 5pm`, `tomorrow`, `in 10 minutes`) and polite wrappers (`Could you ...`, `I'd love it if you could ...`)
- [x] Verbatim reproduction of the reported bug prompt included
- [x] Existing `test_remind_me_to` still passes (new regex is a superset)
- [x] Full suite: 1476 passed / 19 deselected / 0 failures
- [ ] Live verify: POST tester's prompt → new task record in vault with title "Stop working" (owner to run in separate terminal)

## Out of scope

Q-002 in sprint checklist: after this fix, Ember may still say "I'll remind you at 5pm" even though there's no wall-clock scheduler. The task record is written; the spoken response is a separate honesty gap, logged for a follow-up.