### PR TITLE
docs(claude): never auto-merge release-please PRs

### DIFF
--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -131,6 +131,8 @@ Y does NOT cut independent releases when backend or UI changes are involved — 
 
 All three repos use release-please for automated release PRs. Conventional commits are required. Release PRs require human approval before merging.
 
+Release-please PRs (title format: "chore(main): release X.Y.Z") must NEVER have auto-merge enabled. These PRs require explicit human approval and manual merge only. The human decides when a release is cut. All other PR types (feat, fix, docs, test, chore non-release) may use auto-merge as normal.
+
 ---
 
 *Note: this checklist lives at `.claude/commands/pre-release.md`. Update it here, not in CLAUDE.md.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,8 @@ When writing prompts for Ember's inference-time tasks (reflection, review, synth
 
 Pre-release checklist: run `/pre-release`
 
+Release-please PRs (title format: "chore(main): release X.Y.Z") must NEVER have auto-merge enabled. These PRs require explicit human approval and manual merge only. The human decides when a release is cut. All other PR types (feat, fix, docs, test, chore non-release) may use auto-merge as normal.
+
 ---
 
 ## Key Design Risks to Watch


### PR DESCRIPTION
## Summary

Adds a hard rule that release-please PRs (title format \`chore(main): release X.Y.Z\`) must never have auto-merge enabled. Same wording in two places:

- \`CLAUDE.md\` — under \`## Release Checklist\`
- \`.claude/commands/pre-release.md\` — under the existing \`### release-please\` subsection

Motivation: v0.17.0 was auto-released without explicit human approval — release-please cut the PR and it merged. CLAUDE.md says the human decides when a release is cut. The rule makes that gate explicit at both the policy layer (CLAUDE.md) and the operational layer (the slash command checklist).

## Test plan
- [x] No code changes; pytest unaffected
- [ ] Human approval of wording

## Companion change
A matching commit will land in ember-2-installer (Y) with the same rule in its \`CLAUDE.md\` and \`.claude/commands/pre-release.md\` (if Y has one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)