### PR TITLE
feat(safety): Item 8 — T2 cross-session pattern detection (ADR-021)

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1155,6 +1155,23 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     if _confirmation_web_items:
         context_packet.web_items = _confirmation_web_items
 
+    # ADR-021: T2 cross-session pattern detection. Operates over already-
+    # retrieved conversation records only — no additional vault reads.
+    # Result populated on ContextPacket for both prompt injection (via
+    # PromptBuilder._build_cross_session_pattern_block) and review
+    # consumption (via SafetyReviewContext.t2_pattern_category, per
+    # ADR-035 / Item 7).
+    try:
+        from src.safety.pattern_detector import detect_t2_pattern
+        context_packet.t2_pattern_signal = detect_t2_pattern(
+            context_packet.memory_items,
+            context_packet.query_embedding,
+        )
+    except Exception as exc:
+        # Non-fatal: detection failure must not break the chat path. Fall
+        # back to no signal (existing single-pass review remains active).
+        logger.warning("[T2_DETECTOR] detection failed (non-fatal): %s", exc)
+
     # Reuse early classification when available; only call again for stateless mode
     from src.context.policies import classify_query
     _policy = _early_policy or classify_query(latest_user_message)

--- a/src/context/models.py
+++ b/src/context/models.py
@@ -55,6 +55,14 @@ class ContextPacket:
     # authority-rules line instructing the model to acknowledge the gap
     # explicitly rather than synthesize from ingested content.
     relational_query_empty: bool = False
+    # ADR-021 cross-session pattern signal, populated post-retrieval by
+    # detect_t2_pattern. Default None means no pattern detected this turn.
+    # Consumed by PromptBuilder._build_cross_session_pattern_block (the
+    # ADR-021 <cross_session_pattern> flag) and by LLMAdapter when building
+    # SafetyReviewContext.t2_pattern_category (per ADR-035 / Item 7).
+    # Forward-reference annotation avoids circular import — the actual
+    # PatternSignal type lives in src.safety.pattern_detector.
+    t2_pattern_signal: "object | None" = None
 
     def all_items(self) -> list[ContextItem]:
         # Order matches TDD context packet order:

--- a/src/context/retriever.py
+++ b/src/context/retriever.py
@@ -101,6 +101,21 @@ class ContextRetriever:
             if self._should_exclude_content(content, user_message):
                 continue
 
+            # ADR-021: surface the cached embedding into ContextItem.metadata
+            # so the T2 pattern detector can read it without recomputation.
+            # Only present on results from the SQLite store (legacy JSON-index
+            # results may not carry it). Missing -> detector treats as cache
+            # miss and skips the record.
+            _embedding = result.get("embedding")
+            _enriched_metadata = {
+                **metadata,
+                "path": result.get("path"),
+                "memory_type": mem_type,
+                "raw_score": result.get("raw_score", 0.0),
+            }
+            if _embedding:
+                _enriched_metadata["embedding"] = _embedding
+
             items.append(
                 ContextItem(
                     id=metadata.get("chunk_id", result.get("path", "")),
@@ -111,12 +126,7 @@ class ContextRetriever:
                     score=result.get("score", 0.0),
                     timestamp=metadata.get("created_at"),
                     tags=metadata.get("tags", []),
-                    metadata={
-                        **metadata,
-                        "path": result.get("path"),
-                        "memory_type": mem_type,
-                        "raw_score": result.get("raw_score", 0.0),
-                    },
+                    metadata=_enriched_metadata,
                     tier=result.get("tier", "hot"),
                     # Propagate authorship from the
                     # SQLite index. Missing column returns "unknown" via

--- a/src/llm/adapter.py
+++ b/src/llm/adapter.py
@@ -216,14 +216,12 @@ class LLMAdapter:
             or context_packet.reflection_items
         )
 
-        # ITEM-8 coordination point (ADR-021): replace the literal None below
-        # with the read expression for the T2 pattern category once Item 8
-        # has locked the ContextPacket field name. Until Item 8 lands, this
-        # stays None and the two-step review prompt path is unreachable.
-        # Suggested shape: context_packet.t2_pattern_signal.category if
-        # context_packet.t2_pattern_signal else None — but Item 8's plan is
-        # the source of truth.
-        _t2_category: str | None = None
+        # ADR-021 / ADR-035: read the T2 pattern category from the signal
+        # populated by detect_t2_pattern in the API layer. None when no
+        # pattern was detected this turn — review_service falls through to
+        # the standard single-pass MVR prompt.
+        _signal = getattr(context_packet, "t2_pattern_signal", None)
+        _t2_category: str | None = _signal.category if _signal else None
 
         initial_review_context = SafetyReviewContext(
             user_message=context_packet.user_message,
@@ -388,10 +386,12 @@ class LLMAdapter:
             or context_packet.reflection_items
         )
 
-        # ITEM-8 coordination point (ADR-021): see sync path note. Replace
-        # None with context_packet.t2_pattern_signal.category once Item 8
-        # locks the field name.
-        _t2_category_stream: str | None = None
+        # ADR-021 / ADR-035: T2 pattern category for the streaming path.
+        # Same read pattern as the sync path above.
+        _signal_stream = getattr(context_packet, "t2_pattern_signal", None)
+        _t2_category_stream: str | None = (
+            _signal_stream.category if _signal_stream else None
+        )
 
         # Post-stream safety review
         review_context = SafetyReviewContext(

--- a/src/llm/prompt_builder.py
+++ b/src/llm/prompt_builder.py
@@ -275,6 +275,12 @@ class PromptBuilder:
             # against the RLHF "I can't see images" override (UAT-120 /
             # Deep research recommendation).
             self._build_per_turn_vision_block(vision_description),
+            # ADR-021 cross-session pattern flag — fires only when
+            # detect_t2_pattern populated context_packet.t2_pattern_signal.
+            # Adjacent to other per-turn structural directives.
+            self._build_cross_session_pattern_block(
+                getattr(context_packet, "t2_pattern_signal", None)
+            ),
             # Per-turn search confirmation block — fires only when the
             # classifier routed to web_search AND ask-first mode is active.
             # Louder, more visible than the sticky-note pattern used for
@@ -710,6 +716,33 @@ class PromptBuilder:
             "have already seen this one. Do not suggest external image "
             "tools. Do not invent tool names or URLs.\n"
             "</vision_instruction>"
+        )
+
+    @staticmethod
+    def _build_cross_session_pattern_block(signal) -> str:
+        """ADR-021 cross-session pattern flag.
+
+        Renders only when detect_t2_pattern populated a PatternSignal on
+        the context packet. Carries structural metadata only — counts and
+        a boolean third-party flag. The model decides whether and how to
+        surface the observation, governed by the relational_honesty
+        behavioral sequence.
+
+        Privacy boundary: when named_third_party=true, Ember names the
+        pattern in structural terms only (no relationship-type or third-
+        party identifiers).
+        """
+        if signal is None:
+            return ""
+        return (
+            "<cross_session_pattern>\n"
+            f"A recurring pattern is visible across {signal.instance_count} "
+            f"instances spanning {signal.session_count} sessions. This is "
+            "an observation, not a directive. If relevant to the current "
+            "conversation, you may name it once using relational_honesty "
+            "behavioral sequence. If not relevant, ignore it.\n"
+            f"named_third_party: {str(signal.has_named_party).lower()}\n"
+            "</cross_session_pattern>"
         )
 
     @staticmethod

--- a/src/memory/third_party_detection.py
+++ b/src/memory/third_party_detection.py
@@ -1,0 +1,89 @@
+"""
+src/memory/third_party_detection.py
+
+Lightweight heuristic for detecting whether a conversation record
+mentions a named third party (someone other than the user). Sets the
+`contains_named_third_party` metadata flag at write time, used by the
+ADR-021 cross-session pattern detector to enforce the privacy boundary
+in the relational_honesty behavioral sequence.
+
+The detection is intentionally conservative:
+- False positives (flagging when no real third party is present) are
+  cheap — they only cause Ember to name patterns in structural terms
+  ("this comes up when you describe interactions with someone specific")
+  rather than identifying terms ("this comes up when you talk about
+  your partner"). Both are valid Ember behaviors.
+- False negatives are higher cost — Ember might name a third party
+  identifier she shouldn't.
+
+Three patterns trigger the flag:
+1. Possessive third-party kinship (e.g. "my partner said")
+2. Reported speech about non-self pronouns (e.g. "she said hi")
+3. Capitalized proper-noun + reported-speech verb (e.g. "Sam told me")
+
+NER (e.g. spaCy) is the right long-term answer but adds a dependency
+and inference cost on every conversation write. This regex MVP is
+v0.17.x scope; a future enhancement can swap in NER without changing
+the function signature.
+"""
+
+from __future__ import annotations
+
+import re
+
+# 1. Possessive third-party kinship — "my mom", "my partner", etc.
+# Bounded to a closed list of common kinship/relationship terms to avoid
+# false positives on phrases like "my opinion", "my plan".
+_KINSHIP_PATTERN = re.compile(
+    r"\bmy\s+("
+    r"mom|dad|mother|father|parent|parents|"
+    r"partner|wife|husband|spouse|girlfriend|boyfriend|ex|"
+    r"sister|brother|sibling|siblings|"
+    r"son|daughter|kid|kids|child|children|"
+    r"friend|friends|bestie|best\s+friend|"
+    r"boss|coworker|coworkers|colleague|colleagues|manager|teammate|"
+    r"therapist|doctor|teacher|professor|advisor|mentor|coach|"
+    r"roommate|neighbor"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# 2. Reported speech about non-self pronouns — "she said", "they told",
+# "he believes", etc. The verb list covers reporting and propositional
+# attitude verbs; conjugation is handled with optional 's'/'ed' tails.
+_REPORTED_SPEECH_PATTERN = re.compile(
+    r"\b(she|he|they)\s+"
+    r"(said|told|asked|thinks?|thought|feels?|felt|wants?|wanted|"
+    r"believes?|believed|knows?|knew|did|does|mentioned|"
+    r"replied|answered|claimed|insisted|admitted|agreed|disagreed)\b",
+    re.IGNORECASE,
+)
+
+# 3. Capitalized proper-noun token followed by a reported-speech verb.
+# Matches "Sam said", "Alex told me", etc. Two-character minimum on the
+# name token to avoid matching sentence-initial articles like "A said"
+# (rare but possible in fragmented text). Word-internal capitalization
+# (CamelCase) is not matched — only sentence-style capitalized names.
+_NAMED_SPEECH_PATTERN = re.compile(
+    r"\b[A-Z][a-z]+\s+"
+    r"(said|told|asked|thinks?|thought|feels?|felt|wants?|wanted|"
+    r"believes?|believed|did|does|mentioned)\b"
+)
+
+
+def contains_named_third_party(text: str) -> bool:
+    """Return True if the text appears to reference a named third party.
+
+    Conservative regex heuristic — see module docstring for the design
+    rationale. Pure function: no I/O, no state, safe to call inline at
+    every conversation write.
+    """
+    if not text:
+        return False
+    if _KINSHIP_PATTERN.search(text):
+        return True
+    if _REPORTED_SPEECH_PATTERN.search(text):
+        return True
+    if _NAMED_SPEECH_PATTERN.search(text):
+        return True
+    return False

--- a/src/memory/write_memory.py
+++ b/src/memory/write_memory.py
@@ -144,6 +144,17 @@ def write_memory(
     normalized = normalize_text(text)
     clean_metadata = flatten_metadata(metadata)
 
+    # ADR-021 prerequisite: tag conversation records with whether they
+    # mention a named third party. Heuristic detection at write time.
+    # setdefault preserves explicit caller overrides (manual annotations,
+    # ingestion-time NER, etc.).
+    if memory_type == "conversation":
+        from src.memory.third_party_detection import contains_named_third_party
+        clean_metadata.setdefault(
+            "contains_named_third_party",
+            contains_named_third_party(text),
+        )
+
     memory = {
         "id": memory_id,
         "timestamp": timestamp,

--- a/src/retrieval/sqlite_vector_store.py
+++ b/src/retrieval/sqlite_vector_store.py
@@ -222,6 +222,10 @@ class SqliteVectorStore:
                     "metadata": metadata,
                     "tier": tier,
                     "authorship": authorship,
+                    # ADR-021 amendment 2026-04-24: surface the cached
+                    # embedding so the T2 pattern detector can read it
+                    # from ContextItem.metadata without recomputation.
+                    "embedding": embedding,
                 }
             )
 

--- a/src/safety/pattern_detector.py
+++ b/src/safety/pattern_detector.py
@@ -1,0 +1,197 @@
+"""
+src/safety/pattern_detector.py
+
+ADR-021 cross-session pattern detection signal.
+
+Detects when retrieved conversation records form a recurring relational
+pattern across multiple sessions, surfacing a structured signal that
+gets injected into the prompt (as <cross_session_pattern>) and into
+the constitutional review context (per ADR-035 / Item 7).
+
+The detector operates over already-retrieved conversation records — no
+additional vault reads. Embeddings are read from cached metadata
+populated at write time (per ADR-021 amendment 2026-04-24).
+
+Carries only structural metadata (counts, max similarity, category,
+boolean named-third-party flag). Never contains record content, ids,
+or third-party identifiers.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.context.models import ContextItem
+
+
+logger = logging.getLogger("ember.pattern_detector")
+
+
+# Hyperparameters per ADR-021 §"Evidence threshold".
+# Amendment 2026-04-24: the 30-day recency gate is a tunable
+# hyperparameter, not theory-derived. Adjust empirically as needed.
+T2_MIN_INSTANCES = 3
+T2_MIN_SIMILARITY = 0.82
+T2_MIN_SESSIONS = 2
+T2_RECENCY_DAYS = 30
+
+
+# Category taxonomy. ADR-021 currently scopes to relational_honesty T2,
+# so "relational" is the only category in the MVP. The field exists
+# because ADR-035 / SafetyReviewContext.t2_pattern_category is a string
+# label that may carry richer taxonomies in future ADRs.
+T2_CATEGORIES = ("relational",)
+
+
+@dataclass(frozen=True)
+class PatternSignal:
+    """Cross-session pattern detection result, per ADR-021.
+
+    Carries only structural metadata - counts and a category label.
+    Never contains record content, ids, or third-party identifiers.
+
+    Consumed by:
+      - PromptBuilder._build_cross_session_pattern_block (ADR-021 flag)
+      - SafetyReviewContext.t2_pattern_category (ADR-035 review hook,
+        via context_packet.t2_pattern_signal.category)
+    """
+
+    instance_count: int        # number of similar conversation records
+    session_count: int         # distinct session_ids spanned
+    has_named_party: bool      # any candidate has contains_named_third_party=True
+    max_similarity: float      # max cosine similarity in the cluster
+    category: str = "relational"  # taxonomy label (MVP: only "relational")
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Module-local cosine helper. Mirrors src/context/lodestone_resolver.py
+    so this module has no cross-package dependency on private symbols."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    mag_a = math.sqrt(sum(x * x for x in a))
+    mag_b = math.sqrt(sum(x * x for x in b))
+    if mag_a == 0 or mag_b == 0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def detect_t2_pattern(
+    retrieved_items: "list[ContextItem]",
+    query_embedding: list[float] | None,
+) -> PatternSignal | None:
+    """Detect a T2 cross-session relational pattern. Returns None if any
+    threshold per ADR-021 is not met.
+
+    Inputs are the already-retrieved context items and the pre-computed
+    query embedding (both available on ContextPacket post-retrieval).
+
+    The detector:
+      1. Filters to memory_type == "conversation" only (per ADR-021 -
+         state, reflection, lodestone are derived/operational artifacts
+         that would contaminate the signal).
+      2. Computes cosine similarity between query and each candidate's
+         cached embedding (read from metadata, populated at write time
+         per ADR-021 amendment).
+      3. Applies four thresholds: instance count, similarity floor,
+         distinct session count, recency gate.
+      4. If all pass, derives `has_named_party` from any candidate's
+         `contains_named_third_party` metadata flag.
+
+    Returns None on:
+      - Missing query_embedding
+      - Fewer than T2_MIN_INSTANCES retrieved conversations
+      - Fewer than T2_MIN_INSTANCES candidates above the similarity floor
+      - Fewer than T2_MIN_SESSIONS distinct session_ids in the cluster
+      - No candidates within T2_RECENCY_DAYS
+
+    TODO (Item 8 follow-up, deferred per Q4): post-generation detection
+    of whether Ember named the pattern, and writing a system_event audit
+    record. ADR-021 specifies this for human review; phrase-detection
+    heuristic needs design before implementation.
+    """
+    if not query_embedding:
+        return None
+
+    convs = [
+        item for item in retrieved_items
+        if getattr(item, "memory_type", None) == "conversation"
+    ]
+    if len(convs) < T2_MIN_INSTANCES:
+        return None
+
+    candidates: list[tuple["ContextItem", float]] = []
+    cache_misses = 0
+    for item in convs:
+        emb = (item.metadata or {}).get("embedding")
+        if not emb:
+            # Cache miss: skip rather than recompute. Per ADR-021 amendment,
+            # writes are expected to populate the cache. Missing means a
+            # legacy record predating the amendment - candidate for backfill.
+            cache_misses += 1
+            continue
+        sim = _cosine_similarity(query_embedding, emb)
+        if sim >= T2_MIN_SIMILARITY:
+            candidates.append((item, sim))
+
+    if cache_misses:
+        # Single log line per turn (not per record) to surface coverage gaps
+        # without flooding logs. Backfill script (deferred per plan Q5) would
+        # close this over time.
+        logger.info(
+            "[T2_DETECTOR] cache_miss skipped %d/%d conversation records "
+            "(legacy records lacking cached embedding)",
+            cache_misses,
+            len(convs),
+        )
+
+    if len(candidates) < T2_MIN_INSTANCES:
+        return None
+
+    session_ids = {
+        ((item.metadata or {}).get("session_id") or "")
+        for item, _ in candidates
+    }
+    session_ids.discard("")  # records missing session_id don't count
+    if len(session_ids) < T2_MIN_SESSIONS:
+        return None
+
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=T2_RECENCY_DAYS)
+    ).isoformat()
+    if not any(
+        (item.timestamp or "") >= cutoff for item, _ in candidates
+    ):
+        return None
+
+    has_named_party = any(
+        bool((item.metadata or {}).get("contains_named_third_party", False))
+        for item, _ in candidates
+    )
+
+    signal = PatternSignal(
+        instance_count=len(candidates),
+        session_count=len(session_ids),
+        has_named_party=has_named_party,
+        max_similarity=max(sim for _, sim in candidates),
+        category="relational",
+    )
+
+    # Audit log hook (Q4 deferred decision: logging only for MVP, no
+    # vault system_event write). Surfaces detector firings without the
+    # complexity of post-generation phrase detection.
+    logger.info(
+        "[T2_AUDIT] pattern_signal_emitted instance_count=%d "
+        "session_count=%d has_named_party=%s max_similarity=%.3f",
+        signal.instance_count,
+        signal.session_count,
+        signal.has_named_party,
+        signal.max_similarity,
+    )
+
+    return signal

--- a/tests/test_pattern_detector.py
+++ b/tests/test_pattern_detector.py
@@ -1,0 +1,247 @@
+"""
+tests/test_pattern_detector.py
+
+Coverage for src/safety/pattern_detector.py — PatternSignal dataclass
+and detect_t2_pattern over seeded retrieval items.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.context.models import ContextItem
+from src.safety.pattern_detector import (
+    PatternSignal,
+    T2_CATEGORIES,
+    T2_MIN_INSTANCES,
+    T2_MIN_SESSIONS,
+    T2_MIN_SIMILARITY,
+    T2_RECENCY_DAYS,
+    detect_t2_pattern,
+)
+
+
+# ---------------------------------------------------------------------------
+# PatternSignal dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_signal_dataclass_defaults() -> None:
+    sig = PatternSignal(
+        instance_count=3,
+        session_count=2,
+        has_named_party=False,
+        max_similarity=0.85,
+    )
+    assert sig.category == "relational"
+    assert sig.category in T2_CATEGORIES
+
+
+def test_pattern_signal_is_frozen() -> None:
+    sig = PatternSignal(
+        instance_count=3,
+        session_count=2,
+        has_named_party=False,
+        max_similarity=0.85,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        sig.instance_count = 4  # type: ignore[misc]
+
+
+def test_pattern_signal_equality() -> None:
+    a = PatternSignal(3, 2, False, 0.85)
+    b = PatternSignal(3, 2, False, 0.85)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Helpers for seeding ContextItems
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _old_iso(days: int = 60) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def _make_item(
+    *,
+    embedding: list[float] | None = None,
+    session_id: str = "sess_a",
+    timestamp: str | None = None,
+    contains_named_third_party: bool = False,
+    memory_type: str = "conversation",
+    content: str = "x",
+) -> ContextItem:
+    metadata: dict = {"session_id": session_id}
+    if embedding is not None:
+        metadata["embedding"] = embedding
+    if contains_named_third_party:
+        metadata["contains_named_third_party"] = True
+    return ContextItem(
+        id=f"id_{session_id}_{timestamp or _now_iso()}",
+        content=content,
+        source="test",
+        item_type="memory",
+        memory_type=memory_type,
+        timestamp=timestamp or _now_iso(),
+        metadata=metadata,
+    )
+
+
+# Embedding pair with cosine similarity ~ 1.0 (identical vectors)
+_VEC_HIGH_SIM = [1.0, 0.0, 0.0]
+# Embedding pair with cosine similarity ~ 0.0 (orthogonal vectors)
+_VEC_LOW_SIM = [0.0, 1.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# detect_t2_pattern - happy path
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_signal_when_all_thresholds_met() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s3"),
+    ]
+    signal = detect_t2_pattern(items, _VEC_HIGH_SIM)
+    assert signal is not None
+    assert signal.instance_count == 3
+    assert signal.session_count == 3
+    assert signal.has_named_party is False
+    assert signal.max_similarity == pytest.approx(1.0)
+    assert signal.category == "relational"
+
+
+def test_has_named_party_true_when_any_candidate_has_flag() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s2",
+            contains_named_third_party=True,
+        ),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s3"),
+    ]
+    signal = detect_t2_pattern(items, _VEC_HIGH_SIM)
+    assert signal is not None
+    assert signal.has_named_party is True
+
+
+def test_has_named_party_false_when_no_candidate_has_flag() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s3"),
+    ]
+    signal = detect_t2_pattern(items, _VEC_HIGH_SIM)
+    assert signal is not None
+    assert signal.has_named_party is False
+
+
+# ---------------------------------------------------------------------------
+# detect_t2_pattern - threshold failures
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_none_below_min_instances() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2"),
+    ]
+    assert detect_t2_pattern(items, _VEC_HIGH_SIM) is None
+
+
+def test_detect_returns_none_below_similarity_threshold() -> None:
+    items = [
+        _make_item(embedding=_VEC_LOW_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_LOW_SIM, session_id="s2"),
+        _make_item(embedding=_VEC_LOW_SIM, session_id="s3"),
+    ]
+    assert detect_t2_pattern(items, _VEC_HIGH_SIM) is None
+
+
+def test_detect_returns_none_single_session() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+    ]
+    assert detect_t2_pattern(items, _VEC_HIGH_SIM) is None
+
+
+def test_detect_returns_none_no_recent_records() -> None:
+    items = [
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s1",
+            timestamp=_old_iso(60),
+        ),
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s2",
+            timestamp=_old_iso(60),
+        ),
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s3",
+            timestamp=_old_iso(60),
+        ),
+    ]
+    assert detect_t2_pattern(items, _VEC_HIGH_SIM) is None
+
+
+def test_detect_returns_none_when_query_embedding_missing() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s3"),
+    ]
+    assert detect_t2_pattern(items, None) is None
+    assert detect_t2_pattern(items, []) is None
+
+
+def test_detect_skips_records_with_missing_embedding() -> None:
+    items = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1"),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2"),
+        # Third item lacks embedding metadata - should be skipped, dropping
+        # the candidate count below T2_MIN_INSTANCES.
+        _make_item(embedding=None, session_id="s3"),
+    ]
+    assert detect_t2_pattern(items, _VEC_HIGH_SIM) is None
+
+
+def test_detect_excludes_non_conversation_types() -> None:
+    items = [
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s1",
+            memory_type="reflection",
+        ),
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s2",
+            memory_type="lodestone",
+        ),
+        _make_item(
+            embedding=_VEC_HIGH_SIM, session_id="s3",
+            memory_type="state",
+        ),
+    ]
+    assert detect_t2_pattern(items, _VEC_HIGH_SIM) is None
+
+
+def test_detect_returns_none_for_empty_input() -> None:
+    assert detect_t2_pattern([], _VEC_HIGH_SIM) is None
+
+
+def test_detect_constant_thresholds_match_adr() -> None:
+    """Pin the ADR-021 hyperparameters at the constant-definition level
+    so a future change to defaults is intentional."""
+    assert T2_MIN_INSTANCES == 3
+    assert T2_MIN_SESSIONS == 2
+    assert T2_MIN_SIMILARITY == 0.82
+    assert T2_RECENCY_DAYS == 30

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -237,3 +237,48 @@ class TestInstructionHierarchy:
             assert hierarchy_pos < nature_pos, (
                 "Hierarchy statement must appear before nature section"
             )
+
+
+class TestCrossSessionPatternBlock:
+    """ADR-021: <cross_session_pattern> block injection from PatternSignal."""
+
+    def test_block_omitted_when_signal_none(self):
+        block = PromptBuilder._build_cross_session_pattern_block(None)
+        assert block == ""
+
+    def test_block_rendered_with_signal(self):
+        from src.safety.pattern_detector import PatternSignal
+        sig = PatternSignal(
+            instance_count=4, session_count=3,
+            has_named_party=True, max_similarity=0.91,
+        )
+        block = PromptBuilder._build_cross_session_pattern_block(sig)
+        assert "<cross_session_pattern>" in block
+        assert "</cross_session_pattern>" in block
+        assert "4 instances spanning 3 sessions" in block
+        assert "named_third_party: true" in block
+
+    def test_block_renders_named_party_false_lowercase(self):
+        from src.safety.pattern_detector import PatternSignal
+        sig = PatternSignal(3, 2, False, 0.85)
+        block = PromptBuilder._build_cross_session_pattern_block(sig)
+        # Per ADR-021 spec the value must be the literal "true" or "false"
+        # (lowercase), not Python's "True"/"False".
+        assert "named_third_party: false" in block
+        assert "named_third_party: False" not in block
+
+    def test_block_in_assembled_prompt_when_packet_has_signal(self):
+        from src.safety.pattern_detector import PatternSignal
+        pb = PromptBuilder()
+        packet = ContextPacket(user_message="hello")
+        packet.t2_pattern_signal = PatternSignal(3, 2, False, 0.85)
+        prompt = pb.build_prompt(packet)
+        assert "<cross_session_pattern>" in prompt
+        assert "3 instances spanning 2 sessions" in prompt
+
+    def test_block_absent_from_assembled_prompt_by_default(self):
+        pb = PromptBuilder()
+        packet = ContextPacket(user_message="hello")
+        # No t2_pattern_signal set — defaults to None.
+        prompt = pb.build_prompt(packet)
+        assert "<cross_session_pattern>" not in prompt

--- a/tests/test_review_service.py
+++ b/tests/test_review_service.py
@@ -584,3 +584,67 @@ def test_vault_grounded_derivation_matches_adr_allowlist() -> None:
         derive(ContextPacket(user_message="q", web_items=[{"url": "https://x"}]))
         is False
     )
+
+
+# ---------------------------------------------------------------------------
+# Item-7 ↔ Item-8 wiring: PatternSignal on the packet -> two-step prompt fires
+# ---------------------------------------------------------------------------
+
+
+def test_review_two_step_path_reachable_via_t2_signal_chain() -> None:
+    """End-to-end pin: a PatternSignal on the packet flows through to the
+    review prompt, which switches to two-step structure.
+
+    This test asserts the integration without invoking the LLMAdapter directly
+    (avoids the Ollama dependency). Mirrors the inline read expression in
+    src/llm/adapter.py — same expression, asserted against a constructed
+    SafetyReviewContext.
+    """
+    from src.context.models import ContextPacket
+    from src.safety.pattern_detector import PatternSignal
+
+    # Simulate the Item-8 producer (openai_adapter) populating the field
+    packet = ContextPacket(user_message="hi")
+    packet.t2_pattern_signal = PatternSignal(3, 2, False, 0.85)
+
+    # Mirror of src/llm/adapter.py read expression (both call sites)
+    signal = getattr(packet, "t2_pattern_signal", None)
+    t2_category = signal.category if signal else None
+    assert t2_category == "relational"
+
+    # Build the SafetyReviewContext as the adapter would
+    ctx = SafetyReviewContext(
+        user_message="hi",
+        draft_response="hello",
+        t2_pattern_category=t2_category,
+    )
+
+    # The review prompt switches to two-step
+    service = ResponseReviewService()
+    prompt = service._build_critique_prompt(ctx)
+    assert "TWO-STEP" in prompt
+    assert "pattern_observation" in prompt
+    assert "relational" in prompt
+
+
+def test_review_single_pass_when_packet_has_no_signal() -> None:
+    """Negative pin: no PatternSignal on the packet -> single-pass prompt."""
+    from src.context.models import ContextPacket
+
+    packet = ContextPacket(user_message="hi")
+    # t2_pattern_signal defaults to None
+
+    signal = getattr(packet, "t2_pattern_signal", None)
+    t2_category = signal.category if signal else None
+    assert t2_category is None
+
+    ctx = SafetyReviewContext(
+        user_message="hi",
+        draft_response="hello",
+        t2_pattern_category=t2_category,
+    )
+
+    service = ResponseReviewService()
+    prompt = service._build_critique_prompt(ctx)
+    assert "TWO-STEP" not in prompt
+    assert "pattern_observation" not in prompt

--- a/tests/test_third_party_flag.py
+++ b/tests/test_third_party_flag.py
@@ -1,0 +1,183 @@
+"""
+tests/test_third_party_flag.py
+
+Coverage for contains_named_third_party() heuristic and the write-time
+integration in src/memory/write_memory.py (per ADR-021 prerequisite).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.memory.third_party_detection import contains_named_third_party
+
+
+# ---------------------------------------------------------------------------
+# Heuristic — positive cases
+# ---------------------------------------------------------------------------
+
+
+def test_kinship_marker_partner_detected() -> None:
+    assert contains_named_third_party("my partner said we should leave early")
+
+
+def test_kinship_marker_mom_detected() -> None:
+    assert contains_named_third_party("My mom called yesterday")
+
+
+def test_kinship_marker_coworker_detected() -> None:
+    assert contains_named_third_party("my coworker is being weird about it")
+
+
+def test_reported_speech_she_said_detected() -> None:
+    assert contains_named_third_party("she said it would be fine")
+
+
+def test_reported_speech_they_think_detected() -> None:
+    assert contains_named_third_party("they think the deadline is tight")
+
+
+def test_reported_speech_he_believed_detected() -> None:
+    assert contains_named_third_party("He believed the original plan was better")
+
+
+def test_named_proper_noun_speech_detected() -> None:
+    assert contains_named_third_party("Sam told me yesterday it was done")
+
+
+def test_named_proper_noun_thinks_detected() -> None:
+    assert contains_named_third_party("Alex thinks the design is overengineered")
+
+
+# ---------------------------------------------------------------------------
+# Heuristic — negative cases
+# ---------------------------------------------------------------------------
+
+
+def test_first_person_only_not_detected() -> None:
+    assert not contains_named_third_party(
+        "I went to the store and got groceries"
+    )
+
+
+def test_third_person_no_speech_marker_not_detected() -> None:
+    assert not contains_named_third_party("the weather was nice today")
+
+
+def test_my_plus_inanimate_not_detected() -> None:
+    """`my plan`, `my opinion`, `my work` should not match — only kinship."""
+    assert not contains_named_third_party("my plan for tomorrow is to rest")
+    assert not contains_named_third_party("my opinion is that we should wait")
+    assert not contains_named_third_party("my work has been overwhelming")
+
+
+def test_empty_string_not_detected() -> None:
+    assert not contains_named_third_party("")
+
+
+def test_pronoun_without_speech_verb_not_detected() -> None:
+    """`she walked` is not reported speech — should NOT trigger."""
+    assert not contains_named_third_party("she walked into the room")
+
+
+def test_capitalized_word_without_speech_verb_not_detected() -> None:
+    """Sentence-initial capitalization without a speech verb is safe."""
+    assert not contains_named_third_party("Tomorrow looks busy")
+
+
+# ---------------------------------------------------------------------------
+# Integration — write_memory sets the flag for conversation type
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_vault(tmp_path, monkeypatch):
+    """Override PRIVATE_VAULT_PATH to a tmp dir for isolated write tests."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "memory").mkdir()
+    (vault / "embeddings").mkdir()
+    monkeypatch.setenv("PRIVATE_VAULT_PATH", str(vault))
+    # Re-import config so it picks up the env override.
+    import importlib
+    import src.core.config as cfg
+    importlib.reload(cfg)
+    yield vault
+
+
+def _read_record(file_path: Path) -> dict:
+    import json
+    return json.loads(file_path.read_text(encoding="utf-8"))
+
+
+def test_write_memory_sets_flag_for_conversation_type(temp_vault, monkeypatch) -> None:
+    """conversation type with third-party content -> flag True in metadata."""
+    # Stub embed_text to avoid Ollama dependency in tests.
+    monkeypatch.setattr(
+        "src.memory.write_memory.embed_text", lambda _text: [0.0] * 768
+    )
+    from src.memory.write_memory import write_memory
+
+    file_path = write_memory(
+        text="my partner said we should rebook the flight",
+        memory_type="conversation",
+        source="test",
+    )
+    assert file_path is not None
+    record = _read_record(file_path)
+    assert record["metadata"]["contains_named_third_party"] is True
+
+
+def test_write_memory_sets_flag_false_when_no_third_party(temp_vault, monkeypatch) -> None:
+    """conversation type with self-only content -> flag False in metadata."""
+    monkeypatch.setattr(
+        "src.memory.write_memory.embed_text", lambda _text: [0.0] * 768
+    )
+    from src.memory.write_memory import write_memory
+
+    file_path = write_memory(
+        text="I went for a walk this morning",
+        memory_type="conversation",
+        source="test",
+    )
+    assert file_path is not None
+    record = _read_record(file_path)
+    assert record["metadata"]["contains_named_third_party"] is False
+
+
+def test_write_memory_skips_flag_for_non_conversation_type(temp_vault, monkeypatch) -> None:
+    """journal/profile/etc. -> no flag added (not in scope for ADR-021)."""
+    monkeypatch.setattr(
+        "src.memory.write_memory.embed_text", lambda _text: [0.0] * 768
+    )
+    from src.memory.write_memory import write_memory
+
+    file_path = write_memory(
+        text="my partner said we should rebook the flight",
+        memory_type="journal",
+        source="test",
+    )
+    assert file_path is not None
+    record = _read_record(file_path)
+    assert "contains_named_third_party" not in record["metadata"]
+
+
+def test_write_memory_caller_override_wins_over_heuristic(temp_vault, monkeypatch) -> None:
+    """If caller passes the flag explicitly, heuristic does not override."""
+    monkeypatch.setattr(
+        "src.memory.write_memory.embed_text", lambda _text: [0.0] * 768
+    )
+    from src.memory.write_memory import write_memory
+
+    file_path = write_memory(
+        text="my partner said we should rebook the flight",
+        memory_type="conversation",
+        source="test",
+        metadata={"contains_named_third_party": False},
+    )
+    assert file_path is not None
+    record = _read_record(file_path)
+    assert record["metadata"]["contains_named_third_party"] is False


### PR DESCRIPTION
## Summary

Implements ADR-021 cross-session relational pattern detection. Closes the producer side that Item 7 (ADR-035, PR #23) left as a marker comment — the `_t2_category = None` literal in `src/llm/adapter.py` is now replaced with the read expression `context_packet.t2_pattern_signal.category if context_packet.t2_pattern_signal else None`.

When a recurring pattern is visible across multiple sessions, the constitutional review's two-step prompt path becomes reachable in production, and the prompt itself carries an `<cross_session_pattern>` block so Ember can name the observation in structural terms (privacy boundary enforced at the signal layer).

## Commits (8)

| Step | Commit | Layer |
|---|---|---|
| a | `d9e418f` | feat(memory): `contains_named_third_party` heuristic + 14 tests |
| b | `09e81d5` | feat(memory): wire heuristic into `write_memory` for conversation type |
| c | `ac90735` | feat(safety): `PatternSignal` + `detect_t2_pattern` + 15 tests |
| d | `168d4b0` | feat(context): `t2_pattern_signal` field on packet + surface SQLite embedding via retriever |
| e | `3d37853` | feat(api): invoke detector after `context_service.build_context` |
| f | `609e859` | feat(llm): resolve Item 7 ITEM-8 marker (both sync + stream call sites) |
| g | `b13d65f` | feat(prompt): `<cross_session_pattern>` block injection + 5 tests |
| h | `2361646` | test(safety): pin Item-7 ↔ Item-8 wiring end-to-end |

## ADR-021 fidelity

Detector pseudocode implemented verbatim with three documented deviations:
1. Skip records with missing embedding rather than recompute (per amendment 2026-04-24 — writes are expected to populate the cache)
2. Discard empty session_ids before counting (guards legacy data)
3. Timezone-aware `datetime.now(timezone.utc)` (timestamps are ISO with TZ)

Hyperparameters per ADR (3+ instances, 0.82+ similarity, 2+ sessions, 30-day recency) are constants at module scope, pinned by a test.

## Q-resolution recap (per manager direction)

- **Q1** PatternSignal `category="relational"` ✓ with `T2_CATEGORIES = ("relational",)` constant
- **Q2** `contains_named_third_party` regex heuristic (option a) ✓
- **Q3** Embedding cache satisfied via SQLite surface fix (no new cache layer) ✓
- **Q4** system_event audit deferred — logging hook only ✓ (`[T2_AUDIT] pattern_signal_emitted ...`)
- **Q5** Backfill deferred — missing flag → False, graceful no-op ✓

## Test plan

- [x] 1532 tests pass (was 1492; +40 across new and extended test files):
  - `tests/test_third_party_flag.py` (new) — 18 tests
  - `tests/test_pattern_detector.py` (new) — 15 tests
  - `tests/test_prompt_builder.py` (extended) — +5 tests
  - `tests/test_review_service.py` (extended) — +2 wiring tests
- [x] All threshold-failure modes covered (instances, similarity, sessions, recency)
- [x] Cache-miss handling tested (legacy records skipped, not recomputed)
- [x] Non-conversation types excluded from clustering
- [x] End-to-end pin: PatternSignal on packet → two-step prompt fires
- [ ] CI passes
- [ ] Optional: manual smoke against test vault (seed 3 conversation records spanning 2 sessions, query, inspect `GET /debug-context` for the block)

## Auto-merge enabled

Per manager direction: tests are thorough, Item 7 set the precedent for auto-merge on this kind of pure-feature work.