### PR TITLE
feat(api): add POST /v1/service/shutdown for UI shut-down button

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,14 +13,16 @@ a refactor candidate if the file exceeds ~1500 lines.
 
 import json
 import logging
+import os
 import secrets
+import signal
 import time
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 
 import ollama
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -1046,6 +1048,21 @@ def pin_change_endpoint(request: Request, body: PinChangeRequest):
 # ── Service management endpoints ─────────────────────────────────────
 
 
+def _shutdown_self(delay: float = 3.0) -> None:
+    """Send SIGTERM to our own process after a delay.
+
+    Fallback for dev runs without the watchdog. The delay lets a running
+    watchdog observe ember_stop.signal and kill us first, which prevents
+    the watchdog from seeing an "unexpected exit" and restarting
+    (scripts/watchdog.py:118).
+    """
+    time.sleep(delay)
+    try:
+        os.kill(os.getpid(), signal.SIGTERM)
+    except Exception:
+        pass
+
+
 @app.post("/v1/service/{name}/restart")
 def service_restart_endpoint(name: str):
     """Restart a named service (api or docker).
@@ -1159,6 +1176,27 @@ def service_stop_endpoint(name: str):
             raise HTTPException(status_code=500, detail=f"Failed to stop docker: {exc}")
 
     raise HTTPException(status_code=400, detail=f"Unknown service: {name}. Valid: api, docker.")
+
+
+@app.post("/v1/service/shutdown")
+def service_shutdown_endpoint(background_tasks: BackgroundTasks):
+    """Shut down the Ember API permanently (no auto-restart).
+
+    Writes ember_stop.signal so the watchdog kills the API and exits
+    itself. Also schedules an in-process SIGTERM as a fallback for dev
+    runs without the watchdog. Returns immediately; the kill fires
+    after the response is flushed.
+
+    The 3s delay in _shutdown_self is load-bearing: it lets a running
+    watchdog observe the signal and stop the API first, avoiding the
+    watchdog's unexpected-exit restart path.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    signal_path = repo_root / "ember_stop.signal"
+    signal_path.write_text("stop", encoding="utf-8")
+
+    background_tasks.add_task(_shutdown_self)
+    return {"status": "shutting_down"}
 
 
 # ── System endpoints ──────────────────────────────────────────────────

--- a/tests/test_service_endpoints.py
+++ b/tests/test_service_endpoints.py
@@ -98,6 +98,62 @@ class TestServiceRestart:
         assert "Unknown service" in resp.json()["detail"]
 
 
+class TestServiceShutdown:
+    """POST /v1/service/shutdown."""
+
+    def _client(self):
+        with patch("src.api.main.get_ember_api_key", return_value=None):
+            from fastapi.testclient import TestClient
+            from src.api.main import app
+            return TestClient(app)
+
+    def _cleanup_signal(self):
+        from pathlib import Path
+        sig = Path(__file__).resolve().parents[1] / "ember_stop.signal"
+        if sig.exists():
+            sig.unlink()
+
+    def test_shutdown_returns_200_and_shutting_down_body(self):
+        # Patch the self-kill helper so the test runner doesn't die.
+        with patch("src.api.main.get_ember_api_key", return_value=None), \
+             patch("src.api.main._shutdown_self") as mock_kill:
+            resp = self._client().post("/v1/service/shutdown")
+        try:
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "shutting_down"}
+            # Background task was scheduled and TestClient ran it.
+            mock_kill.assert_called_once()
+        finally:
+            self._cleanup_signal()
+
+    def test_shutdown_writes_stop_signal_file(self):
+        from pathlib import Path
+        sig = Path(__file__).resolve().parents[1] / "ember_stop.signal"
+        try:
+            with patch("src.api.main.get_ember_api_key", return_value=None), \
+                 patch("src.api.main._shutdown_self"):
+                resp = self._client().post("/v1/service/shutdown")
+            assert resp.status_code == 200
+            assert sig.exists()
+            assert sig.read_text(encoding="utf-8") == "stop"
+        finally:
+            self._cleanup_signal()
+
+    def test_shutdown_does_not_actually_kill_under_mock(self):
+        # Belt-and-suspenders: patch os.kill too so even if the helper
+        # ran (it shouldn't, since _shutdown_self is mocked), it can't
+        # take down the test process.
+        with patch("src.api.main.get_ember_api_key", return_value=None), \
+             patch("src.api.main._shutdown_self"), \
+             patch("src.api.main.os.kill") as mock_oskill:
+            resp = self._client().post("/v1/service/shutdown")
+        try:
+            assert resp.status_code == 200
+            mock_oskill.assert_not_called()
+        finally:
+            self._cleanup_signal()
+
+
 class TestDeveloperStatus:
     """GET /v1/developer/status."""
 


### PR DESCRIPTION
## Summary

Adds the backend endpoint the UI already calls from its "Shut Down Ember" button. Before this PR, the UI got a 404 and the catch block swallowed it silently — the app kept running.

## Behavior

- `POST /v1/service/shutdown` → `{"status": "shutting_down"}` immediately
- Writes `ember_stop.signal` → watchdog observes, kills API + exits itself (no restart loop)
- Schedules an in-process `SIGTERM` after a 3s delay via FastAPI `BackgroundTasks` as a fallback for dev runs without the watchdog
- 3s delay is load-bearing: lets the watchdog win the kill race, preventing its unexpected-exit auto-restart path (`scripts/watchdog.py:118`)
- Response flushes before any kill fires (FastAPI contract for BackgroundTasks)

## Why not just reuse `/v1/service/api/stop`?

The UI was coded against `/v1/service/shutdown` specifically. M-side wire is correct; the endpoint just never shipped. Adding it is less work than changing the UI. The existing `/stop` remains untouched.

## Test plan

- [x] `TestServiceShutdown` class added (3 tests): 200/body, signal-file write, no-real-kill under mock
- [x] Signal file cleaned up in each test's `finally`
- [x] Full suite: 1479 passed / 19 deselected / 0 failures
- [ ] Live UI verify: click "Shut Down Ember" → API stops within ~3s, no auto-relaunch (owner to test from UI)

## Risks / notes

- Same auth/dev-mode posture as the existing `/stop` and `/restart` endpoints (ungated; API binds to `127.0.0.1`)
- Orphaned `ember_stop.signal` in dev path if no watchdog running — same limitation as existing `/stop`; watchdog clears stale signals on next start (`watchdog.py:109`)