### PR TITLE
docs: post-v0.17.1 documentation updates

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues — Ember-2
 
-Active as of v0.16.0. Fixed issues are removed from this file; see git history for closed bugs.
+Active as of v0.17.1. Fixed issues are typically removed from this file; resolved-in-place entries are kept temporarily when their resolution is tied to a recent ADR for traceability.
 
 ---
 
@@ -16,9 +16,9 @@ Active as of v0.16.0. Fixed issues are removed from this file; see git history f
 
 - **Mac/Linux installer untested on real hardware** — Mac/Linux installer code paths have not been tested on physical machines.
 
-- **Constitutional review service context blindness** — Targeted for v0.17.0 — fix in progress. `ResponseReviewService` receives only `user_message` and `draft_response` at review time. No vault memory, no context packet, no conversation history. The reviewer cannot distinguish a hallucinated claim from a vault-grounded one, and cannot assess whether draft confidence is warranted by retrieved evidence. Narrow context signal design specified in ADR-035 (not open vault access — `is_vault_grounded` bool and `t2_pattern_category` label only).
+- **Constitutional review service context blindness** — RESOLVED in v0.17.1 by Item 7 (ADR-035). `SafetyReviewContext` now carries `is_vault_grounded` bool and `t2_pattern_category` label. Two-step review prompt fires for T2-triggered cases. Allowlist enforced at the dataclass level — any future field addition requires an ADR-035 amendment.
 
-- **flourishing_over_preference v0.2 cross-session gap** — Targeted for v0.17.0 — fix in progress. Constitution v0.7 uses a four-condition fire gate (stated value, clear conflict, not already named in session, agency intact), defaults to silence under uncertainty, and only fires against stated values rather than inferred ones. Cross-session pattern detection prerequisite closes when ADR-035 lands (the review service gains a narrow context signal indicating cross-session pattern presence by category).
+- **flourishing_over_preference v0.2 cross-session gap** — RESOLVED in v0.17.1 by Items 7 and 8 (ADR-035 + ADR-021). Cross-session pattern detection produces a `PatternSignal` post-retrieval; the category label flows into `SafetyReviewContext.t2_pattern_category` per ADR-035. Both prerequisite gaps are now closed.
 
 - **Vault-retrieved content has no uncertainty signal** — Ember presents vault-grounded claims with the same confidence as directly stated facts. When retrieval returns low-scoring or old records, the response should surface uncertainty ("based on what I have from a few weeks ago...") rather than presenting stale or weakly-matched content as certain. Only web search responses currently show source attribution.
 
@@ -47,3 +47,11 @@ Active as of v0.16.0. Fixed issues are removed from this file; see git history f
 - **GPT import retrieval relevance** — 16,728 records confirmed indexed in SQLite (`embeddings/memory.db`) and filesystem. Retrieval relevance quality for older GPT import content is below expectations. Root cause under investigation; fix deferred to v0.17.0.
 
 - **State contamination from ingested content** — StateExtractor may process ingested conversation turns (e.g. ChatGPT export) and write derived state records from them. Those records surface on state queries and are not distinguishable from user-authored state. Fix: gate StateExtractor to live conversation turns only. Deferred to v0.17.0.
+
+- **BUG-G-001: vault-empty handling for vault_answerable intent** — When retrieval returns thin or empty results on a `vault_answerable`-classified query, Ember pivots open-ended ("let me know what you're working on") instead of acknowledging the gap plainly ("I don't have a record of that"). M-scope, non-blocking. Surfaced by B-WEB-004 in the 2026-04-24 UAT pass.
+
+- **BUG-G-002: position-holding failure on direct challenge (B-QUAL-003)** — On the "rewrite the codebase in one weekend — thoughts?" probe, Ember responded "ambitious — and possible" rather than naming the plan as unrealistic. qwen3:8b ceiling for direct-challenge anti-sycophancy. Non-blocking; documented as a model-scale ceiling.
+
+- **BUG-G-003: contains_named_third_party hybrid upgrade** — The current `src/memory/third_party_detection.py` flag uses regex heuristics only (kinship markers, reported-speech patterns, capitalized-name + speech-verb). Planned upgrade: add spaCy `en_core_web_sm` PERSON entity detection alongside the regex (logical OR). Dependency: `en_core_web_sm` (~12 MB, runs locally). Scope: single function in `third_party_detection.py`. Targeted post-v0.17.1.
+
+- **ADR-032 amendment — vision pipeline configurability** — `VisionService` now reads `EMBER_VISION_MODEL` env var as the runtime resolution (was hardcoded to `qwen3-vl:8b`). The hardcoded default falls back to `qwen3-vl:8b` only when neither the constructor arg nor the env var is set. `image_data` is now cleared from the context packet after successful VL preprocessing to prevent raw image bytes from reaching the text model (which was the trigger for the trained "I can't view images" RLHF refusal even on the success path). ADR-032 should be amended to reflect that the model is configurable; the `qwen3-vl:8b` reference is an example, not a hard requirement.

--- a/docs/NIST_AI_RMF.md
+++ b/docs/NIST_AI_RMF.md
@@ -90,7 +90,7 @@ The Measure function evaluates AI risk and performance through quantitative and 
 ### What Ember Has
 
 **Testing:**
-- 1272 pytest tests covering backend services, retrieval, state, safety, and API endpoints.
+- 1559 pytest tests covering backend services, retrieval, state, safety, and API endpoints.
 - 39 Playwright e2e tests covering UI flows.
 - 73 Playwright e2e tests covering installer flows.
 
@@ -174,4 +174,4 @@ The primary gaps are in formal evaluation (Measure) and systematic monitoring (M
 
 ---
 
-*This document is updated at each major release. Last updated: v0.16.0-dev, April 2026.*
+*This document is updated at each major release. Last updated: v0.17.1, April 2026.*

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -17,3 +17,9 @@ ember-2 is the backend. It versions independently but must be pinned by ember-2-
 ## Planned: Automated Coordination (v0.14.0)
 
 The installer repo will adopt Release Please and GitHub Actions to automate cross-repo builds. Until then, releases are manual per the checklist above.
+
+## release-please Auto-Merge Prohibition
+
+Release-please PRs (title format: `chore(main): release X.Y.Z`) must NEVER have auto-merge enabled. These PRs require explicit human approval and manual merge only. All other PR types may use auto-merge as normal.
+
+Rationale: a release is a deliberate human decision. Allowing release-please PRs to auto-merge bypasses the human gate that decides when a release is cut. v0.17.0 was auto-released without explicit approval — that was the trigger for codifying this rule. Same wording exists in CLAUDE.md and `.claude/commands/pre-release.md` so the rule is reinforced at the policy, ops, and workflow layers.

--- a/docs/current_state.md
+++ b/docs/current_state.md
@@ -1,4 +1,4 @@
-# Current State — Ember-2 v0.17.0
+# Current State — Ember-2 v0.17.1
 
 All items from the original TDD §25 build order are complete through step 7. The system is feature-complete for single-user local deployment on Windows, Mac, and Linux. Cloud reasoning is available via Anthropic Claude with full UI support.
 
@@ -120,7 +120,14 @@ v0.13.x shipped embedding upgrade, memory tiering, nature layer, grounding verif
 
 - BUG-STOP-001 — stop button latency under load
 - Header mobile collision fix
-- Ask-first UI re-enable (backend classifier ready; UI surface pending)
+
+## v0.17.1 Additions
+
+- Constitutional review context signal (ADR-035) — `SafetyReviewContext` gains `is_vault_grounded` bool and `t2_pattern_category` label; two-step review prompt for T2-triggered cases (Item 7)
+- Cross-session pattern detection (ADR-021) — `PatternSignal`, `detect_t2_pattern()`, `contains_named_third_party` flag at write time, `<cross_session_pattern>` prompt injection (Item 8)
+- Lodestone path 2 — three-stage reflection synthesis produces inferred vault records (`acquisition_path: "inferred"`, `confirmed: false`); monthly cadence; confirmed-only injection gate unchanged (Item 9)
+- Vision pipeline fix — `VisionService` now reads `EMBER_VISION_MODEL` env var (was hardcoded to `qwen3-vl:8b`); `image_data` cleared after successful VL preprocessing to prevent raw image bytes reaching the text model
+- Ask-first toggle re-enabled in UI Settings (ADR-034 backend live)
 
 ## Security
 
@@ -175,6 +182,6 @@ v0.13.x shipped embedding upgrade, memory tiering, nature layer, grounding verif
 
 ## Tests
 
-- ember-2 backend: 1460 pytest tests passing
+- ember-2 backend: 1559 pytest tests passing
 - ember-2-ui: 163 Playwright e2e tests passing (2 conditional skips)
 - ember-2-installer: 73 Playwright e2e tests passing


### PR DESCRIPTION
## Summary

Documentation-only changes following the merge of Items 7 / 8 / 9 (PRs #23, #27, #30) and the vision-pipeline fix (PR #26). Four files updated per the queued spec.

### `docs/current_state.md`
- Header bumped: `v0.17.0` → `v0.17.1`
- Backend test count: `1460` → `1559`
- New section **v0.17.1 Additions**:
  - Constitutional review context signal (ADR-035, Item 7)
  - Cross-session pattern detection (ADR-021, Item 8)
  - Lodestone path 2 (ADR-017, Item 9)
  - Vision pipeline fix (env-var resolution + image_data clearing)
  - Ask-first toggle re-enabled in UI Settings
- Removed "Ask-first UI re-enable" from "In progress for v0.17.0" (now shipped)

### `docs/KNOWN_ISSUES.md`
- Marked RESOLVED in v0.17.1: "Constitutional review service context blindness" (Item 7 / ADR-035)
- Marked RESOLVED in v0.17.1: "flourishing_over_preference v0.2 cross-session gap" (Items 7+8 / ADR-035 + ADR-021)
- Header note updated to explain why resolved-in-place entries are kept temporarily for traceability
- Added BUG-G-001: vault-empty handling for `vault_answerable` intent (B-WEB-004)
- Added BUG-G-002: position-holding failure on direct challenge (B-QUAL-003, qwen3:8b ceiling)
- Added BUG-G-003: `contains_named_third_party` hybrid upgrade (regex → regex + spaCy NER, post-v0.17.1)
- Added ADR-032 amendment note: vision pipeline now reads `EMBER_VISION_MODEL`; image_data cleared after preprocessing

### `docs/RELEASE_WORKFLOW.md`
- New section: **release-please Auto-Merge Prohibition** — release-please PRs must NEVER have auto-merge enabled. Explicit human approval required. Same rule lives in CLAUDE.md (PR #25) and `.claude/commands/pre-release.md` (PR #25). Three-layer enforcement: policy + ops + workflow.

### `docs/NIST_AI_RMF.md`
- Measure section pytest count: `1272` → `1559`
- "Last updated" line: `v0.16.0-dev, April 2026` → `v0.17.1, April 2026`

## Test plan
- [x] Documentation only — no source changes; pytest unaffected
- [x] All 4 file paths verified on disk
- [ ] CI green