### PR TITLE
v0.18.0 coaching filter fixes + nightly scheduler date bug

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -18,7 +18,7 @@ import secrets
 import signal
 import time
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import ollama
@@ -1662,15 +1662,26 @@ import threading
 import time as _time
 
 
+def _next_tiering_run_time(now: datetime) -> datetime:
+    """Return the next 00:05 datetime strictly after `now`.
+
+    Uses timedelta to advance by one day so month-end and year-end
+    rollovers (e.g. April 30, December 31) don't raise ValueError. The
+    earlier implementation used datetime.replace(day=day+1), which
+    failed on the last day of any month.
+    """
+    candidate = now.replace(hour=0, minute=5, second=0, microsecond=0)
+    if candidate <= now:
+        candidate = candidate + timedelta(days=1)
+    return candidate
+
+
 def _nightly_tiering_loop():
     """Sleep until 00:05, run tiering (and monthly reflection on day 1), repeat."""
     while True:
         now = datetime.now()
-        # Next 00:05
-        tomorrow = now.replace(hour=0, minute=5, second=0, microsecond=0)
-        if tomorrow <= now:
-            tomorrow = tomorrow.replace(day=tomorrow.day + 1)
-        sleep_seconds = (tomorrow - now).total_seconds()
+        next_run = _next_tiering_run_time(now)
+        sleep_seconds = (next_run - now).total_seconds()
         _time.sleep(sleep_seconds)
 
         try:

--- a/src/llm/coaching_filter.py
+++ b/src/llm/coaching_filter.py
@@ -65,6 +65,10 @@ _COACHING_CLOSINGS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) 
     # since these often appear mid-response, not just at the end.
     r"how (?:are you|do you) (?:feeling|feel)(?: about)?(?: that| this| it)?",
     r"how does (?:that|this|it) feel",
+    # Trailing softeners: qualifiers appended to undermine a stated
+    # position, producing a hedged, coaching-tone close. Tail-anchored
+    # by the 200-char window in _detect_patterns().
+    r"though i(?:'d| would) still (?:bet|think|guess)",
 ))
 
 # Therapeutic mid-response patterns — not just openers/closers but
@@ -75,7 +79,10 @@ _THERAPEUTIC_MID_RESPONSE: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNOR
     r"i(?:'m| am) here (?:as )?a steady presence",
     r"i(?:'m| am) here for you",
     r"that takes (?:real )?courage",
-    r"it(?:'s| is) okay to (?:not be okay|feel|struggle|take time)",
+    r"it(?:'s| is) okay to (?:not be okay|feel|sit (?:with)?|struggle|cry|grieve|rest|take time|pause)",
+    r"it(?:'s| is) okay that (?:you|this)",
+    r"let(?:'s| us) fix (?:that|this)",
+    r"sit with (?:it|this|the weight)",
     r"be (?:gentle|kind|patient) with yourself",
     r"(?:honor|respect|validate) (?:your|those|the) (?:feelings?|emotions?)",
     r"there(?:'s| is) no (?:right|wrong) way to (?:feel|process|grieve)",
@@ -116,13 +123,32 @@ _NUMBERED_STRUCTURES: tuple[re.Pattern, ...] = (
     re.compile(r"(?:^|\n)\s*(?:1\.|first,)\s+", re.IGNORECASE | re.MULTILINE),
 )
 
+# Intent classes where numbered lists are appropriate response format
+# (factual content, web search results, status reports). Suppressing
+# numbered_structure detection on these classes prevents the false-
+# positive rewrite calls observed in production logs: the rewrite
+# returned null because the LLM correctly refused to convert legitimate
+# factual numbered lists into prose.
+_NUMBERED_STRUCTURE_SUPPRESSED_INTENTS: frozenset[str] = frozenset({
+    "web_search",
+    "factual_recall",
+    "recent",
+    "status_state",
+})
+
 
 # ---------------------------------------------------------------------------
 # Stage 1: Detection
 # ---------------------------------------------------------------------------
 
-def _detect_patterns(text: str, is_emotional: bool) -> list[dict]:
+def _detect_patterns(text: str, is_emotional: bool, intent_class: str = "default") -> list[dict]:
     """Detect coaching-frame patterns in the response text.
+
+    intent_class gates a small subset of patterns (currently
+    _NUMBERED_STRUCTURES) that would produce false positives on factual
+    response classes where numbered lists are the appropriate format.
+    Defaults to "default" so legacy call sites without an intent class
+    see the full pre-gate behavior.
 
     Returns a list of match dicts: {"pattern": str, "match": str, "position": str, "deletable": bool}
     """
@@ -179,16 +205,19 @@ def _detect_patterns(text: str, is_emotional: bool) -> list[dict]:
                 "deletable": False,  # Needs rewrite
             })
 
-    # Numbered structures
-    for pat in _NUMBERED_STRUCTURES:
-        m = pat.search(text)
-        if m:
-            matches.append({
-                "pattern": "numbered_structure",
-                "match": m.group().strip(),
-                "position": "body",
-                "deletable": False,  # Needs rewrite — structure removal changes meaning
-            })
+    # Numbered structures: skip on factual intent classes where lists
+    # are the appropriate response format. See
+    # _NUMBERED_STRUCTURE_SUPPRESSED_INTENTS for the gate.
+    if intent_class not in _NUMBERED_STRUCTURE_SUPPRESSED_INTENTS:
+        for pat in _NUMBERED_STRUCTURES:
+            m = pat.search(text)
+            if m:
+                matches.append({
+                    "pattern": "numbered_structure",
+                    "match": m.group().strip(),
+                    "position": "body",
+                    "deletable": False,  # Needs rewrite, structure removal changes meaning
+                })
 
     return matches
 
@@ -570,13 +599,27 @@ def filter_coaching_frame(
     is_emotional = intent_class in _EMOTIONAL_INTENTS or is_conversational
 
     # Stage 1: detect coaching patterns
-    matches = _detect_patterns(text, is_emotional)
+    matches = _detect_patterns(text, is_emotional, intent_class)
     if not matches:
         return text
 
     # Stage 1: apply deletions for deletable patterns
     result = _apply_deletions(text, matches)
     stage = 1
+
+    # Short-response therapeutic-opener guard. When the entire response
+    # is essentially the matched opener (under 40 chars, only opener
+    # matches), the rewrite call always returns null because there is
+    # nothing left after the frame is removed. Log the intervention and
+    # return empty so the LLM is not invoked for a guaranteed-empty
+    # rewrite.
+    if (
+        len(text) < 40
+        and matches
+        and all(m["pattern"] == "therapeutic_opener" for m in matches)
+    ):
+        _log_intervention(intent_class, matches, text, "", stage=1)
+        return ""
 
     # Stage 2: rewrite if any non-deletable patterns remain
     if _needs_rewrite(matches):

--- a/tests/test_coaching_filter.py
+++ b/tests/test_coaching_filter.py
@@ -279,3 +279,204 @@ def test_chat_ollama_stream_passes_num_predict_to_options() -> None:
 
     assert "num_predict" in captured["options"]
     assert captured["options"]["num_predict"] >= 2048
+
+
+# ---------------------------------------------------------------------------
+# v0.18.0 Item 1: Tier 4 eval phrase additions
+# ---------------------------------------------------------------------------
+
+
+def test_v018_okay_that_you_feel_caught_as_therapeutic_mid() -> None:
+    """'It's okay that you feel that way' is the new 'that' branch of the
+    therapeutic-okay pattern (Haiku flag in v0.17.1 Tier 4)."""
+    from src.llm.coaching_filter import _detect_patterns
+
+    text = "I get that. It's okay that you feel that way."
+    matches = _detect_patterns(text, is_emotional=True)
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "therapeutic_mid" in pattern_kinds
+
+
+def test_v018_okay_to_sit_with_caught_as_therapeutic_mid() -> None:
+    """'It's okay to sit with it' is the new sit/cry/grieve/rest branch."""
+    from src.llm.coaching_filter import _detect_patterns
+
+    text = "It's okay to sit with it for a moment before deciding."
+    matches = _detect_patterns(text, is_emotional=True)
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "therapeutic_mid" in pattern_kinds
+
+
+def test_v018_lets_fix_that_caught_as_therapeutic_mid() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    text = "I see what you mean. Let's fix that together."
+    matches = _detect_patterns(text, is_emotional=True)
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "therapeutic_mid" in pattern_kinds
+
+
+def test_v018_sit_with_the_weight_caught_as_therapeutic_mid() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    text = "Just sit with the weight of it for a while."
+    matches = _detect_patterns(text, is_emotional=True)
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "therapeutic_mid" in pattern_kinds
+
+
+def test_v018_trailing_softener_caught_as_coaching_closing() -> None:
+    """Trailing 'though I'd still bet/think/guess' softener appended to a
+    stated position, hedging it. Tail-anchored (must appear in last 200 chars)."""
+    from src.llm.coaching_filter import _detect_patterns
+
+    text = (
+        "It's probably a connection-pool issue based on the symptoms, "
+        "though I'd still bet on the migration if I had to choose."
+    )
+    matches = _detect_patterns(text, is_emotional=True)
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "coaching_closing" in pattern_kinds
+
+
+# ---------------------------------------------------------------------------
+# v0.18.0 Item 2: numbered_structure intent gate
+# ---------------------------------------------------------------------------
+
+
+_TECHNICAL_NUMBERED_LIST = (
+    "Connection pooling reuses database connections. The benefits are:\n"
+    "1. Lower latency on repeated queries.\n"
+    "2. Reduced connection overhead.\n"
+    "3. Better resource utilization."
+)
+
+
+def test_v018_numbered_structure_suppressed_on_web_search() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    matches = _detect_patterns(
+        _TECHNICAL_NUMBERED_LIST, is_emotional=True, intent_class="web_search",
+    )
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "numbered_structure" not in pattern_kinds
+
+
+def test_v018_numbered_structure_suppressed_on_factual_recall() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    matches = _detect_patterns(
+        _TECHNICAL_NUMBERED_LIST, is_emotional=True, intent_class="factual_recall",
+    )
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "numbered_structure" not in pattern_kinds
+
+
+def test_v018_numbered_structure_suppressed_on_recent() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    matches = _detect_patterns(
+        _TECHNICAL_NUMBERED_LIST, is_emotional=True, intent_class="recent",
+    )
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "numbered_structure" not in pattern_kinds
+
+
+def test_v018_numbered_structure_suppressed_on_status_state() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    matches = _detect_patterns(
+        _TECHNICAL_NUMBERED_LIST, is_emotional=True, intent_class="status_state",
+    )
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "numbered_structure" not in pattern_kinds
+
+
+def test_v018_numbered_structure_still_fires_on_default() -> None:
+    """Regression guard: the gate must NOT change behavior on the default
+    intent class. Numbered structure on emotional/default content still fires."""
+    from src.llm.coaching_filter import _detect_patterns
+
+    matches = _detect_patterns(
+        _TECHNICAL_NUMBERED_LIST, is_emotional=True, intent_class="default",
+    )
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "numbered_structure" in pattern_kinds
+
+
+def test_v018_numbered_structure_still_fires_on_reflective() -> None:
+    from src.llm.coaching_filter import _detect_patterns
+
+    matches = _detect_patterns(
+        _TECHNICAL_NUMBERED_LIST, is_emotional=True, intent_class="reflective",
+    )
+    pattern_kinds = {m["pattern"] for m in matches}
+    assert "numbered_structure" in pattern_kinds
+
+
+# ---------------------------------------------------------------------------
+# v0.18.0 Item 3: short-response therapeutic-opener short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_v018_short_therapeutic_opener_short_circuits_to_empty() -> None:
+    """A response that is essentially the matched opener (under 40 chars)
+    must short-circuit to empty without invoking _rewrite()."""
+    from unittest.mock import patch
+    from src.llm.coaching_filter import filter_coaching_frame
+
+    with patch("src.llm.coaching_filter._rewrite") as mock_rewrite, \
+         patch("src.llm.coaching_filter._check_semantic_identity_collapse", return_value=False), \
+         patch("src.llm.coaching_filter._log_intervention"):
+        result = filter_coaching_frame(
+            "I hear you.", intent_class="default", is_conversational=False,
+        )
+
+    assert result == ""
+    assert mock_rewrite.call_count == 0
+
+
+def test_v018_long_therapeutic_opener_does_not_short_circuit() -> None:
+    """A longer response (>40 chars) that begins with a therapeutic opener
+    must still invoke _rewrite(). The short-circuit is for very short
+    responses only, where removing the opener leaves nothing."""
+    from unittest.mock import patch
+    from src.llm.coaching_filter import filter_coaching_frame
+
+    long_text = (
+        "I hear you. Take a break, stretch, or do something that feels good "
+        "to you for a while."
+    )
+
+    with patch("src.llm.coaching_filter._rewrite", return_value=long_text) as mock_rewrite, \
+         patch("src.llm.coaching_filter._check_semantic_identity_collapse", return_value=False), \
+         patch("src.llm.coaching_filter._log_intervention"):
+        filter_coaching_frame(
+            long_text, intent_class="default", is_conversational=False,
+        )
+
+    assert mock_rewrite.call_count == 1
+
+
+def test_v018_short_response_with_non_opener_match_does_not_short_circuit() -> None:
+    """The short-circuit fires only when ALL matches are therapeutic_opener.
+    A short response with another pattern type must not short-circuit."""
+    from unittest.mock import patch
+    from src.llm.coaching_filter import filter_coaching_frame
+
+    # Short coaching closing, not a therapeutic opener.
+    text = "You've got this!"
+
+    with patch("src.llm.coaching_filter._rewrite", return_value=text) as mock_rewrite, \
+         patch("src.llm.coaching_filter._check_semantic_identity_collapse", return_value=False), \
+         patch("src.llm.coaching_filter._log_intervention"):
+        result = filter_coaching_frame(
+            text, intent_class="default", is_conversational=False,
+        )
+
+    # This is a deletable closing, so result should be the deletion outcome
+    # (empty or near-empty after stripping the closing). The key assertion is
+    # that the short-circuit did not fire and _rewrite was not called for it.
+    assert mock_rewrite.call_count == 0
+    # Deletion path: closing stripped, possibly leaving empty or a fragment.
+    assert "got this" not in result.lower()

--- a/tests/test_tiering.py
+++ b/tests/test_tiering.py
@@ -294,3 +294,69 @@ def test_search_results_include_tier(tmp_path: Path):
     assert "tier" in results[0]
     assert results[0]["tier"] == "hot"  # default
     store.close()
+
+
+# ---------------------------------------------------------------------------
+# _next_tiering_run_time: month and year boundary regression
+# ---------------------------------------------------------------------------
+
+
+def test_next_tiering_run_time_rolls_over_month_end():
+    """Regression: April 30 -> May 1 must not raise. The prior
+    implementation used datetime.replace(day=day+1), which failed on
+    the last day of any month with ValueError 'day is out of range'."""
+    from datetime import datetime
+    from src.api.main import _next_tiering_run_time
+
+    now = datetime(2026, 4, 30, 12, 0, 0)
+    result = _next_tiering_run_time(now)
+    assert result == datetime(2026, 5, 1, 0, 5, 0)
+
+
+def test_next_tiering_run_time_rolls_over_31_day_month_end():
+    from datetime import datetime
+    from src.api.main import _next_tiering_run_time
+
+    now = datetime(2026, 5, 31, 23, 59, 59)
+    result = _next_tiering_run_time(now)
+    assert result == datetime(2026, 6, 1, 0, 5, 0)
+
+
+def test_next_tiering_run_time_rolls_over_year_end():
+    from datetime import datetime
+    from src.api.main import _next_tiering_run_time
+
+    now = datetime(2026, 12, 31, 23, 0, 0)
+    result = _next_tiering_run_time(now)
+    assert result == datetime(2027, 1, 1, 0, 5, 0)
+
+
+def test_next_tiering_run_time_same_day_when_before_target():
+    """When called before 00:05 on a given day, the next run is later
+    that same day (no rollover)."""
+    from datetime import datetime
+    from src.api.main import _next_tiering_run_time
+
+    now = datetime(2026, 4, 15, 0, 4, 0)
+    result = _next_tiering_run_time(now)
+    assert result == datetime(2026, 4, 15, 0, 5, 0)
+
+
+def test_next_tiering_run_time_next_day_when_after_target():
+    """When called after 00:05, the next run is 00:05 the following day."""
+    from datetime import datetime
+    from src.api.main import _next_tiering_run_time
+
+    now = datetime(2026, 4, 15, 0, 6, 0)
+    result = _next_tiering_run_time(now)
+    assert result == datetime(2026, 4, 16, 0, 5, 0)
+
+
+def test_next_tiering_run_time_handles_leap_day_boundary():
+    """Leap-year February 29 -> March 1 boundary."""
+    from datetime import datetime
+    from src.api.main import _next_tiering_run_time
+
+    now = datetime(2028, 2, 29, 12, 0, 0)
+    result = _next_tiering_run_time(now)
+    assert result == datetime(2028, 3, 1, 0, 5, 0)


### PR DESCRIPTION
## Summary

First feature branch for v0.18.0. Two `fix:` commits, each conventionally formatted so release-please picks up the changelog entries:

- **`fix(llm)`** — coaching filter v0.18.0: Tier 4 phrases, intent gate, short-response guard
- **`fix(api)`** — `_nightly_tiering_loop` ValueError on month-end dates

## Driver: 15-day production log analysis

The original v0.17.2 ticket proposed an embedding-similarity refactor of the coaching filter to "stop the regex arms race." A read of `logs/coaching_filter/` (74 interventions, 15-day window) showed the proposal targeted the wrong categories:

- `therapeutic_mid_response` (16 patterns): **0 hits**
- `sycophantic_opener` (7 patterns): **0 hits**
- `therapeutic_opener` (4 patterns): 9 hits
- `numbered_structure`: 23 hits, **48% false-positive rate** (LLM correctly refused to rewrite legitimate factual numbered lists)
- 17 of 57 Stage 2 calls (30%) returned null and produced no change

The embedding refactor was rejected. This PR delivers three smaller, data-driven fixes plus an unrelated scheduler bug surfaced by the test suite.

## What changed

### 1. Tier 4 eval phrases (commit `cd9e0a0`)

New regex patterns flagged by Haiku in the v0.17.1 Tier 4 eval (per `KNOWN_ISSUES.md`):

- `_THERAPEUTIC_MID_RESPONSE`: extends "it's okay to" with sit/cry/grieve/rest/pause; adds "it's okay that you/this", "let's fix that/this", "sit with it/this/the weight"
- `_COACHING_CLOSINGS`: trailing softener "though I'd still bet/think/guess"
- "you're not alone" was already covered by an existing pattern; no duplicate added.

### 2. Suppress `numbered_structure` on factual intents (commit `cd9e0a0`)

Adds `_NUMBERED_STRUCTURE_SUPPRESSED_INTENTS = {web_search, factual_recall, recent, status_state}`. Threads `intent_class` through `_detect_patterns` (with `"default"` default value to preserve legacy callers). Gate skips numbered-list detection on factual response classes where lists are appropriate format. Eliminates the 48% false-positive rate observed in production logs.

### 3. Short-response therapeutic-opener guard (commit `cd9e0a0`)

When the entire response is essentially the matched opener (under 40 chars, only `therapeutic_opener` matches), removing the frame leaves nothing — the LLM rewrite always returned null. New short-circuit returns empty string directly without invoking `_rewrite`. Accounted for 6 of the 17 wasted Stage 2 LLM calls observed.

### 4. Nightly scheduler `ValueError` on month-end (commit `fb2165b`)

`src/api/main.py:_nightly_tiering_loop` used `datetime.replace(day=tomorrow.day + 1)` to advance to the next day. This raises `ValueError: day is out of range for month` on the last day of any month (Apr 30 → day=31, May 31 → day=32, Dec 31 → day=32). Surfaced as a `PytestUnhandledThreadExceptionWarning` during today's test run. Extracted a pure helper `_next_tiering_run_time(now)` that uses `timedelta(days=1)`, correctly handling month/year/leap-day boundaries.

## Tests added

20 new tests:
- 5 — Item 1 patterns trigger correctly
- 6 — Item 2 numbered_structure gate (4 suppression cases + 2 regression guards on `default`/`reflective`)
- 3 — Item 3 short-circuit (fires under 40 chars, doesn't fire over 40 chars, doesn't fire on non-opener matches)
- 6 — `_next_tiering_run_time` (April 30, May 31, Dec 31, leap-day Feb 29, before/after 00:05 same-day)

## Test plan

- [x] `pytest tests/ -q` clean: **1747 passed, 20 deselected, 0 warnings** (was 1741 + 1 unhandled-thread warning)
- [x] `tests/test_coaching_filter.py` — 31 passed
- [x] `tests/test_tiering.py` — 33 passed
- [x] All added comments and strings ASCII-only per the project rule
- [ ] Tier 2 retrieval eval (no retrieval-layer changes; not run)
- [ ] Tier 3/4 evals — not warranted for these correctness fixes; reserve for register-tier changes

## Notes for review

- `_detect_patterns` signature gained `intent_class: str = "default"`. Default value preserves all existing test contracts and any legacy callers.
- Both commits are independently revertable.
- Branch is one of multiple expected for v0.18.0 — merging triggers release-please to open the v0.18.0 tracking PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)