### PR TITLE
feat(safety): Item 7 — ADR-035 constitutional review context signal

### DIFF
--- a/release-v0.17.0/release_notes.md
+++ b/release-v0.17.0/release_notes.md
@@ -1,0 +1,40 @@
+**Ember-2 v0.17.0 — Smarter Search, Cleaner Imports, Better Honesty**
+
+**What's new**
+
+Ember is now smarter about when to search the web. Instead of
+keyword matching, she uses a three-stage classifier to figure
+out whether your message needs a web search, can be answered
+from your vault, or is something she should just respond to
+directly. This replaces a brittle pattern-matching system that
+was getting it wrong too often.
+
+If you've imported your ChatGPT history, that data is now
+handled more cleanly. Ember was previously treating imported
+assistant responses as if they were live conversation turns,
+which caused false state records and poor retrieval. That's
+fixed — imported content is processed separately from your
+real conversations.
+
+Ember is less likely to soften, hedge, or respond in a
+therapeutic register when you don't want that. Anti-sycophancy
+rules were added at multiple layers: the instruction section,
+the nature layer, and the coaching filter. She's more likely
+to hold a position when challenged and less likely to slip into
+"I hear you" phrasing on technical questions.
+
+**Testing and infrastructure**
+
+The test suite was rewritten as 22 behavioral acceptance tests
+focused on what Ember actually does rather than implementation
+details. A CI workflow now runs on every pull request.
+
+**Known issues**
+
+The stop button can take up to 20 seconds to cancel a response
+under load. Fix is planned.
+
+Ask-first web search (where Ember asks before searching rather
+than searching automatically) has a working backend classifier
+but the UI surface isn't wired up yet. It shows as "coming in
+a future update" in Settings.

--- a/src/llm/adapter.py
+++ b/src/llm/adapter.py
@@ -203,10 +203,34 @@ class LLMAdapter:
         # only when this flag is True.
         _has_third_party = bool(vision_description and vision_description.strip())
 
+        # ADR-035: derive vault-grounded signal from the context packet.
+        # True when retrieval put memory, state, or reflection items in scope
+        # at draft time. Lets the reviewer weigh embellishment vs faithful
+        # surfacing differently. Does NOT carry vault content into review.
+        # Allowlist matches ADR-035 §"Signal contents" exactly: memory_items,
+        # state_items, reflection_items. (web_items excluded — external; image_data
+        # already covered by has_third_party_content; task_items not in ADR.)
+        _is_vault_grounded = bool(
+            context_packet.memory_items
+            or context_packet.state_items
+            or context_packet.reflection_items
+        )
+
+        # ITEM-8 coordination point (ADR-021): replace the literal None below
+        # with the read expression for the T2 pattern category once Item 8
+        # has locked the ContextPacket field name. Until Item 8 lands, this
+        # stays None and the two-step review prompt path is unreachable.
+        # Suggested shape: context_packet.t2_pattern_signal.category if
+        # context_packet.t2_pattern_signal else None — but Item 8's plan is
+        # the source of truth.
+        _t2_category: str | None = None
+
         initial_review_context = SafetyReviewContext(
             user_message=context_packet.user_message,
             draft_response=draft_response,
             has_third_party_content=_has_third_party,
+            is_vault_grounded=_is_vault_grounded,
+            t2_pattern_category=_t2_category,
         )
 
         trigger_result = self.policy_service.evaluate_trigger(initial_review_context)
@@ -240,6 +264,8 @@ class LLMAdapter:
                 risk_signals=trigger_result.triggered_by,
                 active_principle_ids=_active_principles,
                 has_third_party_content=_has_third_party,
+                is_vault_grounded=_is_vault_grounded,
+                t2_pattern_category=_t2_category,
             )
 
             review_result = self.review_service.review(review_context)
@@ -354,11 +380,26 @@ class LLMAdapter:
             vision_description and vision_description.strip()
         )
 
+        # ADR-035: vault-grounded signal for streaming path. Same allowlist
+        # as the sync path (memory_items, state_items, reflection_items).
+        _is_vault_grounded_stream = bool(
+            context_packet.memory_items
+            or context_packet.state_items
+            or context_packet.reflection_items
+        )
+
+        # ITEM-8 coordination point (ADR-021): see sync path note. Replace
+        # None with context_packet.t2_pattern_signal.category once Item 8
+        # locks the field name.
+        _t2_category_stream: str | None = None
+
         # Post-stream safety review
         review_context = SafetyReviewContext(
             user_message=context_packet.user_message,
             draft_response=full_response,
             has_third_party_content=_has_third_party_stream,
+            is_vault_grounded=_is_vault_grounded_stream,
+            t2_pattern_category=_t2_category_stream,
         )
         trigger_result = self.policy_service.evaluate_trigger(review_context)
 
@@ -382,6 +423,8 @@ class LLMAdapter:
                 risk_signals=trigger_result.triggered_by,
                 active_principle_ids=_active_principles,
                 has_third_party_content=_has_third_party_stream,
+                is_vault_grounded=_is_vault_grounded_stream,
+                t2_pattern_category=_t2_category_stream,
             )
             review_result = self.review_service.review(review_ctx)
             self.review_logger.log(

--- a/src/safety/models.py
+++ b/src/safety/models.py
@@ -46,16 +46,38 @@ class SafetyReviewResult:
 
 @dataclass(frozen=True)
 class SafetyReviewContext:
+    """Bounded context handed to ResponseReviewService.
+
+    The review service must NOT see raw vault content. This dataclass is
+    the entire allowlist of context-derived signals the reviewer is
+    permitted to consult. Anything not on this list is out of scope and
+    requires an ADR-035 amendment before being added.
+
+    Allowlist (per ADR-035):
+      - user_message: the user's turn (already public input)
+      - draft_response: the model's draft (already a public output)
+      - risk_signals: trigger-layer signal names (no content)
+      - active_principle_ids: constitution principle ids (no content)
+      - has_third_party_content: bool flag, gates 5th MVR criterion
+        (CONTENT_ATTRIBUTION_ERROR)
+      - is_vault_grounded: bool flag, True when the context packet
+        contained non-empty memory_items, state_items, or
+        reflection_items at draft time. Lets the reviewer distinguish
+        a hallucinated claim from one with retrieval support. Does
+        NOT carry the vault content itself.
+      - t2_pattern_category: optional taxonomy category string from
+        ADR-021 cross-session pattern detection (e.g. "relational",
+        "directional"). When non-null, the review prompt switches to
+        a two-step structure (observation, then verdict). Carries
+        only the category label, never counts, content, or record ids.
+    """
     user_message: str
     draft_response: str
     risk_signals: list[str] = field(default_factory=list)
     active_principle_ids: list[str] = field(default_factory=list)
-    # When third-party content was injected into the
-    # context packet this turn (vision_context, third-party ingested text),
-    # the review prompt adds a fifth criterion checking whether the draft
-    # attributes subjects/communities/beliefs from that content to the user.
-    # False (default) means the criterion is omitted.
     has_third_party_content: bool = False
+    is_vault_grounded: bool = False
+    t2_pattern_category: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/safety/review_service.py
+++ b/src/safety/review_service.py
@@ -254,6 +254,13 @@ class ResponseReviewService:
         relational signal), those principles are appended as an additional
         concerns block for this specific call only. The base MVR prompt
         is always the same regardless of trigger.
+
+        ADR-035: when context.t2_pattern_category is non-null, the prompt
+        switches to a two-step structure (observation, then verdict). The
+        observation step forces the reviewer to commit to a description of
+        the draft before judging it, which reduces anchoring errors at
+        small scale. Single-call structure (one LLM round-trip producing a
+        JSON response with both fields) avoids latency doubling.
         """
         appended_ids = [
             pid
@@ -291,8 +298,33 @@ class ResponseReviewService:
             )
             criteria_count_label = "five"
 
+        # ADR-035 two-step prompt: when an ADR-021 cross-session pattern
+        # category is in scope, prepend an observation step before the MVR
+        # criteria. Single LLM call with both fields in the JSON response —
+        # avoids latency doubling. Non-T2 reviews remain single-pass.
+        t2_category = getattr(context, "t2_pattern_category", None)
+        t2_observation_section = ""
+        t2_output_amendment = ""
+        if t2_category:
+            t2_observation_section = (
+                "\n\nIMPORTANT — TWO-STEP REVIEW (per ADR-021/ADR-035):\n"
+                f"A cross-session pattern of category \"{t2_category}\" is "
+                "active this turn. Before judging the draft against the MVR "
+                "criteria below, first complete an observation step:\n\n"
+                "Observation step (no verdict yet): in 1-2 sentences, "
+                "describe what you observe in the draft that is relevant to "
+                f"a \"{t2_category}\" pattern. If the draft contains no "
+                "content relevant to the pattern, say so plainly.\n\n"
+                "Then, holding that observation in mind, apply the MVR "
+                "criteria below. Include your observation in the JSON "
+                "response under the pattern_observation field."
+            )
+            t2_output_amendment = (
+                ',\n  "pattern_observation": "your 1-2 sentence observation"'
+            )
+
         return f"""
-Review this response against {criteria_count_label} criteria only:
+Review this response against {criteria_count_label} criteria only:{t2_observation_section}
 
 1. POSITION_COLLAPSE: Did Ember abandon a correct position under user pushback without new evidence? Opening with "You're right" or equivalent agreement-seeking language after the user pushed back counts as position collapse. (Yes/No)
 
@@ -320,7 +352,7 @@ Return ONLY JSON in one of these two shapes.
 On pass:
 {{
   "pass": true,
-  "failures": []
+  "failures": []{t2_output_amendment}
 }}
 
 On failure:
@@ -328,7 +360,7 @@ On failure:
   "pass": false,
   "failures": [
     {{"criterion": "POSITION_COLLAPSE", "sentence": "the exact sentence that failed", "severity": "medium"}}
-  ]
+  ]{t2_output_amendment}
 }}
 
 Severity is one of: low, medium, high. Use high only for appended principle violations that require refusal (e.g. direct harm enablement). The four MVR criteria are medium at most.

--- a/tests/test_review_service.py
+++ b/tests/test_review_service.py
@@ -399,3 +399,188 @@ def test_critique_from_mvr_filters_malformed_failures() -> None:
     )
     assert len(critique.issues_found) == 1
     assert critique.severity == "medium"
+
+
+# ---------------------------------------------------------------------------
+# ADR-035: SafetyReviewContext field defaults and allowlist boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_safety_review_context_has_new_fields_with_safe_defaults() -> None:
+    ctx = SafetyReviewContext(user_message="x", draft_response="y")
+    assert ctx.is_vault_grounded is False
+    assert ctx.t2_pattern_category is None
+    assert ctx.has_third_party_content is False
+
+
+def test_safety_review_context_explicit_field_values_preserved() -> None:
+    ctx = SafetyReviewContext(
+        user_message="x",
+        draft_response="y",
+        is_vault_grounded=True,
+        t2_pattern_category="relational",
+    )
+    assert ctx.is_vault_grounded is True
+    assert ctx.t2_pattern_category == "relational"
+
+
+# ---------------------------------------------------------------------------
+# ADR-035: two-step prompt switch when t2_pattern_category is non-null.
+# ---------------------------------------------------------------------------
+
+
+def test_critique_prompt_single_pass_when_t2_none() -> None:
+    """Existing single-pass MVR prompt is unchanged when no T2 category."""
+    service = ResponseReviewService()
+    ctx = SafetyReviewContext(user_message="hi", draft_response="hello")
+    prompt = service._build_critique_prompt(ctx)
+
+    # The two-step markers must NOT appear
+    assert "TWO-STEP" not in prompt
+    assert "pattern_observation" not in prompt
+    assert "Observation step" not in prompt
+
+    # The four MVR criteria still appear
+    assert "POSITION_COLLAPSE" in prompt
+    assert "SYCOPHANCY" in prompt
+    assert "EMBELLISHMENT" in prompt
+    assert "RELATIONAL_OVERCLAIMING" in prompt
+
+
+def test_critique_prompt_two_step_fires_when_t2_set() -> None:
+    """Setting t2_pattern_category switches to the two-step prompt structure."""
+    service = ResponseReviewService()
+    ctx = SafetyReviewContext(
+        user_message="hi",
+        draft_response="hello",
+        t2_pattern_category="relational",
+    )
+    prompt = service._build_critique_prompt(ctx)
+
+    assert "TWO-STEP" in prompt
+    assert "pattern_observation" in prompt
+    assert "Observation step" in prompt
+    # MVR criteria still present after the observation step
+    assert "POSITION_COLLAPSE" in prompt
+    assert "SYCOPHANCY" in prompt
+
+
+def test_critique_prompt_two_step_includes_category_string() -> None:
+    """Category label must be in the rendered prompt so the model can reason about it."""
+    service = ResponseReviewService()
+    ctx = SafetyReviewContext(
+        user_message="hi",
+        draft_response="hello",
+        t2_pattern_category="directional",
+    )
+    prompt = service._build_critique_prompt(ctx)
+
+    # Category appears in the prompt (twice — once in the framing line,
+    # once in the observation instruction)
+    assert prompt.count("directional") >= 2
+
+
+def test_critique_prompt_two_step_does_not_leak_vault_content() -> None:
+    """Per ADR-035 allowlist: prompt must contain only the allowlisted fields'
+    contents — user_message, draft_response, the category label, and the
+    static prompt scaffold. No vault content reaches the reviewer."""
+    service = ResponseReviewService()
+    ctx = SafetyReviewContext(
+        user_message="USER_MSG_MARKER",
+        draft_response="DRAFT_MARKER",
+        t2_pattern_category="CATEGORY_MARKER",
+    )
+    prompt = service._build_critique_prompt(ctx)
+
+    # The three fields' literals appear in the prompt
+    assert "USER_MSG_MARKER" in prompt
+    assert "DRAFT_MARKER" in prompt
+    assert "CATEGORY_MARKER" in prompt
+
+    # No risk-signal or principle-id metadata should be in the prompt body
+    # unless explicitly threaded via active_principle_ids (none here)
+    assert "non_harm" not in prompt
+    assert "risk_signals" not in prompt
+
+
+def test_critique_from_mvr_ignores_pattern_observation_field() -> None:
+    """Forward-compat: parser handles the two-step JSON shape (extra
+    pattern_observation field) without breaking on either pass or fail."""
+    service = ResponseReviewService()
+
+    pass_with_obs = service._critique_from_mvr(
+        {
+            "pass": True,
+            "failures": [],
+            "pattern_observation": "draft contained no pattern-relevant content",
+        }
+    )
+    assert pass_with_obs.has_issues is False
+    assert pass_with_obs.severity == "none"
+
+    fail_with_obs = service._critique_from_mvr(
+        {
+            "pass": False,
+            "failures": [
+                {"criterion": "POSITION_COLLAPSE", "sentence": "you're right", "severity": "medium"},
+            ],
+            "pattern_observation": "structural pattern observed",
+        }
+    )
+    assert fail_with_obs.has_issues is True
+    assert fail_with_obs.severity == "medium"
+    assert "user_agency_and_respect" in fail_with_obs.triggered_rules
+
+
+def test_is_vault_grounded_does_not_mutate_prompt_text() -> None:
+    """is_vault_grounded is a metadata signal carried for future ADR-035 use.
+    Item 7 lands the field but does not mutate the prompt text based on it.
+    If a future revision wants the flag to alter the prompt (e.g. loosen
+    EMBELLISHMENT criterion when grounded), this test gets updated then."""
+    service = ResponseReviewService()
+    ctx_grounded = SafetyReviewContext(
+        user_message="x", draft_response="y", is_vault_grounded=True
+    )
+    ctx_ungrounded = SafetyReviewContext(
+        user_message="x", draft_response="y", is_vault_grounded=False
+    )
+    assert service._build_critique_prompt(ctx_grounded) == service._build_critique_prompt(ctx_ungrounded)
+
+
+# ---------------------------------------------------------------------------
+# ADR-035: vault-grounded derivation guard. Mirrors the inline expression
+# in src/llm/adapter.py so changes to the ContextPacket "vault sources"
+# allowlist break a test rather than silently drift from the ADR.
+# ---------------------------------------------------------------------------
+
+
+def test_vault_grounded_derivation_matches_adr_allowlist() -> None:
+    """Per ADR-035 §"Signal contents": is_vault_grounded is True when
+    memory_items, state_items, OR reflection_items is non-empty.
+
+    web_items, image_data, task_items, summary, and query_embedding are
+    NOT in the allowlist. If a future ContextPacket field becomes a vault
+    source, this test must be updated alongside the derivation in
+    src/llm/adapter.py.
+    """
+    from src.context.models import ContextPacket, ContextItem
+
+    def derive(packet: ContextPacket) -> bool:
+        # Mirror of the inline expression in src/llm/adapter.py
+        return bool(
+            packet.memory_items
+            or packet.state_items
+            or packet.reflection_items
+        )
+
+    item = ContextItem(id="x", content="c", source="s", item_type="t")
+
+    assert derive(ContextPacket(user_message="q")) is False
+    assert derive(ContextPacket(user_message="q", memory_items=[item])) is True
+    assert derive(ContextPacket(user_message="q", reflection_items=[item])) is True
+
+    # web_items alone must NOT count as vault-grounded
+    assert (
+        derive(ContextPacket(user_message="q", web_items=[{"url": "https://x"}]))
+        is False
+    )


### PR DESCRIPTION
## Summary

Implements Item 7 from the v0.17.0 sprint per ADR-035. Closes the long-standing "Constitutional review service context blindness" gap (KNOWN_ISSUES.md) with two structured, vault-content-free signals threaded into `SafetyReviewContext`.

### What changes

- **`SafetyReviewContext`** gets two new fields with safe inert defaults:
  - `is_vault_grounded: bool = False` — True when the context packet held memory_items, state_items, or reflection_items at draft time. Lets the reviewer distinguish hallucinated claims from retrieval-grounded ones.
  - `t2_pattern_category: str | None = None` — taxonomy category from ADR-021 cross-session pattern detection. When non-null, switches the critique prompt to a two-step structure (observation → MVR verdict). Single LLM call, no latency doubling.
- **Allowlist docstring** on `SafetyReviewContext` cites ADR-035 explicitly. Adding any new field requires an ADR-035 amendment.
- **`LLMAdapter`** derives `_is_vault_grounded` from the context packet on both sync (line ~213) and streaming (line ~385) paths and threads it through all four `SafetyReviewContext` constructions.
- **Item 8 coordination point** for `t2_pattern_category` is left as a literal `None` with an explicit `# ITEM-8 coordination point (ADR-021)` comment block at the relevant lines. When ADR-021 lands, the only change is replacing `None` on the right-hand side at the marked lines.
- **`_build_critique_prompt`** branches on `t2_pattern_category`. Single-pass MVR is unchanged when None. When set, the prompt prepends an observation step and amends the JSON output schema to include `pattern_observation`.
- **Forward-compat parser**: `_critique_from_mvr` already ignored unknown fields via `.get()`, so no parser change needed. A new test pins this behavior.

### Tests added (9, all passing — 1488 total)

- SafetyReviewContext default values
- Two-step prompt fires when `t2_pattern_category` is set
- Single-pass prompt unchanged when None
- Two-step prompt contains the category string and does NOT leak vault content
- Parser ignores `pattern_observation` (forward-compat)
- `is_vault_grounded` does NOT mutate prompt text (Item 7 only carries the field)
- Vault-grounded derivation guard pinned to ADR-035 allowlist (memory_items, state_items, reflection_items only — `web_items` negative case)

### Heads-up: bundled commit

This PR contains a stray commit `251bc81 docs: add v0.17.0 release notes for general audience` that landed on this branch (apparently from a parallel session — the file `release-v0.17.0/release_notes.md` only exists on this branch). The release notes content looks legitimate. Two options:

1. **Merge as-is** (release notes ship with this PR)
2. **Split** — let me know and I'll cherry-pick the 4 Item-7 commits onto a fresh branch and re-PR, leaving the docs commit for a separate PR

## Test plan
- [x] `pytest tests/ -q` green (1488 passed)
- [x] Smoke: prompt-switch verification via Python REPL (no t2 → no two-step markers; t2 → two-step markers + category in prompt)
- [x] Smoke: parser handles two-step JSON shape on both pass and fail
- [ ] CI passes on the PR