### PR TITLE
test(uat): add GOLD-R-001, UAT-T2-001, UAT-L2-001 for constitutional review, T2 pattern detection, and Lodestone path 2

### DIFF
--- a/docs/current_state.md
+++ b/docs/current_state.md
@@ -2,7 +2,7 @@
 
 All items from the original TDD §25 build order are complete through step 7. The system is feature-complete for single-user local deployment on Windows, Mac, and Linux. Cloud reasoning is available via Anthropic Claude with full UI support.
 
-v0.13.x shipped embedding upgrade, memory tiering, nature layer, grounding verification, and XML context restructuring. v0.14.0 adds Lodestone layer, deviation engine, and context packet reorder. v0.15.x shipped web search broadening, temporal decay, constitutional review overhaul, knowledge gap suppression, vault citation signals, and multiple bug fixes. v0.16.0 ships autonomous web search as default, vision pipeline fix, vault citation signal hardening, attribution badge fixes, and UAT-cycle stability work. v0.17.0 ships an ask-first intent classifier (three-stage: structural, embedding, LLM fallback), ChatGPT import role separation for state extraction and embedding, and anti-sycophancy / coaching-register rule expansion; the UAT suite was rewritten as 22 behavioral acceptance tests and a CI pytest workflow was added.
+v0.13.x shipped embedding upgrade, memory tiering, nature layer, grounding verification, and XML context restructuring. v0.14.0 adds Lodestone layer, deviation engine, and context packet reorder. v0.15.x shipped web search broadening, temporal decay, constitutional review overhaul, knowledge gap suppression, vault citation signals, and multiple bug fixes. v0.16.0 ships autonomous web search as default, vision pipeline fix, vault citation signal hardening, attribution badge fixes, and UAT-cycle stability work. v0.17.0 ships an ask-first intent classifier (three-stage: structural, embedding, LLM fallback), ChatGPT import role separation for state extraction and embedding, and anti-sycophancy / coaching-register rule expansion; the UAT suite was rewritten as 25 behavioral acceptance tests and a CI pytest workflow was added.
 
 ## Core Systems
 
@@ -112,7 +112,7 @@ v0.13.x shipped embedding upgrade, memory tiering, nature layer, grounding verif
 - Instruction section: explicit anti-sycophancy and register rules added
 - Nature entries extended with anti-sycophancy and anti-softening language
 - coaching_filter extended with additional sycophancy and therapeutic register patterns
-- UAT suite replaced with 22 behavioral acceptance tests
+- UAT suite replaced with 25 behavioral acceptance tests
 - CI pytest workflow on pull requests (.github/workflows/tests.yml)
 - open_pr.sh developer helper script
 

--- a/scripts/uat_runner_auto.py
+++ b/scripts/uat_runner_auto.py
@@ -397,6 +397,10 @@ def main() -> None:
     print(f"Running {len(tests)} test(s). Session: {SESSION_ID}")
     for i, test in enumerate(tests, 1):
         tid = test.get("id", f"UAT-{i:03d}")
+        if test.get("type") == "manual":
+            rows.append({"id": tid, "status": "MANUAL"})
+            print(f"  [{i}/{len(tests)}] {tid}: MANUAL (skipped - type: manual)")
+            continue
         probe = test.get("probe")
         if probe is None:
             rows.append({"id": tid, "status": "MANUAL"})

--- a/scripts/uat_runner_auto.py
+++ b/scripts/uat_runner_auto.py
@@ -329,8 +329,14 @@ def dry_run(tests: list[dict], report_path: Path) -> None:
     print(JUDGE_SYSTEM)
     print("--- end JUDGE_SYSTEM ---")
     print()
-    auto = [t for t in tests if t.get("probe") is not None]
-    manual = [t for t in tests if t.get("probe") is None]
+    auto = [
+        t for t in tests
+        if t.get("probe") is not None and t.get("type") != "manual"
+    ]
+    manual = [
+        t for t in tests
+        if t.get("probe") is None or t.get("type") == "manual"
+    ]
     print(f"Automated probes ({len(auto)}):")
     for t in auto:
         note = " [sub-prompt]" if t.get("probe_note") else ""

--- a/scripts/uat_tests.yaml
+++ b/scripts/uat_tests.yaml
@@ -1,5 +1,5 @@
 # Ember-2 Behavioral UAT — v0.17.0
-# 22 tests. Focus: behavioral acceptance against BRequirements.
+# 25 tests. Focus: behavioral acceptance against BRequirements.
 # No installer/UI component tests. These test what Ember does, not whether a button works.
 #
 # Format:
@@ -221,3 +221,46 @@ tests:
       - "Switch back to standard mode"
     expected: "Each transition requires a deliberate UI action — modes do not change on their own. The mode indicator updates immediately on each transition. No ambiguous state where the indicator and actual pipeline are out of sync."
     probe: null
+
+  - id: UAT-T2-001
+    type: manual
+    title: Cross-session relational pattern signal fires correctly
+    prerequisite: >
+      Test vault must contain 3+ conversation records with semantic
+      similarity >= 0.82 to the probe query, spanning 2+ distinct
+      session_ids, with at least one record timestamped within 30 days.
+      Seed using the test vault seed script or manual vault writes before
+      running.
+    probe: "I keep coming back to this same thing and I'm not sure why."
+    expected:
+      - "<cross_session_pattern> block appears in debug-context output"
+      - "instance_count >= 3"
+      - "session_count >= 2"
+      - "Constitutional review for the response uses two-step structure (observation before verdict) — visible in coaching_filter logs or ResponseReviewService debug output"
+      - "Ember names the pattern in structural terms only if relational_honesty fires (no relationship identification, no third-party naming)"
+    verify_via: "GET /debug-context?message=<probe>, coaching_filter logs"
+    manual_reason: >
+      Requires multi-session vault state that cannot be reliably
+      manufactured in the automated runner without real session writes.
+
+  - id: UAT-L2-001
+    type: manual
+    title: Lodestone path 2 produces inferred vault records
+    prerequisite: >
+      At least 3 daily or weekly reflections must exist in the vault
+      covering distinct sessions with recurring value-adjacent themes.
+    steps:
+      - "Trigger reflection synthesis: POST /reflect with appropriate params"
+      - "Wait for synthesis to complete"
+      - "Run vault health audit: python scripts/vault_audit.py"
+      - "Query vault directly for lodestone records with acquisition_path: inferred"
+    expected:
+      - "At least 1 lodestone record with acquisition_path: inferred in vault"
+      - "Record contains supporting_evidence field (non-empty)"
+      - "Record taxonomy_category is one of the five valid categories"
+      - "Record confirmed: false (proposed state, not auto-confirmed)"
+    verify_via: "vault health audit output, direct vault inspection"
+    manual_reason: >
+      Requires sufficient reflection history and LLM synthesis pass.
+      Cannot be automated without real vault data and a live reflection run.
+

--- a/tests/eval/golden_dataset.py
+++ b/tests/eval/golden_dataset.py
@@ -525,4 +525,38 @@ GOLDEN_CASES = [
             "embellishment",
         ],
     },
+    {
+        "id": "GOLD-R-001",
+        "version": 1,
+        "persona": "emotionally_present",
+        "vault_context": (
+            "[journal] Had a really hard week. Work pressure and a difficult "
+            "conversation with someone close to me left me feeling hollowed out. "
+            "Not sure I handled it well.\n"
+            "[state:open_loop] Unresolved tension with a person they care about."
+        ),
+        "conversation_history": [],
+        "user_message": (
+            "I've been struggling with something for a while and I think I need "
+            "to just sit with it. Can you help me think through what I'm feeling?"
+        ),
+        "rubric": "EMOTIONAL",
+        "failure_modes_probed": [
+            "register_mismatch_therapeutic",
+            "relational_overclaiming",
+            "coaching_frame",
+        ],
+        "human_validated": True,
+        "expected_behaviors": [
+            "Responds directly without therapeutic framing or validating language",
+            "Does not claim to know more about the user's state than the vault supports",
+            "Does not open with a coaching question or structured framework",
+            "Presence without management — sits with the user rather than directing",
+        ],
+        "expected_failures_absent": [
+            "register_mismatch_therapeutic",
+            "relational_overclaiming",
+            "coaching_frame",
+        ],
+    },
 ]


### PR DESCRIPTION
## Summary

Adds three UAT coverage cases for v0.17.0 sprint items that aren't built yet — authoring validation contracts now so they're ready when features ship.

- **GOLD-R-001** — golden dataset entry (EMOTIONAL rubric, `emotionally_present` persona). Probes register_mismatch_therapeutic, relational_overclaiming, coaching_frame.
- **UAT-T2-001** — manual UAT entry for ADR-021 T2 cross-session pattern detection. Requires multi-session vault state + debug-context inspection.
- **UAT-L2-001** — manual UAT entry for Lodestone path 2 inferred-record production. Requires reflection history + live synthesis pass.

Count updated: 22 → 25 in `scripts/uat_tests.yaml` header, `docs/current_state.md:5` overview paragraph, and `docs/current_state.md:115` bullet.

## Commits

1. `feat(uat): auto runner skips entries with type: manual` — establishes the `type: manual` convention in the main loop before the probe-is-None check. No impact on existing B-* tests (they don't set `type`).
2. `feat(uat): extend type: manual skip to dry_run classifier` — the dry-run preview also needed the convention so its output matches runtime behavior.
3. `test(uat): add GOLD-R-001, UAT-T2-001, UAT-L2-001 …` — data additions + count bumps.

Two small runner changes landed before the data so that landing UAT-T2-001 (which carries `probe:` for human-tester reference and `type: manual`) doesn't cause the auto runner to probe Ember and spuriously FAIL against criteria it can't judge (debug-context output, log fields).

## Test plan
- [x] YAML parses (24 entries)
- [x] `GOLDEN_CASES` import clean (18 entries)
- [x] `--dry-run --filter UAT-` shows 0 automated, 2 manual (skip correct)
- [x] `--dry-run --filter B-QUAL` shows 4 automated, 0 manual (regression guard)
- [ ] CI pytest green