### PR TITLE
feat(reflection): Item 9 — Lodestone path 2 inferred-value synthesis (ADR-017)

### DIFF
--- a/src/memory/lodestone_service.py
+++ b/src/memory/lodestone_service.py
@@ -23,6 +23,11 @@ from src.memory.storage import MemoryStorage
 logger = logging.getLogger("ember.lodestone")
 
 MAX_ACTIVE_RECORDS = 15
+# Cap proposed (unconfirmed) record growth. write() bypasses MAX_ACTIVE_RECORDS
+# when confirmed=False, so without this ceiling a never-confirming user could
+# accumulate inferred records every month forever. Path-2 synthesis
+# (src/reflection/lodestone_synthesis.py) checks against this before each run.
+MAX_PROPOSED_RECORDS = 20
 
 storage = MemoryStorage()
 

--- a/src/reflection/lodestone_synthesis.py
+++ b/src/reflection/lodestone_synthesis.py
@@ -1,0 +1,304 @@
+"""
+src/reflection/lodestone_synthesis.py
+
+Path 2 lodestone acquisition (ADR-017): three-stage reflection synthesis
+that proposes inferred value records when a recurring theme is visible
+across the prior month's reflections.
+
+Most runs short-circuit at Stage 1 or 2. That is correct behavior per
+ADR-017 - the architecture trades yield for signal quality.
+
+Output records are written with confirmed=False; the user confirms via
+PATCH /v1/lodestone/{id}. Until confirmed, lodestone_resolver does not
+inject them into the prompt (read_active() filters confirmed-only).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import ollama
+
+from src.core.config import get_ember_model
+from src.memory import lodestone_service
+from src.memory.service import MemoryService
+
+logger = logging.getLogger("ember.lodestone_synthesis")
+
+
+# Hyperparameters per ADR-017. Tunable - revisit after real usage data exists.
+SYNTHESIS_WINDOW_DAYS = 30
+MIN_REFLECTIONS_FOR_SYNTHESIS = 4
+MAX_REFLECTIONS_INPUT = 30
+REFLECTION_TRUNCATE_CHARS = 400
+STAGE1_MIN_THEME_WORDS = 5  # density floor: rejects single-token themes ("honesty")
+
+VALID_CATEGORIES = {"character", "relational", "directional", "ground", "beyond"}
+
+
+_STAGE1_PROMPT = """\
+You are reviewing one month of reflection summaries from a personal AI's
+journal of a user's behavior and stated thinking. Your task is to identify
+whether ONE specific theme recurs across these reflections.
+
+A theme qualifies only if:
+- It appears in 3 or more separate reflections (not just 3 mentions in one)
+- It is something the user keeps returning to of their own volition, not
+  a topic the AI introduced
+- It is concrete enough that a stranger could describe what behavior would
+  follow from it
+
+Output:
+- If a qualifying theme is present, write the theme in ONE short phrase
+  (under 12 words). Example: "the user keeps returning to honest
+  conversation over comfortable conversation"
+- If no qualifying theme is present, output exactly: NO_VALUE_FOUND
+
+Do not list multiple themes. Do not output JSON. Do not explain. Output
+the phrase OR the literal string NO_VALUE_FOUND.
+
+Reflections (one per record, separated by ---):
+
+{reflection_block}
+"""
+
+
+_STAGE2_PROMPT = """\
+You are deciding whether a recurring theme expresses a VALUE the user
+holds, or whether it is a SITUATION the user is currently navigating.
+
+A value is something the user is committed to over time, that would
+influence behavior across many situations. A situation is a current
+project, problem, or context that will pass.
+
+Theme:
+"{theme}"
+
+If this is a value, name the single best taxonomy category for it:
+- character: what kind of person am I committed to being?
+- relational: how do I hold my responsibilities to people I'm connected to?
+- directional: what am I moving toward or guarding?
+- ground: what do I draw from when everything else is uncertain?
+- beyond: what connects me to something larger than myself?
+
+Output exactly ONE of these strings:
+- character
+- relational
+- directional
+- ground
+- beyond
+- NO_CATEGORY_MATCH
+
+Output the literal string only. No explanation.
+"""
+
+
+_STAGE3_PROMPT = """\
+You are writing a candidate lodestone record for a user. The theme
+recurred across this month and was classified as a {category} value.
+
+Write a single, specific value statement in the user's voice (first person,
+present tense, declarative). Avoid abstractions ("integrity"); write the
+concrete commitment ("I'd rather lose comfort than skip a hard conversation
+that needs to happen"). Keep it under 25 words.
+
+Then list the supporting evidence: 2-4 short verbatim or paraphrased
+excerpts from the reflections that demonstrate the pattern. Each excerpt
+on its own line, prefixed with "- ".
+
+Theme: "{theme}"
+Category: {category}
+
+Reflections:
+{reflection_block}
+
+Output exactly this format:
+VALUE: <one sentence value statement>
+EVIDENCE:
+- <excerpt 1>
+- <excerpt 2>
+[- <excerpt 3>]
+[- <excerpt 4>]
+"""
+
+
+def _format_reflection_block(reflections: list[dict]) -> str:
+    """Build the reflection input block. Capped at MAX_REFLECTIONS_INPUT records,
+    each truncated to REFLECTION_TRUNCATE_CHARS characters."""
+    lines: list[str] = []
+    for rec in reflections[:MAX_REFLECTIONS_INPUT]:
+        ts = rec.get("timestamp") or rec.get("created_at") or ""
+        date_prefix = ts[:10] if ts else "unknown"
+        text = (rec.get("text") or rec.get("summary") or "").strip()
+        if not text:
+            continue
+        truncated = text[:REFLECTION_TRUNCATE_CHARS].rstrip()
+        if len(text) > REFLECTION_TRUNCATE_CHARS:
+            truncated += "..."
+        lines.append(f"[{date_prefix}] {truncated}")
+    return "\n---\n".join(lines)
+
+
+def _ollama_text(prompt: str, num_predict: int) -> str | None:
+    """Single-message Ollama call with deterministic settings. Returns None on
+    error so callers short-circuit cleanly."""
+    try:
+        result = ollama.chat(
+            model=get_ember_model(),
+            messages=[{"role": "user", "content": prompt}],
+            options={"temperature": 0.0, "num_predict": num_predict},
+            think=False,
+        )
+        return (result.get("message") or {}).get("content", "").strip()
+    except Exception as exc:
+        logger.warning("[LODESTONE_SYNTHESIS] LLM call failed: %s", exc)
+        return None
+
+
+def _stage1_pattern_check(reflection_block: str) -> str | None:
+    """Return the theme phrase, or None if NO_VALUE_FOUND / too abstract / error."""
+    response = _ollama_text(_STAGE1_PROMPT.format(reflection_block=reflection_block), num_predict=30)
+    if not response:
+        return None
+    if response.upper().strip() == "NO_VALUE_FOUND":
+        logger.info("[LODESTONE_SYNTHESIS] stage1 NO_VALUE_FOUND - exiting")
+        return None
+    if len(response.split()) < STAGE1_MIN_THEME_WORDS:
+        logger.info(
+            "[LODESTONE_SYNTHESIS] stage1 theme too abstract (<%d words): %r - exiting",
+            STAGE1_MIN_THEME_WORDS,
+            response[:80],
+        )
+        return None
+    return response
+
+
+def _stage2_taxonomy_check(theme: str) -> str | None:
+    """Return the category in VALID_CATEGORIES, or None for any other response."""
+    response = _ollama_text(_STAGE2_PROMPT.format(theme=theme), num_predict=10)
+    if not response:
+        return None
+    normalized = response.strip().lower().split()[0] if response.strip() else ""
+    if normalized in VALID_CATEGORIES:
+        return normalized
+    logger.info(
+        "[LODESTONE_SYNTHESIS] stage2 no category match (response=%r) - exiting",
+        response[:60],
+    )
+    return None
+
+
+def _parse_stage3_output(text: str) -> tuple[str, list[str]] | None:
+    """Parse VALUE: + EVIDENCE: lines. Returns (value, [evidence_lines]) or None
+    on parse failure / missing markers / empty value / zero evidence."""
+    lines = text.splitlines()
+    value = ""
+    evidence: list[str] = []
+    in_evidence = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        upper = stripped.upper()
+        if upper.startswith("VALUE:"):
+            value = stripped.split(":", 1)[1].strip()
+            in_evidence = False
+        elif upper.startswith("EVIDENCE:"):
+            in_evidence = True
+        elif in_evidence and stripped.startswith("-"):
+            excerpt = stripped.lstrip("-").strip()
+            if excerpt:
+                evidence.append(excerpt)
+    if not value or not evidence:
+        return None
+    return value, evidence
+
+
+def _stage3_record_draft(
+    theme: str, category: str, reflection_block: str
+) -> tuple[str, list[str]] | None:
+    """Return parsed (value, evidence) or None on parser/LLM failure."""
+    response = _ollama_text(
+        _STAGE3_PROMPT.format(theme=theme, category=category, reflection_block=reflection_block),
+        num_predict=200,
+    )
+    if not response:
+        return None
+    parsed = _parse_stage3_output(response)
+    if parsed is None:
+        logger.info("[LODESTONE_SYNTHESIS] stage3 parser failure - exiting")
+        return None
+    return parsed
+
+
+def _recent_reflections(memory_service: MemoryService) -> list[dict]:
+    """Return reflection records timestamped within the last
+    SYNTHESIS_WINDOW_DAYS, sorted ascending by timestamp."""
+    records = memory_service.read(memory_type="reflection", limit=MAX_REFLECTIONS_INPUT * 2)
+    cutoff = (datetime.now() - timedelta(days=SYNTHESIS_WINDOW_DAYS)).strftime(
+        "%Y-%m-%dT%H-%M-%S-%f"
+    )
+    in_window = [
+        rec for rec in records
+        if (rec.get("timestamp") or rec.get("created_at") or "") >= cutoff
+    ]
+    in_window.sort(key=lambda r: r.get("timestamp") or r.get("created_at") or "")
+    return in_window
+
+
+def synthesize_lodestone_candidates(
+    memory_service: MemoryService | None = None,
+) -> dict | None:
+    """Run the three-stage path-2 synthesis. Writes a proposed lodestone
+    record on full success; returns the written record dict or None.
+
+    The function is intentionally side-effecting (writes a vault record)
+    rather than returning a draft for the caller to commit - matches the
+    pattern of generate_reflection() and keeps the runner glue trivial.
+    """
+    svc = memory_service or MemoryService()
+    reflections = _recent_reflections(svc)
+    if len(reflections) < MIN_REFLECTIONS_FOR_SYNTHESIS:
+        logger.info(
+            "[LODESTONE_SYNTHESIS] insufficient evidence: %d reflections in window",
+            len(reflections),
+        )
+        return None
+
+    reflection_block = _format_reflection_block(reflections)
+    if not reflection_block:
+        logger.info("[LODESTONE_SYNTHESIS] reflection block empty after formatting")
+        return None
+
+    theme = _stage1_pattern_check(reflection_block)
+    if theme is None:
+        return None
+
+    category = _stage2_taxonomy_check(theme)
+    if category is None:
+        return None
+
+    parsed = _stage3_record_draft(theme, category, reflection_block)
+    if parsed is None:
+        return None
+
+    value, evidence = parsed
+    # TODO (v0.18.0+): set recurrence_count from len(evidence) once the UI
+    # surfaces "this came up N times this month" on the confirmation queue.
+    # MVP keeps the lodestone_service default of 1.
+    record = lodestone_service.write(
+        value=value,
+        taxonomy_category=category,
+        acquisition_path="inferred",
+        source="reflection_synthesis",
+        supporting_evidence="\n".join(f"- {line}" for line in evidence),
+        confirmed=False,
+    )
+    logger.info(
+        "[LODESTONE_SYNTHESIS] proposed inferred record (%s): %s",
+        category,
+        value[:80],
+    )
+    return record

--- a/src/reflection/lodestone_synthesis.py
+++ b/src/reflection/lodestone_synthesis.py
@@ -30,10 +30,25 @@ logger = logging.getLogger("ember.lodestone_synthesis")
 
 # Hyperparameters per ADR-017. Tunable - revisit after real usage data exists.
 SYNTHESIS_WINDOW_DAYS = 30
-MIN_REFLECTIONS_FOR_SYNTHESIS = 4
+# Aligned with the Stage 1 prompt's "appears in 3 or more separate reflections"
+# rule. A vault with exactly 3 on-theme reflections is acceptable evidence.
+MIN_REFLECTIONS_FOR_SYNTHESIS = 3
 MAX_REFLECTIONS_INPUT = 30
 REFLECTION_TRUNCATE_CHARS = 400
 STAGE1_MIN_THEME_WORDS = 5  # density floor: rejects single-token themes ("honesty")
+# Stage 3 must produce at least this many evidence excerpts. Mirrors the
+# Stage 1 "3+ reflections" requirement on the output side - prevents the
+# parser from accepting a single-excerpt draft when the prompt asked for 3+.
+STAGE3_MIN_EVIDENCE_LINES = 3
+# Read 3x the window cap to ensure date-filtering happens before the
+# read-layer hard limit. Without this, a high-volume vault could lose
+# in-window records to the read limit and silently miss recent evidence.
+_REFLECTION_READ_OVERHEAD = 5
+# Cap proposed-record growth. Path 2 doesn't compete for the active-record
+# budget (lodestone_service.write skips the cap when confirmed=False), so
+# a never-confirming user could accumulate proposed records indefinitely.
+# Skip new synthesis until the queue drops below this ceiling.
+MAX_PROPOSED_QUEUE = 20
 
 VALID_CATEGORIES = {"character", "relational", "directional", "ground", "beyond"}
 
@@ -166,10 +181,11 @@ def _stage1_pattern_check(reflection_block: str) -> str | None:
         logger.info("[LODESTONE_SYNTHESIS] stage1 NO_VALUE_FOUND - exiting")
         return None
     if len(response.split()) < STAGE1_MIN_THEME_WORDS:
+        # Vault Privacy Rule: log word count only, not the theme text itself
+        # (theme is derived from vault reflections and is therefore vault content).
         logger.info(
-            "[LODESTONE_SYNTHESIS] stage1 theme too abstract (<%d words): %r - exiting",
+            "[LODESTONE_SYNTHESIS] stage1 theme too abstract (<%d words) - exiting",
             STAGE1_MIN_THEME_WORDS,
-            response[:80],
         )
         return None
     return response
@@ -183,16 +199,22 @@ def _stage2_taxonomy_check(theme: str) -> str | None:
     normalized = response.strip().lower().split()[0] if response.strip() else ""
     if normalized in VALID_CATEGORIES:
         return normalized
+    # Vault Privacy Rule: log response length only, not the response content.
     logger.info(
-        "[LODESTONE_SYNTHESIS] stage2 no category match (response=%r) - exiting",
-        response[:60],
+        "[LODESTONE_SYNTHESIS] stage2 no category match (response_len=%d) - exiting",
+        len(response),
     )
     return None
 
 
 def _parse_stage3_output(text: str) -> tuple[str, list[str]] | None:
-    """Parse VALUE: + EVIDENCE: lines. Returns (value, [evidence_lines]) or None
-    on parse failure / missing markers / empty value / zero evidence."""
+    """Parse VALUE: + EVIDENCE: lines. Returns (value, [evidence_lines]) or
+    None on parse failure: missing markers, empty value, or fewer than
+    STAGE3_MIN_EVIDENCE_LINES evidence excerpts (mirrors Stage 1's "3+
+    reflections" rule on the output side).
+
+    Accepts evidence lines prefixed with "-" or "*" (qwen3:8b sometimes
+    emits markdown bullets despite the prompt asking for hyphens)."""
     lines = text.splitlines()
     value = ""
     evidence: list[str] = []
@@ -207,11 +229,11 @@ def _parse_stage3_output(text: str) -> tuple[str, list[str]] | None:
             in_evidence = False
         elif upper.startswith("EVIDENCE:"):
             in_evidence = True
-        elif in_evidence and stripped.startswith("-"):
-            excerpt = stripped.lstrip("-").strip()
+        elif in_evidence and (stripped.startswith("-") or stripped.startswith("*")):
+            excerpt = stripped.lstrip("-* ").strip()
             if excerpt:
                 evidence.append(excerpt)
-    if not value or not evidence:
+    if not value or len(evidence) < STAGE3_MIN_EVIDENCE_LINES:
         return None
     return value, evidence
 
@@ -235,14 +257,25 @@ def _stage3_record_draft(
 
 def _recent_reflections(memory_service: MemoryService) -> list[dict]:
     """Return reflection records timestamped within the last
-    SYNTHESIS_WINDOW_DAYS, sorted ascending by timestamp."""
-    records = memory_service.read(memory_type="reflection", limit=MAX_REFLECTIONS_INPUT * 2)
+    SYNTHESIS_WINDOW_DAYS, sorted ascending by timestamp.
+
+    Reads MAX_REFLECTIONS_INPUT * _REFLECTION_READ_OVERHEAD records so that
+    the date filter, not the read limit, determines what reaches the LLM.
+    A high-volume vault could otherwise lose in-window records to the
+    read-layer cap.
+
+    Cutoff format strips microseconds so it lexically compares correctly
+    with older records that may not include the %f suffix."""
+    records = memory_service.read(
+        memory_type="reflection",
+        limit=MAX_REFLECTIONS_INPUT * _REFLECTION_READ_OVERHEAD,
+    )
     cutoff = (datetime.now() - timedelta(days=SYNTHESIS_WINDOW_DAYS)).strftime(
-        "%Y-%m-%dT%H-%M-%S-%f"
+        "%Y-%m-%dT%H-%M-%S"
     )
     in_window = [
         rec for rec in records
-        if (rec.get("timestamp") or rec.get("created_at") or "") >= cutoff
+        if (rec.get("timestamp") or rec.get("created_at") or "")[:19] >= cutoff
     ]
     in_window.sort(key=lambda r: r.get("timestamp") or r.get("created_at") or "")
     return in_window
@@ -259,6 +292,22 @@ def synthesize_lodestone_candidates(
     pattern of generate_reflection() and keeps the runner glue trivial.
     """
     svc = memory_service or MemoryService()
+
+    # Don't let the proposed-records queue grow without bound. Path 2 writes
+    # confirmed=False which bypasses lodestone_service's MAX_ACTIVE_RECORDS
+    # cap (that cap only protects active-record budget). A user who never
+    # confirms could accumulate proposed records every month forever; this
+    # ceiling forces a backlog-clearing pause until the queue drops.
+    proposed_count = len(lodestone_service.read_proposed())
+    if proposed_count >= MAX_PROPOSED_QUEUE:
+        logger.info(
+            "[LODESTONE_SYNTHESIS] proposed queue at cap (%d/%d); "
+            "skipping synthesis until user clears backlog",
+            proposed_count,
+            MAX_PROPOSED_QUEUE,
+        )
+        return None
+
     reflections = _recent_reflections(svc)
     if len(reflections) < MIN_REFLECTIONS_FOR_SYNTHESIS:
         logger.info(
@@ -296,9 +345,11 @@ def synthesize_lodestone_candidates(
         supporting_evidence="\n".join(f"- {line}" for line in evidence),
         confirmed=False,
     )
+    # Vault Privacy Rule: log category + length only, not the value text.
     logger.info(
-        "[LODESTONE_SYNTHESIS] proposed inferred record (%s): %s",
+        "[LODESTONE_SYNTHESIS] proposed inferred record (%s, value_len=%d, evidence_count=%d)",
         category,
-        value[:80],
+        len(value),
+        len(evidence),
     )
     return record

--- a/src/reflection/lodestone_synthesis.py
+++ b/src/reflection/lodestone_synthesis.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any
 
 import ollama
 
@@ -40,16 +39,15 @@ STAGE1_MIN_THEME_WORDS = 5  # density floor: rejects single-token themes ("hones
 # Stage 1 "3+ reflections" requirement on the output side - prevents the
 # parser from accepting a single-excerpt draft when the prompt asked for 3+.
 STAGE3_MIN_EVIDENCE_LINES = 3
+# Defense-in-depth upper bound. The Stage 3 prompt asks for 2-4 lines and
+# num_predict caps tokens, so a runaway response is unlikely; this guards
+# against future prompt or num_predict changes accidentally letting the
+# evidence list grow unbounded.
+STAGE3_MAX_EVIDENCE_LINES = 10
 # Read 3x the window cap to ensure date-filtering happens before the
 # read-layer hard limit. Without this, a high-volume vault could lose
 # in-window records to the read limit and silently miss recent evidence.
 _REFLECTION_READ_OVERHEAD = 5
-# Cap proposed-record growth. Path 2 doesn't compete for the active-record
-# budget (lodestone_service.write skips the cap when confirmed=False), so
-# a never-confirming user could accumulate proposed records indefinitely.
-# Skip new synthesis until the queue drops below this ceiling.
-MAX_PROPOSED_QUEUE = 20
-
 VALID_CATEGORIES = {"character", "relational", "directional", "ground", "beyond"}
 
 
@@ -233,6 +231,8 @@ def _parse_stage3_output(text: str) -> tuple[str, list[str]] | None:
             excerpt = stripped.lstrip("-* ").strip()
             if excerpt:
                 evidence.append(excerpt)
+                if len(evidence) >= STAGE3_MAX_EVIDENCE_LINES:
+                    break
     if not value or len(evidence) < STAGE3_MIN_EVIDENCE_LINES:
         return None
     return value, evidence
@@ -299,12 +299,12 @@ def synthesize_lodestone_candidates(
     # confirms could accumulate proposed records every month forever; this
     # ceiling forces a backlog-clearing pause until the queue drops.
     proposed_count = len(lodestone_service.read_proposed())
-    if proposed_count >= MAX_PROPOSED_QUEUE:
+    if proposed_count >= lodestone_service.MAX_PROPOSED_RECORDS:
         logger.info(
             "[LODESTONE_SYNTHESIS] proposed queue at cap (%d/%d); "
             "skipping synthesis until user clears backlog",
             proposed_count,
-            MAX_PROPOSED_QUEUE,
+            lodestone_service.MAX_PROPOSED_RECORDS,
         )
         return None
 

--- a/src/reflection/run_monthly_reflection.py
+++ b/src/reflection/run_monthly_reflection.py
@@ -4,12 +4,20 @@ src/reflection/run_monthly_reflection.py
 Monthly reflection runner. Uses the monthly_reflection.txt prompt template
 for LLM-driven synthesis across journal, conversation, and reflection records.
 
+After the monthly reflection record is written, runs ADR-017 path-2
+lodestone synthesis as a post-step (monthly cadence only - signal density
+across a month justifies the multi-LLM-call cost).
+
 See ADR-016 prompt writing standards and TDD §32.6 for design rationale.
 """
 
+import logging
 from pathlib import Path
 
 from src.reflection.generate_reflection import generate_reflection
+from src.reflection.lodestone_synthesis import synthesize_lodestone_candidates
+
+logger = logging.getLogger("ember.reflection.monthly")
 
 
 def _load_prompt_template() -> str:
@@ -19,13 +27,25 @@ def _load_prompt_template() -> str:
 
 
 def run_monthly_reflection():
-    return generate_reflection(
+    reflection = generate_reflection(
         memory_types=["journal", "conversation", "reflection"],
         limit=100,
         store=True,
         cadence="monthly",
         prompt_template=_load_prompt_template(),
     )
+
+    # ADR-017 path 2: attempt inferred-value synthesis after the monthly
+    # reflection has been written. Most runs short-circuit at Stage 1 or 2.
+    # Wrapped: synthesis failures must not break the monthly reflection.
+    try:
+        proposed = synthesize_lodestone_candidates()
+        if proposed is not None:
+            reflection["proposed_lodestone_id"] = proposed["id"]
+    except Exception as exc:
+        logger.warning("[LODESTONE_SYNTHESIS] post-reflection pass failed (non-fatal): %s", exc)
+
+    return reflection
 
 
 if __name__ == "__main__":

--- a/tests/test_lodestone_synthesis.py
+++ b/tests/test_lodestone_synthesis.py
@@ -1,0 +1,383 @@
+"""
+tests/test_lodestone_synthesis.py
+
+Coverage for src/reflection/lodestone_synthesis.py - three-stage path-2
+acquisition per ADR-017 + the read_active() injection-gate contract that
+keeps proposed records out of the prompt.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.reflection.lodestone_synthesis import (
+    MIN_REFLECTIONS_FOR_SYNTHESIS,
+    STAGE1_MIN_THEME_WORDS,
+    SYNTHESIS_WINDOW_DAYS,
+    VALID_CATEGORIES,
+    _format_reflection_block,
+    _parse_stage3_output,
+    synthesize_lodestone_candidates,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic reflection records + mocked LLM
+# ---------------------------------------------------------------------------
+
+
+def _record_ts(days_ago: int = 0) -> str:
+    """Timestamp in the format write_memory emits."""
+    return (datetime.now() - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H-%M-%S-%f")
+
+
+def _reflection_record(text: str, days_ago: int = 0) -> dict:
+    return {
+        "type": "reflection",
+        "text": text,
+        "timestamp": _record_ts(days_ago),
+        "metadata": {"cadence": "weekly"},
+    }
+
+
+def _stub_memory_service(reflections: list[dict]) -> MagicMock:
+    svc = MagicMock()
+    svc.read.return_value = reflections
+    return svc
+
+
+def _stub_chat(responses: list[str]):
+    """Return a side_effect callable that yields the given responses in order."""
+    iterator = iter(responses)
+    def _side_effect(**kwargs):
+        return {"message": {"content": next(iterator)}}
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# Stage exit tests
+# ---------------------------------------------------------------------------
+
+
+def test_stage1_insufficient_reflections_skips_entirely() -> None:
+    """Vault has < MIN_REFLECTIONS_FOR_SYNTHESIS reflections in window
+    -> function returns None and makes ZERO LLM calls."""
+    svc = _stub_memory_service(
+        [_reflection_record("a single reflection", days_ago=2)]
+    )
+    with patch("src.reflection.lodestone_synthesis.ollama.chat") as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 0
+
+
+def test_stage1_reflections_outside_window_excluded() -> None:
+    """Records older than SYNTHESIS_WINDOW_DAYS are not counted toward the
+    minimum-evidence floor."""
+    svc = _stub_memory_service(
+        [
+            _reflection_record(f"old reflection {i}", days_ago=SYNTHESIS_WINDOW_DAYS + 5)
+            for i in range(10)
+        ]
+    )
+    with patch("src.reflection.lodestone_synthesis.ollama.chat") as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 0
+
+
+def test_stage1_no_value_found_short_circuits() -> None:
+    """Stage 1 returns NO_VALUE_FOUND -> exit, no Stage 2/3 calls."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat(["NO_VALUE_FOUND"]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 1
+
+
+def test_stage1_too_abstract_theme_short_circuits() -> None:
+    """Stage 1 returns a single word -> rejected as too abstract, no Stage 2 call."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat(["honesty"]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 1
+
+
+def test_stage2_no_category_match_short_circuits() -> None:
+    """Stage 1 returns a theme but Stage 2 returns NO_CATEGORY_MATCH -> exit
+    after 2 LLM calls (no Stage 3)."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to honest conversation over comfort",
+            "NO_CATEGORY_MATCH",
+        ]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 2
+
+
+def test_stage2_invalid_category_treated_as_no_match() -> None:
+    """Stage 2 returns gibberish -> treated as no-match, no Stage 3 call."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to direct conversation over comfort",
+            "miscellaneous",
+        ]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 2
+
+
+def test_stage3_parser_failure_returns_none(tmp_path, monkeypatch) -> None:
+    """Stage 3 returns malformed text (no VALUE: marker) -> no record written."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    monkeypatch.setenv("PRIVATE_VAULT_PATH", str(tmp_path))
+    import importlib
+    import src.core.config as cfg
+    importlib.reload(cfg)
+
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to honest conversation over comfort",
+            "character",
+            "this is not a valid stage 3 output at all",
+        ]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 3
+
+
+def test_stage3_empty_evidence_returns_none(tmp_path, monkeypatch) -> None:
+    """Stage 3 returns VALUE: but no evidence lines -> no record written."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    monkeypatch.setenv("PRIVATE_VAULT_PATH", str(tmp_path))
+    import importlib
+    import src.core.config as cfg
+    importlib.reload(cfg)
+
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to direct conversation over comfort",
+            "character",
+            "VALUE: I value direct honest conversation\nEVIDENCE:\n",
+        ]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+    assert result is None
+    assert mock_chat.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Successful synthesis + record-write contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_vault(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "memory" / "lodestone").mkdir(parents=True)
+    (vault / "embeddings").mkdir()
+    monkeypatch.setenv("PRIVATE_VAULT_PATH", str(vault))
+    import importlib
+    import src.core.config as cfg
+    importlib.reload(cfg)
+    yield vault
+
+
+def test_stage3_produces_record_when_all_stages_pass(temp_vault) -> None:
+    """All three stages return valid output -> record is written via
+    lodestone_service.write with the right fields."""
+    reflections = [_reflection_record(f"reflection {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to direct conversation over comfort",
+            "character",
+            (
+                "VALUE: I would rather lose ease than skip a hard conversation\n"
+                "EVIDENCE:\n"
+                "- declined to soften feedback in three sessions\n"
+                "- noted resistance to performative pleasantness\n"
+                "- chose a hard conversation over a comfortable one this month"
+            ),
+        ]),
+    ) as mock_chat:
+        result = synthesize_lodestone_candidates(memory_service=svc)
+
+    assert result is not None
+    assert mock_chat.call_count == 3
+    assert result["acquisition_path"] == "inferred"
+    assert result["confirmed"] is False
+    assert result["source"] == "reflection_synthesis"
+    assert result["metadata"]["taxonomy_category"] == "character"
+    assert result["supporting_evidence"]
+    assert "declined to soften" in result["supporting_evidence"]
+    assert "lose ease" in result["value"]
+
+
+def test_inferred_record_does_not_appear_in_read_active(temp_vault) -> None:
+    """A record written by path-2 synthesis must NOT appear in read_active()."""
+    from src.memory import lodestone_service
+
+    reflections = [_reflection_record(f"r {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to honest conversation over comfort",
+            "character",
+            "VALUE: I value direct honesty\nEVIDENCE:\n- example one\n- example two",
+        ]),
+    ):
+        synthesize_lodestone_candidates(memory_service=svc)
+
+    active = lodestone_service.read_active()
+    assert all(r["acquisition_path"] != "inferred" for r in active), (
+        "Inferred (proposed) record leaked into read_active() — confirmed-only "
+        "gate is broken. ADR-017 / ADR-035 require proposed records stay "
+        "invisible to prompt assembly."
+    )
+
+
+def test_inferred_record_appears_in_read_proposed(temp_vault) -> None:
+    """Same record is visible via read_proposed() and read_all()."""
+    from src.memory import lodestone_service
+
+    reflections = [_reflection_record(f"r {i}", days_ago=i) for i in range(6)]
+    svc = _stub_memory_service(reflections)
+    with patch(
+        "src.reflection.lodestone_synthesis.ollama.chat",
+        side_effect=_stub_chat([
+            "the user keeps returning to honest conversation over comfort",
+            "character",
+            "VALUE: I value direct honesty\nEVIDENCE:\n- example one\n- example two",
+        ]),
+    ):
+        synthesize_lodestone_candidates(memory_service=svc)
+
+    proposed = lodestone_service.read_proposed()
+    assert any(
+        r["acquisition_path"] == "inferred" and r["confirmed"] is False
+        for r in proposed
+    )
+    assert any(r["acquisition_path"] == "inferred" for r in lodestone_service.read_all())
+
+
+# ---------------------------------------------------------------------------
+# Defensive Q6 contract test - resolver must only call read_active
+# ---------------------------------------------------------------------------
+
+
+def test_lodestone_resolver_only_calls_read_active() -> None:
+    """ADR-035 / Item 7: lodestone_resolver must NEVER call read_proposed
+    or read_all - only read_active. Pins the confirmed-only injection
+    contract so a future resolver refactor can't silently leak proposed
+    records into prompt assembly."""
+    from src.memory import lodestone_service
+
+    def _explode(*_args, **_kwargs):
+        raise AssertionError(
+            "lodestone_resolver called read_proposed/read_all - confirmed-only "
+            "gate violated. Inferred records would leak into the prompt."
+        )
+
+    with patch.object(lodestone_service, "read_proposed", side_effect=_explode), \
+         patch.object(lodestone_service, "read_all", side_effect=_explode):
+        # Import inside the patch context so any module-level eager calls
+        # would also be intercepted.
+        from src.context import lodestone_resolver  # noqa: F401
+        # Trigger the resolve path with empty inputs - read_active should
+        # be the only lodestone_service entrypoint touched.
+        try:
+            lodestone_resolver.resolve(query_embedding=[0.0] * 8, max_records=2)
+        except Exception:
+            # Any internal failure is fine; we only care that the explode
+            # functions were not called.
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests - parser + reflection-block formatter
+# ---------------------------------------------------------------------------
+
+
+def test_parse_stage3_well_formed() -> None:
+    out = _parse_stage3_output(
+        "VALUE: I would rather lose ease than skip a hard conversation\n"
+        "EVIDENCE:\n"
+        "- declined to soften feedback\n"
+        "- chose hard conversation"
+    )
+    assert out is not None
+    value, evidence = out
+    assert value.startswith("I would rather lose ease")
+    assert evidence == ["declined to soften feedback", "chose hard conversation"]
+
+
+def test_parse_stage3_missing_value() -> None:
+    assert _parse_stage3_output("EVIDENCE:\n- ev") is None
+
+
+def test_parse_stage3_missing_evidence_marker() -> None:
+    assert _parse_stage3_output("VALUE: I value X") is None
+
+
+def test_parse_stage3_empty_value_string() -> None:
+    assert _parse_stage3_output("VALUE: \nEVIDENCE:\n- ev") is None
+
+
+def test_format_reflection_block_truncates_long_text() -> None:
+    long_text = "x" * 1000
+    rec = _reflection_record(long_text, days_ago=1)
+    block = _format_reflection_block([rec])
+    assert "..." in block
+    assert len(block) < 1000
+
+
+def test_format_reflection_block_skips_empty_text() -> None:
+    rec = {"type": "reflection", "text": "", "timestamp": _record_ts(1)}
+    assert _format_reflection_block([rec]) == ""
+
+
+def test_valid_categories_match_taxonomy_yaml() -> None:
+    """Pin VALID_CATEGORIES against config/lodestone_taxonomy.yaml so a future
+    taxonomy change doesn't silently drift from what Stage 2 accepts."""
+    import yaml
+    from pathlib import Path
+
+    taxonomy_path = (
+        Path(__file__).resolve().parents[1]
+        / "config"
+        / "lodestone_taxonomy.yaml"
+    )
+    with taxonomy_path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    yaml_categories = set(data["categories"].keys())
+    assert VALID_CATEGORIES == yaml_categories

--- a/tests/test_lodestone_synthesis.py
+++ b/tests/test_lodestone_synthesis.py
@@ -25,7 +25,7 @@ from src.reflection.lodestone_synthesis import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers — synthetic reflection records + mocked LLM
+# Helpers - synthetic reflection records + mocked LLM
 # ---------------------------------------------------------------------------
 
 
@@ -253,14 +253,14 @@ def test_inferred_record_does_not_appear_in_read_active(temp_vault) -> None:
         side_effect=_stub_chat([
             "the user keeps returning to honest conversation over comfort",
             "character",
-            "VALUE: I value direct honesty\nEVIDENCE:\n- example one\n- example two",
+            "VALUE: I value direct honesty\nEVIDENCE:\n- example one\n- example two\n- example three",
         ]),
     ):
         synthesize_lodestone_candidates(memory_service=svc)
 
     active = lodestone_service.read_active()
     assert all(r["acquisition_path"] != "inferred" for r in active), (
-        "Inferred (proposed) record leaked into read_active() — confirmed-only "
+        "Inferred (proposed) record leaked into read_active() -- confirmed-only "
         "gate is broken. ADR-017 / ADR-035 require proposed records stay "
         "invisible to prompt assembly."
     )
@@ -277,7 +277,7 @@ def test_inferred_record_appears_in_read_proposed(temp_vault) -> None:
         side_effect=_stub_chat([
             "the user keeps returning to honest conversation over comfort",
             "character",
-            "VALUE: I value direct honesty\nEVIDENCE:\n- example one\n- example two",
+            "VALUE: I value direct honesty\nEVIDENCE:\n- example one\n- example two\n- example three",
         ]),
     ):
         synthesize_lodestone_candidates(memory_service=svc)
@@ -299,7 +299,12 @@ def test_lodestone_resolver_only_calls_read_active() -> None:
     """ADR-035 / Item 7: lodestone_resolver must NEVER call read_proposed
     or read_all - only read_active. Pins the confirmed-only injection
     contract so a future resolver refactor can't silently leak proposed
-    records into prompt assembly."""
+    records into prompt assembly.
+
+    Wraps read_active so we can also prove the resolver actually exercised
+    the protected path (otherwise a future refactor that bypasses the
+    service entirely would silently pass this test)."""
+    from src.context import lodestone_resolver as resolver_mod
     from src.memory import lodestone_service
 
     def _explode(*_args, **_kwargs):
@@ -308,19 +313,26 @@ def test_lodestone_resolver_only_calls_read_active() -> None:
             "gate violated. Inferred records would leak into the prompt."
         )
 
+    # Patch read_active where the resolver imports it (it does
+    # `from src.memory.lodestone_service import read_active` at module load).
+    active_spy = MagicMock(wraps=lodestone_service.read_active)
+
     with patch.object(lodestone_service, "read_proposed", side_effect=_explode), \
-         patch.object(lodestone_service, "read_all", side_effect=_explode):
-        # Import inside the patch context so any module-level eager calls
-        # would also be intercepted.
-        from src.context import lodestone_resolver  # noqa: F401
-        # Trigger the resolve path with empty inputs - read_active should
-        # be the only lodestone_service entrypoint touched.
+         patch.object(lodestone_service, "read_all", side_effect=_explode), \
+         patch.object(resolver_mod, "read_active", new=active_spy):
         try:
-            lodestone_resolver.resolve(query_embedding=[0.0] * 8, max_records=2)
+            resolver_mod.resolve(
+                user_message="test message",
+                query_embedding=[0.0] * 8,
+                max_records=2,
+            )
         except Exception:
-            # Any internal failure is fine; we only care that the explode
-            # functions were not called.
             pass
+
+    assert active_spy.call_count >= 1, (
+        "Resolver did not call read_active - the confirmed-only gate is "
+        "no longer the source of lodestone records (or signature changed)."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -333,12 +345,40 @@ def test_parse_stage3_well_formed() -> None:
         "VALUE: I would rather lose ease than skip a hard conversation\n"
         "EVIDENCE:\n"
         "- declined to soften feedback\n"
-        "- chose hard conversation"
+        "- chose hard conversation\n"
+        "- named the tension instead of suggesting a workaround"
     )
     assert out is not None
     value, evidence = out
     assert value.startswith("I would rather lose ease")
-    assert evidence == ["declined to soften feedback", "chose hard conversation"]
+    assert len(evidence) == 3
+    assert evidence[0] == "declined to soften feedback"
+
+
+def test_parse_stage3_below_min_evidence_returns_none() -> None:
+    """Mirrors Stage 1's '3+ reflections' rule on the output side."""
+    out = _parse_stage3_output(
+        "VALUE: I value direct conversation\n"
+        "EVIDENCE:\n"
+        "- single excerpt only"
+    )
+    assert out is None
+
+
+def test_parse_stage3_accepts_markdown_bullet_evidence() -> None:
+    """qwen3:8b sometimes emits markdown bullets despite the prompt asking
+    for hyphens. Parser accepts both - and *."""
+    out = _parse_stage3_output(
+        "VALUE: I value clear language\n"
+        "EVIDENCE:\n"
+        "* avoided jargon in feedback\n"
+        "* asked plain-language follow-ups\n"
+        "* corrected an ambiguous phrasing on review"
+    )
+    assert out is not None
+    value, evidence = out
+    assert value == "I value clear language"
+    assert len(evidence) == 3
 
 
 def test_parse_stage3_missing_value() -> None:

--- a/tests/test_lodestone_synthesis.py
+++ b/tests/test_lodestone_synthesis.py
@@ -365,6 +365,19 @@ def test_parse_stage3_below_min_evidence_returns_none() -> None:
     assert out is None
 
 
+def test_parse_stage3_caps_evidence_at_max() -> None:
+    """Defense-in-depth: parser stops after STAGE3_MAX_EVIDENCE_LINES even
+    if the LLM (after a future prompt change) emits a runaway list."""
+    from src.reflection.lodestone_synthesis import STAGE3_MAX_EVIDENCE_LINES
+    runaway = "VALUE: I value clarity\nEVIDENCE:\n" + "\n".join(
+        f"- excerpt {i}" for i in range(STAGE3_MAX_EVIDENCE_LINES + 50)
+    )
+    out = _parse_stage3_output(runaway)
+    assert out is not None
+    _, evidence = out
+    assert len(evidence) == STAGE3_MAX_EVIDENCE_LINES
+
+
 def test_parse_stage3_accepts_markdown_bullet_evidence() -> None:
     """qwen3:8b sometimes emits markdown bullets despite the prompt asking
     for hyphens. Parser accepts both - and *."""

--- a/tests/test_run_monthly_reflection.py
+++ b/tests/test_run_monthly_reflection.py
@@ -1,0 +1,107 @@
+"""
+tests/test_run_monthly_reflection.py
+
+Cover the wiring between monthly reflection and ADR-017 path-2 lodestone
+synthesis. The synthesis call is post-reflection-write and non-fatal.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def test_monthly_runner_invokes_lodestone_synthesis_after_reflection() -> None:
+    """run_monthly_reflection calls synthesize_lodestone_candidates exactly
+    once after the reflection record is written. Order matters: synthesis
+    consumes the most recent reflection."""
+    call_order: list[str] = []
+
+    def _stub_generate(*args, **kwargs):
+        call_order.append("reflection")
+        return {"summary": "monthly stub", "memory_count": 5, "source_type": "test"}
+
+    def _stub_synthesize(*args, **kwargs):
+        call_order.append("synthesis")
+        return None
+
+    with patch(
+        "src.reflection.run_monthly_reflection.generate_reflection",
+        side_effect=_stub_generate,
+    ), patch(
+        "src.reflection.run_monthly_reflection.synthesize_lodestone_candidates",
+        side_effect=_stub_synthesize,
+    ) as mock_synth:
+        from src.reflection.run_monthly_reflection import run_monthly_reflection
+        result = run_monthly_reflection()
+
+    assert call_order == ["reflection", "synthesis"], (
+        "Synthesis must run AFTER reflection write so it consumes the "
+        "newly-written record alongside the prior month."
+    )
+    assert mock_synth.call_count == 1
+    assert result["summary"] == "monthly stub"
+
+
+def test_monthly_runner_attaches_proposed_lodestone_id_when_synthesis_succeeds() -> None:
+    """When synthesis writes a record, its id is attached to the reflection
+    result for downstream observability."""
+    def _stub_generate(*args, **kwargs):
+        return {"summary": "monthly stub", "memory_count": 5}
+
+    def _stub_synthesize(*args, **kwargs):
+        return {"id": "2026-04-25T10-00-00-000000", "value": "I value X"}
+
+    with patch(
+        "src.reflection.run_monthly_reflection.generate_reflection",
+        side_effect=_stub_generate,
+    ), patch(
+        "src.reflection.run_monthly_reflection.synthesize_lodestone_candidates",
+        side_effect=_stub_synthesize,
+    ):
+        from src.reflection.run_monthly_reflection import run_monthly_reflection
+        result = run_monthly_reflection()
+
+    assert result.get("proposed_lodestone_id") == "2026-04-25T10-00-00-000000"
+
+
+def test_monthly_runner_omits_proposed_id_when_synthesis_returns_none() -> None:
+    """The common short-circuit case (Stage 1 or 2 exit) returns None.
+    Reflection result should not carry proposed_lodestone_id in that case."""
+    def _stub_generate(*args, **kwargs):
+        return {"summary": "monthly stub", "memory_count": 5}
+
+    with patch(
+        "src.reflection.run_monthly_reflection.generate_reflection",
+        side_effect=_stub_generate,
+    ), patch(
+        "src.reflection.run_monthly_reflection.synthesize_lodestone_candidates",
+        return_value=None,
+    ):
+        from src.reflection.run_monthly_reflection import run_monthly_reflection
+        result = run_monthly_reflection()
+
+    assert "proposed_lodestone_id" not in result
+
+
+def test_monthly_runner_swallows_synthesis_exceptions() -> None:
+    """Synthesis failures must not break the monthly reflection path -
+    the reflection itself succeeded and its result must be returned
+    intact even if the post-step crashes."""
+    def _stub_generate(*args, **kwargs):
+        return {"summary": "monthly stub", "memory_count": 5}
+
+    def _stub_synthesize_explode(*args, **kwargs):
+        raise RuntimeError("Ollama unreachable")
+
+    with patch(
+        "src.reflection.run_monthly_reflection.generate_reflection",
+        side_effect=_stub_generate,
+    ), patch(
+        "src.reflection.run_monthly_reflection.synthesize_lodestone_candidates",
+        side_effect=_stub_synthesize_explode,
+    ):
+        from src.reflection.run_monthly_reflection import run_monthly_reflection
+        result = run_monthly_reflection()
+
+    assert result["summary"] == "monthly stub"
+    assert "proposed_lodestone_id" not in result


### PR DESCRIPTION
## Summary

Implements ADR-017 path 2: three-stage reflection synthesis that proposes inferred lodestone records when a recurring value-pattern is visible across the prior month's reflections. Closes the "scaffolded but not functional" amendment from 2026-04-24 — zero inferred records exist in any vault today; this PR makes them possible.

## Architecture

```
run_monthly_reflection
  └─ generate_reflection (existing)        → writes reflection record
  └─ synthesize_lodestone_candidates (NEW) → proposes inferred lodestone
      ├─ Stage 1: pattern check       (NO_VALUE_FOUND or theme phrase)
      ├─ Stage 2: taxonomy check      (one of 5 categories or NO_CATEGORY_MATCH)
      └─ Stage 3: record draft        (VALUE: + EVIDENCE: parsed)
          └─ lodestone_service.write(acquisition_path="inferred", confirmed=False)
```

Most runs short-circuit at Stage 1 or 2. That's correct per ADR-017 — the architecture trades yield for signal quality. Each stage exits early if the prior failed; no retries; failure is silent (logged).

## Commits (5)

| Commit | Layer |
|---|---|
| `787263a` | feat(reflection): three-stage synthesis module + write call |
| `429cf20` | test(reflection): 19 tests covering stage exits, write contract, Q6 gate |
| `80e217f` | feat(reflection): wire synthesis into monthly runner + 4 runner tests |
| `d350db8` | fix(reflection): review-agent cleanup (5 must-fix from code/security/quality reviewers) |
| `8d3c975` | refactor(reflection): /simplify pass — drop unused import, cohere caps, defense-in-depth evidence cap |

## Q6: confirmed-only injection gate (ADR-017 / ADR-035)

Verified by code-review and pinned by `test_lodestone_resolver_only_calls_read_active`:
- `lodestone_resolver` imports `read_active` only (which filters `confirmed is True`)
- Proposed records cannot reach the prompt → cannot trigger `flourishing_over_preference` or T2 detection
- Test wraps `read_active` and asserts call_count >= 1 to prove the protected path actually ran (not just that the explode-functions weren't called)

## User confirmation flow (existing)

`PATCH /v1/lodestone/{id}` with `{"confirmed": true}` already accepts the confirmation. UI surface for proposed records is **deferred to v0.18.0+** per Q4 of the approved plan.

## Two parallel review passes — all findings addressed

**First pass (4 review agents per CLAUDE.md project agents)**: code-reviewer, security-reviewer, quality-reviewer, linter. Findings landed in `d350db8`:
- Reflection read cap was masking date filter on high-volume vaults → 5x read overhead
- Cutoff microsecond format mismatch with older records → strip to `:19` chars
- Stage 3 parser accepted single-evidence drafts despite "3+" prompt rule → require ≥3
- No cap on proposed-records growth → MAX_PROPOSED_RECORDS = 20 ceiling
- MIN_REFLECTIONS=4 contradicted Stage 1's "3+" rule → aligned to 3
- Logger calls included vault-derived text (Vault Privacy Rule) → reduced to category + length only
- Em dashes in test file (CLAUDE.md ban) → removed
- Parser brittle to markdown bullets (`*`) → accepts both `-` and `*`
- Resolver pin test under-asserted → wrapped read_active to prove invocation

**Second pass (`/simplify`: reuse, quality, efficiency)**: landed in `8d3c975`:
- Drop unused `from typing import Any`
- Move MAX_PROPOSED_QUEUE → `lodestone_service.MAX_PROPOSED_RECORDS` (cohere with MAX_ACTIVE_RECORDS)
- Cap evidence parser at STAGE3_MAX_EVIDENCE_LINES = 10 (defense-in-depth)

Skipped findings (out-of-scope or false-positive) documented in commit messages.

## Test plan
- [x] 1559 tests pass (was 1532 pre-Item-9; +27 new across synthesis, runner, parser tests)
- [x] All review-agent passes complete; findings applied
- [x] Q6 gate pinned: proposed records cannot leak into prompt assembly
- [ ] CI green
- [ ] Optional: manual smoke (seed test vault with 3+ on-theme reflections, run monthly reflection, inspect for inferred record + verify it doesn't appear in `read_active()`)

## Auto-merge enabled
Per the approved plan + Item 7 / Item 8 precedent for pure-feature work with thorough tests.

## Queued follow-up (separate PR after this merges)
Documentation updates: `current_state.md`, `KNOWN_ISSUES.md`, `RELEASE_WORKFLOW.md`, `NIST_AI_RMF.md` per the manager spec.