### PR TITLE
fix(safety): Item 8 simplify — timestamp bug, dead state, type hints

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1155,12 +1155,8 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     if _confirmation_web_items:
         context_packet.web_items = _confirmation_web_items
 
-    # ADR-021: T2 cross-session pattern detection. Operates over already-
-    # retrieved conversation records only — no additional vault reads.
-    # Result populated on ContextPacket for both prompt injection (via
-    # PromptBuilder._build_cross_session_pattern_block) and review
-    # consumption (via SafetyReviewContext.t2_pattern_category, per
-    # ADR-035 / Item 7).
+    # ADR-021 T2 detection. Non-fatal: detection failure falls through to
+    # no signal so the chat path always completes.
     try:
         from src.safety.pattern_detector import detect_t2_pattern
         context_packet.t2_pattern_signal = detect_t2_pattern(
@@ -1168,8 +1164,6 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
             context_packet.query_embedding,
         )
     except Exception as exc:
-        # Non-fatal: detection failure must not break the chat path. Fall
-        # back to no signal (existing single-pass review remains active).
         logger.warning("[T2_DETECTOR] detection failed (non-fatal): %s", exc)
 
     # Reuse early classification when available; only call again for stateless mode

--- a/src/context/models.py
+++ b/src/context/models.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from src.state.models import StateItem
 from src.tasks.models import TaskItem
+
+if TYPE_CHECKING:
+    from src.safety.models import PatternSignal
 
 
 @dataclass
@@ -55,14 +60,9 @@ class ContextPacket:
     # authority-rules line instructing the model to acknowledge the gap
     # explicitly rather than synthesize from ingested content.
     relational_query_empty: bool = False
-    # ADR-021 cross-session pattern signal, populated post-retrieval by
-    # detect_t2_pattern. Default None means no pattern detected this turn.
-    # Consumed by PromptBuilder._build_cross_session_pattern_block (the
-    # ADR-021 <cross_session_pattern> flag) and by LLMAdapter when building
-    # SafetyReviewContext.t2_pattern_category (per ADR-035 / Item 7).
-    # Forward-reference annotation avoids circular import — the actual
-    # PatternSignal type lives in src.safety.pattern_detector.
-    t2_pattern_signal: "object | None" = None
+    # ADR-021 cross-session pattern signal. Populated post-retrieval by
+    # detect_t2_pattern; None when no pattern was detected this turn.
+    t2_pattern_signal: PatternSignal | None = None
 
     def all_items(self) -> list[ContextItem]:
         # Order matches TDD context packet order:

--- a/src/safety/models.py
+++ b/src/safety/models.py
@@ -96,3 +96,28 @@ class RefusalRedirect:
         if self.safer_alternative.strip():
             return f"{self.reason.strip()} {self.safer_alternative.strip()}".strip()
         return self.reason.strip()
+
+
+# Category taxonomy for ADR-021 PatternSignal. MVP scopes to "relational"
+# (the only T2 category covered by the relational_honesty principle).
+T2_CATEGORIES = ("relational",)
+
+
+@dataclass(frozen=True)
+class PatternSignal:
+    """Cross-session pattern detection result, per ADR-021.
+
+    Carries only structural metadata - counts and a category label.
+    Never contains record content, ids, or third-party identifiers.
+
+    Consumed by:
+      - PromptBuilder._build_cross_session_pattern_block (ADR-021 flag)
+      - SafetyReviewContext.t2_pattern_category (ADR-035 review hook,
+        via context_packet.t2_pattern_signal.category)
+    """
+
+    instance_count: int
+    session_count: int
+    has_named_party: bool
+    max_similarity: float
+    category: str = "relational"

--- a/src/safety/pattern_detector.py
+++ b/src/safety/pattern_detector.py
@@ -1,29 +1,25 @@
 """
 src/safety/pattern_detector.py
 
-ADR-021 cross-session pattern detection signal.
+ADR-021 cross-session pattern detection.
 
-Detects when retrieved conversation records form a recurring relational
-pattern across multiple sessions, surfacing a structured signal that
-gets injected into the prompt (as <cross_session_pattern>) and into
-the constitutional review context (per ADR-035 / Item 7).
+Operates over already-retrieved conversation records (no extra vault
+reads). Embeddings are read from cached metadata populated at write
+time (per ADR-021 amendment 2026-04-24).
 
-The detector operates over already-retrieved conversation records — no
-additional vault reads. Embeddings are read from cached metadata
-populated at write time (per ADR-021 amendment 2026-04-24).
-
-Carries only structural metadata (counts, max similarity, category,
-boolean named-third-party flag). Never contains record content, ids,
-or third-party identifiers.
+PatternSignal lives in src.safety.models alongside the other safety
+dataclasses (re-exported below for back-compat with imports of the
+detector module).
 """
 
 from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
+
+from src.safety.models import PatternSignal, T2_CATEGORIES  # noqa: F401 (re-export)
 
 if TYPE_CHECKING:
     from src.context.models import ContextItem
@@ -32,45 +28,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ember.pattern_detector")
 
 
-# Hyperparameters per ADR-021 §"Evidence threshold".
-# Amendment 2026-04-24: the 30-day recency gate is a tunable
-# hyperparameter, not theory-derived. Adjust empirically as needed.
+# Hyperparameters per ADR-021. Amendment 2026-04-24: the recency gate
+# is a tunable hyperparameter, not theory-derived.
 T2_MIN_INSTANCES = 3
 T2_MIN_SIMILARITY = 0.82
 T2_MIN_SESSIONS = 2
 T2_RECENCY_DAYS = 30
 
-
-# Category taxonomy. ADR-021 currently scopes to relational_honesty T2,
-# so "relational" is the only category in the MVP. The field exists
-# because ADR-035 / SafetyReviewContext.t2_pattern_category is a string
-# label that may carry richer taxonomies in future ADRs.
-T2_CATEGORIES = ("relational",)
-
-
-@dataclass(frozen=True)
-class PatternSignal:
-    """Cross-session pattern detection result, per ADR-021.
-
-    Carries only structural metadata - counts and a category label.
-    Never contains record content, ids, or third-party identifiers.
-
-    Consumed by:
-      - PromptBuilder._build_cross_session_pattern_block (ADR-021 flag)
-      - SafetyReviewContext.t2_pattern_category (ADR-035 review hook,
-        via context_packet.t2_pattern_signal.category)
-    """
-
-    instance_count: int        # number of similar conversation records
-    session_count: int         # distinct session_ids spanned
-    has_named_party: bool      # any candidate has contains_named_third_party=True
-    max_similarity: float      # max cosine similarity in the cluster
-    category: str = "relational"  # taxonomy label (MVP: only "relational")
+# Match write_memory._next_timestamp format so cutoff and record
+# timestamps are string-comparable. Both are zero-padded fixed-width,
+# so lexical compare is correct.
+_TIMESTAMP_FMT = "%Y-%m-%dT%H-%M-%S-%f"
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    """Module-local cosine helper. Mirrors src/context/lodestone_resolver.py
-    so this module has no cross-package dependency on private symbols."""
     if not a or not b or len(a) != len(b):
         return 0.0
     dot = sum(x * y for x, y in zip(a, b))
@@ -88,61 +59,31 @@ def detect_t2_pattern(
     """Detect a T2 cross-session relational pattern. Returns None if any
     threshold per ADR-021 is not met.
 
-    Inputs are the already-retrieved context items and the pre-computed
-    query embedding (both available on ContextPacket post-retrieval).
-
-    The detector:
-      1. Filters to memory_type == "conversation" only (per ADR-021 -
-         state, reflection, lodestone are derived/operational artifacts
-         that would contaminate the signal).
-      2. Computes cosine similarity between query and each candidate's
-         cached embedding (read from metadata, populated at write time
-         per ADR-021 amendment).
-      3. Applies four thresholds: instance count, similarity floor,
-         distinct session count, recency gate.
-      4. If all pass, derives `has_named_party` from any candidate's
-         `contains_named_third_party` metadata flag.
-
-    Returns None on:
-      - Missing query_embedding
-      - Fewer than T2_MIN_INSTANCES retrieved conversations
-      - Fewer than T2_MIN_INSTANCES candidates above the similarity floor
-      - Fewer than T2_MIN_SESSIONS distinct session_ids in the cluster
-      - No candidates within T2_RECENCY_DAYS
-
-    TODO (Item 8 follow-up, deferred per Q4): post-generation detection
-    of whether Ember named the pattern, and writing a system_event audit
-    record. ADR-021 specifies this for human review; phrase-detection
-    heuristic needs design before implementation.
+    TODO (deferred per plan Q4): post-generation detection of whether
+    Ember named the pattern, and writing a system_event audit record.
     """
     if not query_embedding:
         return None
 
-    convs = [
-        item for item in retrieved_items
-        if getattr(item, "memory_type", None) == "conversation"
-    ]
+    convs = [item for item in retrieved_items if item.memory_type == "conversation"]
     if len(convs) < T2_MIN_INSTANCES:
         return None
 
-    candidates: list[tuple["ContextItem", float]] = []
+    candidates: list["ContextItem"] = []
+    max_sim = 0.0
     cache_misses = 0
     for item in convs:
-        emb = (item.metadata or {}).get("embedding")
+        emb = item.metadata.get("embedding")
         if not emb:
-            # Cache miss: skip rather than recompute. Per ADR-021 amendment,
-            # writes are expected to populate the cache. Missing means a
-            # legacy record predating the amendment - candidate for backfill.
             cache_misses += 1
             continue
         sim = _cosine_similarity(query_embedding, emb)
         if sim >= T2_MIN_SIMILARITY:
-            candidates.append((item, sim))
+            candidates.append(item)
+            if sim > max_sim:
+                max_sim = sim
 
     if cache_misses:
-        # Single log line per turn (not per record) to surface coverage gaps
-        # without flooding logs. Backfill script (deferred per plan Q5) would
-        # close this over time.
         logger.info(
             "[T2_DETECTOR] cache_miss skipped %d/%d conversation records "
             "(legacy records lacking cached embedding)",
@@ -153,38 +94,28 @@ def detect_t2_pattern(
     if len(candidates) < T2_MIN_INSTANCES:
         return None
 
-    session_ids = {
-        ((item.metadata or {}).get("session_id") or "")
-        for item, _ in candidates
-    }
-    session_ids.discard("")  # records missing session_id don't count
+    session_ids = {item.metadata.get("session_id") or "" for item in candidates}
+    session_ids.discard("")
     if len(session_ids) < T2_MIN_SESSIONS:
         return None
 
-    cutoff = (
-        datetime.now(timezone.utc) - timedelta(days=T2_RECENCY_DAYS)
-    ).isoformat()
-    if not any(
-        (item.timestamp or "") >= cutoff for item, _ in candidates
-    ):
+    cutoff = (datetime.now() - timedelta(days=T2_RECENCY_DAYS)).strftime(_TIMESTAMP_FMT)
+    if not any((item.timestamp or "") >= cutoff for item in candidates):
         return None
 
     has_named_party = any(
-        bool((item.metadata or {}).get("contains_named_third_party", False))
-        for item, _ in candidates
+        bool(item.metadata.get("contains_named_third_party", False))
+        for item in candidates
     )
 
     signal = PatternSignal(
         instance_count=len(candidates),
         session_count=len(session_ids),
         has_named_party=has_named_party,
-        max_similarity=max(sim for _, sim in candidates),
+        max_similarity=max_sim,
         category="relational",
     )
 
-    # Audit log hook (Q4 deferred decision: logging only for MVP, no
-    # vault system_event write). Surfaces detector firings without the
-    # complexity of post-generation phrase detection.
     logger.info(
         "[T2_AUDIT] pattern_signal_emitted instance_count=%d "
         "session_count=%d has_named_party=%s max_similarity=%.3f",

--- a/tests/test_pattern_detector.py
+++ b/tests/test_pattern_detector.py
@@ -8,7 +8,7 @@ and detect_t2_pattern over seeded retrieval items.
 from __future__ import annotations
 
 import dataclasses
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -62,12 +62,15 @@ def test_pattern_signal_equality() -> None:
 # ---------------------------------------------------------------------------
 
 
+_RECORD_FMT = "%Y-%m-%dT%H-%M-%S-%f"  # matches src/memory/write_memory.py
+
+
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now().strftime(_RECORD_FMT)
 
 
 def _old_iso(days: int = 60) -> str:
-    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    return (datetime.now() - timedelta(days=days)).strftime(_RECORD_FMT)
 
 
 def _make_item(
@@ -245,3 +248,27 @@ def test_detect_constant_thresholds_match_adr() -> None:
     assert T2_MIN_SESSIONS == 2
     assert T2_MIN_SIMILARITY == 0.82
     assert T2_RECENCY_DAYS == 30
+
+
+def test_detect_recency_uses_record_timestamp_format() -> None:
+    """Regression: cutoff must compare in the same format as
+    write_memory._next_timestamp() emits ("%Y-%m-%dT%H-%M-%S-%f", no
+    timezone). Mixed formats string-compare wrong: ":" (0x3A) > "-"
+    (0x2D) so an isoformat cutoff would always be lexically greater
+    than every hyphenated record timestamp, making the recency check
+    always fail in production. This test seeds production-format
+    timestamps and asserts the gate passes when records are recent and
+    fails when they're old."""
+    recent = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1", timestamp=_now_iso()),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2", timestamp=_now_iso()),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s3", timestamp=_now_iso()),
+    ]
+    assert detect_t2_pattern(recent, _VEC_HIGH_SIM) is not None
+
+    old = [
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s1", timestamp=_old_iso(60)),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s2", timestamp=_old_iso(60)),
+        _make_item(embedding=_VEC_HIGH_SIM, session_id="s3", timestamp=_old_iso(60)),
+    ]
+    assert detect_t2_pattern(old, _VEC_HIGH_SIM) is None


### PR DESCRIPTION
## Summary

`/simplify` review of Item 8 (PR #27) caught one correctness bug and four code-quality issues. All fixed in a single commit.

### The bug — production detector was a permanent no-op

`detect_t2_pattern` built its recency cutoff via `datetime.now(timezone.utc).isoformat()` (`2026-04-25T...+00:00`, **colons**), but real records emit timestamps via `write_memory._next_timestamp()` which uses `%Y-%m-%dT%H-%M-%S-%f` (`2026-04-25T...`, **hyphens**, no timezone).

String compare across mixed formats: `:` (0x3A) > `-` (0x2D), so an isoformat cutoff is **always** lexically greater than every hyphenated record timestamp. The recency check `item.timestamp >= cutoff` would have **always returned False on real records** — detector permanently no-op.

Tests passed because the seed helper used isoformat on both sides, masking the bug. The fix:
- Cutoff now uses the same `%Y-%m-%dT%H-%M-%S-%f` format
- Test helpers updated to match production format
- New regression test seeds production-format timestamps and asserts the gate passes/fails correctly

### Other cleanups (in the same commit)

2. **Drop `sim` from candidates list**: was kept only for one final `max()` call. Track `max_sim` in the loop instead. `candidates` is now a flat `list[ContextItem]`.

3. **Move `PatternSignal` + `T2_CATEGORIES` to `src/safety/models.py`** alongside the other safety dataclasses. Removes the `"object | None"` forward-ref dance in `src/context/models.py` — a real `PatternSignal | None` annotation now works via `TYPE_CHECKING` import. Re-exported from `pattern_detector.py` for back-compat.

4. **Drop defensive accessors** (`getattr(item, "memory_type", None)`, `(item.metadata or {})`). `ContextItem` guarantees both fields per its dataclass defaults — the defensiveness implied a contract that doesn't exist.

5. **Trim WHAT-narrating comments** in `pattern_detector.py` and the openai_adapter detector invocation. Per CLAUDE.md, comments explain WHY, not WHAT.

## Test plan
- [x] 1533 tests pass (was 1532; +1 regression test for the timestamp format)
- [x] All `tests/test_pattern_detector.py` tests still pass with production-format timestamps
- [ ] CI green