### PR TITLE
fix(vision): VisionService env-var resolution + clear image_data after preprocessing

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1208,6 +1208,18 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
 
     used_vision = bool(_vision_description)
 
+    # ADR-032: when VL preprocessing succeeded, the image is already
+    # represented in the prompt as text via <vision_context>. Continuing
+    # to pass raw image bytes to the text model (qwen3:8b) is wasted at
+    # best and the trigger for the trained "I can't view images" RLHF
+    # refusal at worst. Clear image_data here so only the VL preprocessor
+    # ever sees the raw bytes; downstream LLM calls stay text-only.
+    # When preprocessing FAILED (used_vision=False), keep image_data on
+    # the packet so the legacy vision path can still attempt direct
+    # routing if a vision-capable text model is configured.
+    if used_vision:
+        context_packet.image_data = []
+
     # Web search autonomous mode: when web_search_autonomous=True, execute
     # searches directly on thin-vault factual queries instead of telling the
     # model to "offer to search". This respects the preference the user sets.

--- a/src/llm/vision_service.py
+++ b/src/llm/vision_service.py
@@ -22,8 +22,10 @@ import ollama
 
 logger = logging.getLogger("ember.vision")
 
-# Default vision model for the preprocessor pipeline.
-# Can be overridden via EMBER_VISION_MODEL env var (read by config).
+# Hardcoded fallback vision model. The runtime resolution order in
+# VisionService.__init__ is: explicit constructor arg → EMBER_VISION_MODEL
+# env var (via get_ember_vision_model()) → this fallback. Only reached when
+# both higher-priority sources are unset.
 DEFAULT_VISION_MODEL = "qwen3-vl:8b"
 
 # Vision analysis prompt — task-specific instructions for the vision model.
@@ -52,6 +54,9 @@ class VisionService:
     """
 
     def __init__(self, model: str | None = None) -> None:
+        if model is None:
+            from src.core.config import get_ember_vision_model
+            model = get_ember_vision_model()
         self.model = model or DEFAULT_VISION_MODEL
 
     def analyze(self, image_data: list[str]) -> str:

--- a/tests/test_vision_pipeline.py
+++ b/tests/test_vision_pipeline.py
@@ -205,3 +205,44 @@ class TestVisionInBuildPrompt:
         prompt = builder.build_prompt(packet, vision_description="")
 
         assert "<vision_context>" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# VisionService model resolution chain (env var honored)
+# ---------------------------------------------------------------------------
+
+
+class TestVisionServiceModelResolution:
+    """The constructor's model resolution order is:
+    1. explicit `model` arg
+    2. EMBER_VISION_MODEL env var (via get_ember_vision_model())
+    3. DEFAULT_VISION_MODEL hardcoded fallback
+    """
+
+    def test_explicit_model_arg_wins_over_env(self):
+        with patch.dict("os.environ", {"EMBER_VISION_MODEL": "from-env:1b"}):
+            service = VisionService(model="explicit-arg:1b")
+        assert service.model == "explicit-arg:1b"
+
+    def test_env_var_used_when_no_explicit_arg(self):
+        with patch.dict("os.environ", {"EMBER_VISION_MODEL": "from-env:11b"}):
+            service = VisionService()
+        assert service.model == "from-env:11b"
+
+    def test_default_used_when_neither_set(self):
+        from src.llm.vision_service import DEFAULT_VISION_MODEL
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+            saved = os.environ.pop("EMBER_VISION_MODEL", None)
+            try:
+                service = VisionService()
+                assert service.model == DEFAULT_VISION_MODEL
+            finally:
+                if saved is not None:
+                    os.environ["EMBER_VISION_MODEL"] = saved
+
+    def test_empty_env_var_falls_through_to_default(self):
+        from src.llm.vision_service import DEFAULT_VISION_MODEL
+        with patch.dict("os.environ", {"EMBER_VISION_MODEL": ""}):
+            service = VisionService()
+        assert service.model == DEFAULT_VISION_MODEL


### PR DESCRIPTION
## Summary

Fixes the vision pipeline failure (Ember responding "I can't view images or files directly" despite vision being enabled). Two related fixes, single PR, two source commits + one test commit.

### Commit 1 — `VisionService` honors `EMBER_VISION_MODEL`

`VisionService.__init__` was hardcoding `qwen3-vl:8b` as the default and never reading `EMBER_VISION_MODEL`. The comment claimed env-var override was supported but the code path didn't exist (`get_ember_vision_model()` in `src/core/config.py` was never called).

Resolution chain is now: explicit constructor arg → `EMBER_VISION_MODEL` env var → `DEFAULT_VISION_MODEL` fallback. This matches what the comment already promised.

### Commit 2 — Clear `image_data` after successful preprocessing

After VL returns a text description, the image is fully represented in `<vision_context>`. Continuing to pass raw image bytes through to the text model (`qwen3:8b`) does nothing useful and is the most likely trigger for the trained "I can't view images" RLHF refusal — `LLMAdapter._chat_ollama` attaches `images=image_data` to every Ollama call when the field is non-empty.

When VL succeeds (`used_vision=True`), `context_packet.image_data` is now cleared. When VL fails, the field is left intact so the legacy fallback path can attempt direct routing if a vision-capable text model is configured.

### Commit 3 — Tests

`TestVisionServiceModelResolution` (4 cases): explicit > env > default, plus empty-env-var falls through.

1492 tests pass (was 1488; +4).

## ADR-032 amendment note

ADR-032 line 18 names `qwen3-vl:8b` as the vision preprocessor. That was treated as a hard requirement in the code (hardcoded default with no env override). After this fix the env var is the configuration surface and `qwen3-vl:8b` is just the fallback when nothing is configured. ADR-032 should be amended to clarify that the model is configurable via `EMBER_VISION_MODEL` and the named model is an example, not a hard requirement. Not done in this PR — would be a separate docs commit.

## Live verification

Performed against API restarted from this branch with `.env` configured `EMBER_VISION_MODEL=llama3.2-vision:11b`:

1. **Pre-submission**: `qwen3:8b` loaded, no vision model loaded
2. **Direct VL probe**: `llama3.2-vision:11b` loaded successfully (17s), returned valid description for 1x1 PNG
3. **Image submission via Ember API** (`POST /v1/chat/completions` with `image_url` content + text "Describe the colors and shapes you observe"):
   - Response time: **110.9s** (full pipeline: VL preprocess + text generation)
   - Response: *"The image you shared is a solid olive green color, a muted and earthy tone without any bright or vibrant accents. There are no discernible shapes, objects, or patterns—just a blank, uniform space."* — describes actual image content via the VL preprocessor's output
   - Headers: `x-ember-vault-used: true`, `x-ember-vision-used: true` ✓
   - **No canned RLHF refusal** anywhere in the response

## Badge mystery resolution

The badge correctly fires only when VL preprocessing succeeded. The user's prior report of "Vision + Vault" badge with refusal text was likely the case where the VL preprocessor ran (badge correct) but `image_data` continued through to the text model, which emitted the canned refusal. Commit 2 closes that secondary failure.

## Test plan
- [x] Tier 1 pytest green (1492 passed)
- [x] Live image submission via curl confirms VL ran and Ember responded with image content
- [x] Header `X-Ember-Vision-Used: true` fires correctly
- [x] No canned RLHF refusal in response
- [ ] Manual UI test (recommend Chas before merge — submit an image via the actual UI)

## Auto-merge intentionally NOT enabled

Per request — review the verification results before this lands.