### PR TITLE
fix(logging): remove em dashes from logger calls (Windows cp1252)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -130,7 +130,7 @@ async def api_key_auth(request: Request, call_next):
         provided_key = request.headers.get("X-API-Key", "")
 
     if not provided_key or not secrets.compare_digest(provided_key, expected_key):
-        logger.warning("[AUTH] Rejected request to %s — invalid or missing API key", request.url.path)
+        logger.warning("[AUTH] Rejected request to %s - invalid or missing API key", request.url.path)
         return JSONResponse(status_code=401, content={"detail": "Invalid or missing API key"})
 
     return await call_next(request)

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -410,7 +410,7 @@ def _extract_session_id(request: Request) -> str:
     session_id = request.headers.get("X-Session-ID", "").strip()
     if not session_id:
         session_id = f"sess_{uuid.uuid4().hex[:16]}"
-        logger.info("[SESSION] No X-Session-ID header — generated %s", session_id)
+        logger.info("[SESSION] No X-Session-ID header - generated %s", session_id)
     return session_id
 
 
@@ -794,7 +794,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # (3) ### Task: guard — Open WebUI injects a RAG wrapper as the last user message.
     #     The real user query is always the second-to-last user message.
     if latest_user_message.startswith("### Task:"):
-        logger.warning("[INTERCEPT] ### Task: injection detected — using prior user message")
+        logger.warning("[INTERCEPT] ### Task: injection detected - using prior user message")
         prior_user_messages = user_messages[:-1]
         if prior_user_messages:
             latest_user_message = prior_user_messages[-1].content or ""
@@ -804,7 +804,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # (1) Empty message guard — fires only when there is truly nothing:
     #     no text AND no image parts. Image-only uploads are not empty.
     if (not latest_user_message or not latest_user_message.strip()) and not image_parts:
-        logger.warning("[INTERCEPT] Empty user message — returning without pipeline")
+        logger.warning("[INTERCEPT] Empty user message - returning without pipeline")
         return ChatCompletionsResponse(
             id=f"chatcmpl-{uuid.uuid4().hex}",
             object="chat.completion",
@@ -858,7 +858,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
 
     # If image present but no text, use a placeholder so the pipeline runs.
     if image_parts and not latest_user_message.strip():
-        logger.warning("[IMAGE] Image upload with no text — %d image part(s)", len(image_parts))
+        logger.warning("[IMAGE] Image upload with no text - %d image part(s)", len(image_parts))
         latest_user_message = "Please describe what you see in this image."
 
     # Extract raw base64 strings from image_url parts (strip data URL prefix).

--- a/src/llm/adapter.py
+++ b/src/llm/adapter.py
@@ -275,7 +275,7 @@ class LLMAdapter:
         # or the coaching filter rewrite returned empty, surface a
         # recoverable error rather than sending a blank response to the user.
         if not final_response or not final_response.strip():
-            logger.warning("[RESPONSE] Empty final_response — surfacing fallback message")
+            logger.warning("[RESPONSE] Empty final_response - surfacing fallback message")
             final_response = (
                 "I had trouble generating a response to that. Try rephrasing, "
                 "or let me know what you're actually trying to figure out."
@@ -558,7 +558,7 @@ class LLMAdapter:
         if not api_key:
             raise ValueError("No Anthropic API key configured. Store one via POST /provider-key.")
 
-        logger.info("[CLOUD] Anthropic %s — non-streaming", self.model)
+        logger.info("[CLOUD] Anthropic %s - non-streaming", self.model)
 
         resp = httpx.post(
             "https://api.anthropic.com/v1/messages",
@@ -591,7 +591,7 @@ class LLMAdapter:
         if not api_key:
             raise ValueError("No Anthropic API key configured. Store one via POST /provider-key.")
 
-        logger.info("[CLOUD] Anthropic %s — streaming", self.model)
+        logger.info("[CLOUD] Anthropic %s - streaming", self.model)
 
         with httpx.stream(
             "POST",
@@ -644,7 +644,7 @@ class LLMAdapter:
         if not api_key:
             raise ValueError("No OpenAI API key configured. Store one via POST /provider-key.")
 
-        logger.info("[CLOUD] OpenAI %s — non-streaming", self.model)
+        logger.info("[CLOUD] OpenAI %s - non-streaming", self.model)
 
         resp = httpx.post(
             "https://api.openai.com/v1/chat/completions",
@@ -678,7 +678,7 @@ class LLMAdapter:
         if not api_key:
             raise ValueError("No OpenAI API key configured. Store one via POST /provider-key.")
 
-        logger.info("[CLOUD] OpenAI %s — streaming", self.model)
+        logger.info("[CLOUD] OpenAI %s - streaming", self.model)
 
         with httpx.stream(
             "POST",

--- a/src/llm/coaching_filter.py
+++ b/src/llm/coaching_filter.py
@@ -248,7 +248,7 @@ def _rewrite(text: str, matches: list[dict]) -> str:
 
         # Sanity check: rewrite should not be empty or drastically longer
         if not rewritten or len(rewritten) > len(text) * 2:
-            logger.warning("[COACHING_FILTER] Rewrite rejected — empty or too long")
+            logger.warning("[COACHING_FILTER] Rewrite rejected - empty or too long")
             return text
 
         return rewritten
@@ -409,7 +409,7 @@ def _rewrite_identity_collapse(text: str) -> str:
         rewritten = response["message"]["content"].strip()
 
         if not rewritten or len(rewritten) > len(text) * 2:
-            logger.warning("[COACHING_FILTER] Identity rewrite rejected — empty or too long")
+            logger.warning("[COACHING_FILTER] Identity rewrite rejected - empty or too long")
             return text
 
         return rewritten

--- a/src/llm/post_gen_pipeline.py
+++ b/src/llm/post_gen_pipeline.py
@@ -138,7 +138,7 @@ def run_post_gen_pipeline(
             "I tried searching but hit an error. Want me to try again?"
         )
         ask_first_substituted = True
-        logger.warning("[POSTGEN] confirmation search failed — retry offer substituted")
+        logger.warning("[POSTGEN] confirmation search failed - retry offer substituted")
 
     if not reply or not reply.strip():
         reply = _EMPTY_FALLBACK

--- a/src/onboarding/service.py
+++ b/src/onboarding/service.py
@@ -100,7 +100,7 @@ class OnboardingService:
         # First ever call — no state record yet
         if not records:
             self._write_progress(step=0, completed=[])
-            logger.info("[ONBOARDING] Starting — asking step 0 (%s)", ONBOARDING_STEPS[0].key)
+            logger.info("[ONBOARDING] Starting - asking step 0 (%s)", ONBOARDING_STEPS[0].key)
             return _WELCOME.format(first_question=ONBOARDING_STEPS[0].question)
 
         # Subsequent calls — save answer for current step, then advance
@@ -169,5 +169,5 @@ class OnboardingService:
             formatted = resp["message"]["content"].strip()
             return formatted if len(formatted) >= 10 else answer
         except Exception as exc:
-            logger.warning("[ONBOARDING] LLM format call failed: %s — storing raw answer", exc)
+            logger.warning("[ONBOARDING] LLM format call failed: %s - storing raw answer", exc)
             return answer

--- a/src/reflection/session_reflection.py
+++ b/src/reflection/session_reflection.py
@@ -66,7 +66,7 @@ def generate_session_reflection(
         The reflection text, or None if generation failed or was skipped.
     """
     if not buffer_turns or len(buffer_turns) < MIN_TURNS_FOR_REFLECTION:
-        logger.info("[SESSION_REFLECT] Skipped — %d turns (minimum %d)", len(buffer_turns), MIN_TURNS_FOR_REFLECTION)
+        logger.info("[SESSION_REFLECT] Skipped - %d turns (minimum %d)", len(buffer_turns), MIN_TURNS_FOR_REFLECTION)
         return None
 
     model = model or get_ember_model()

--- a/src/retrieval/vector_index.py
+++ b/src/retrieval/vector_index.py
@@ -68,7 +68,7 @@ class VectorIndex:
                 )
                 return []
 
-            logger.info("[VECTOR_INDEX] Cache miss — loading: %s (%.2f MB)", index_path.name, size_mb)
+            logger.info("[VECTOR_INDEX] Cache miss - loading: %s (%.2f MB)", index_path.name, size_mb)
 
             with index_path.open("r", encoding="utf-8") as f:
                 data = json.load(f)

--- a/src/state/state_extractor.py
+++ b/src/state/state_extractor.py
@@ -134,7 +134,7 @@ class StateExtractor:
         # Skip short messages — unlikely to contain state
         word_count = len(user_message.split())
         if word_count < MIN_WORDS_FOR_EXTRACTION:
-            logger.info("[STATE_EXTRACT] Skipped — user message too short (%d words)", word_count)
+            logger.info("[STATE_EXTRACT] Skipped - user message too short (%d words)", word_count)
             return []
 
         # Build the extraction prompt


### PR DESCRIPTION
## Summary

Sweeps 18 em-dash characters from `logger.*` calls across 9 files. Per CLAUDE.md Bug Fix Standard #7, non-ASCII characters in diagnostic prints crash on Windows cp1252 and produce silent failures that look like routing bugs. Recent commit `d7fb0fd` already did the same fix for one state log line; this is the broader sweep.

## How it surfaced

During live verify of the new shutdown endpoint, the auth log showed:
```
[AUTH] Rejected request to /v1/tasks (?) invalid or missing API key
```
The `(?)` was an em dash (`U+2014`) failing to render under cp1252 — the same class of bug `d7fb0fd` already fixed once.

## Scope

Only `logger.*` and `print()` lines were modified. Em dashes in docstrings, prompts, user-facing strings, and Ember's nature/voice content are preserved.

| File | Replacements |
|---|---|
| `src/api/main.py` | 1 (the auth line) |
| `src/api/openai_adapter.py` | 4 |
| `src/llm/adapter.py` | 5 |
| `src/llm/coaching_filter.py` | 2 |
| `src/llm/post_gen_pipeline.py` | 1 |
| `src/onboarding/service.py` | 2 |
| `src/reflection/session_reflection.py` | 1 |
| `src/retrieval/vector_index.py` | 1 |
| `src/state/state_extractor.py` | 1 |
| **Total** | **18** |

## Test plan

- [x] Re-scan after fix: 0 non-ASCII chars remain in `logger.*`/`print()` lines under `src/`
- [x] Full suite: 1479 passed / 19 deselected / 0 failures
- [ ] Live verify: trigger an auth rejection and confirm the log line renders cleanly under cp1252