### PR TITLE
docs: rewrite v0.16.0 release notes for general audience

### DIFF
--- a/release-v0.16.0/release_notes.md
+++ b/release-v0.16.0/release_notes.md
@@ -1,0 +1,47 @@
+**Ember-2 v0.16.0 — Vision, Bare Mode, Web Search Hardening**
+
+**What's new**
+
+Ember can now see images you send her. Drop an image into the chat and ask her about it and she'll look at it rather than ignoring it or making something up.
+
+You can now turn off Ember's personality layer for a conversation if you want plain, direct output without her voice. You can also turn off vault writing per conversation if you want a session that leaves no memory behind. Safety logging stays on in both cases.
+
+Web search now happens automatically when Ember thinks it's relevant. You don't have to ask. If you want her to search something specific, just tell her to search.
+
+Responses are less likely to slip into a coaching or therapy register on emotional topics. This was a consistent quality issue and a lot of work went into it this release.
+
+The interface has four visual styles to choose from. Fonts are self-hosted. The time-of-day greeting has 180 variants. Feature status is visible in the top bar.
+
+---
+
+**Technical details**
+
+- Vision pipeline (ADR-032): image_data forwarded through
+  LLMAdapter.chat; vision model preprocesses upstream, main
+  model runs with full character layer
+- Bare mode: personality layers stripped on opt-in; vault
+  retrieval, web search, safety logging remain active
+- Per-conversation vault toggle (ADR-031): stateless mode per
+  conversation; safety logs persist
+- Autonomous web search default: web_search_autonomous=True;
+  explicit/implicit marker split in context policies; "search
+  the web" bypasses ask-first
+- Two-stage post-generation coaching filter: therapeutic
+  register reduction on emotional/task content; semantic
+  rewrite pass for preference-expression identity collapse
+- Constitutional review additions: numeric fabrication
+  detector, validation-before-correction criterion
+- State items in vault citation signal: state records surface
+  alongside memory and reflection
+- CLI UAT runner, conversation quality eval framework,
+  synthetic test profile and test vault
+- 30+ UAT hardening fixes: ask-first confirmation flow,
+  retrieval leakage, vault badge, source suppression,
+  soft-delete cascade, override block SSE streaming, and more
+
+**Known issues**
+
+- cross_domain_leakage retrieval eval case is a pre-existing
+  FAIL, stable since April 17
+- CHANGELOG.md was not maintained during v0.15.0-v0.15.3;
+  this release consolidates those changes


### PR DESCRIPTION
## Summary

Creates `release-v0.16.0/release_notes.md` at the repo root with a general-audience rewrite of the v0.16.0 release notes.

**Context for the placement:** The repo's rolling `release_notes.md` at the root has already moved on to G's v0.17.0 draft, and `docs/releases/` was abandoned after v0.10.0 — so there was no in-repo file holding v0.16.0 notes. The authoritative v0.16.0 content currently lives only on the GitHub release body, which is technical-heavy. New file matches the `release-v0.16.0/` workspace coordination folder pattern.

## What this does NOT do
- Does not update the GitHub release body at https://github.com/niansahc/ember-2/releases/tag/v0.16.0. If you want the published release to show the new copy, that's a follow-up `gh release edit v0.16.0 --notes-file release-v0.16.0/release_notes.md` — flagging rather than doing it silently.

## Test plan
- [x] No code changes — existing test suite is unaffected.
- [ ] Human approval of the rewritten copy before considering the v0.16 docs updated.

## Scope guard
Only the new file is staged. G's in-progress edits on `fix/uat-timeout-180` (`.claude/settings.local.json`, `release_notes.md`) are not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)