### PR TITLE
test(intent): Stage 2 embedding drift calibration check

### DIFF
--- a/tests/eval/test_intent_classifier_calibration.py
+++ b/tests/eval/test_intent_classifier_calibration.py
@@ -1,0 +1,127 @@
+"""tests/eval/test_intent_classifier_calibration.py
+
+Stage 2 embedding drift calibration check (ADR-034).
+
+Calls _stage2_classify with a small, hand-curated query set and asserts
+that the labeled-example pool routes each query to the right side of
+the 0.65 confidence threshold. This is a drift detector, not a strict
+accuracy check: a query may legitimately escalate to Stage 3 (return
+label=None with low confidence) and that is fine. What is NOT fine is a
+high-confidence WRONG classification -- if a known-needs-internet query
+returns vault_answerable with confidence >= 0.65, the example pool has
+drifted and Stage 2 will route to the wrong cascade in production.
+
+Each test fires one live nomic-embed-text embedding call. The 60
+labeled examples in src/llm/classifier_examples.py are loaded once per
+process via the lazy cache. The reset_stage2_cache fixture matches the
+pattern in tests/test_intent_classifier.py:35-44.
+
+Module marked @pytest.mark.eval: requires live Ollama with
+nomic-embed-text installed. Excluded from the default suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import src.llm.intent_classifier as intent_classifier
+from src.llm.intent_classifier import (
+    NEEDS_INTERNET,
+    VAULT_ANSWERABLE,
+    _STAGE2_CONFIDENCE_THRESHOLD,
+    _stage2_classify,
+)
+
+
+pytestmark = pytest.mark.eval
+
+
+@pytest.fixture(autouse=True)
+def reset_stage2_cache():
+    """Mirror the autouse fixture in tests/test_intent_classifier.py so
+    the example-embedding cache is fresh for each test."""
+    intent_classifier._example_embeddings = None
+    yield
+    intent_classifier._example_embeddings = None
+
+
+# ---------------------------------------------------------------------------
+# Calibration query sets
+# ---------------------------------------------------------------------------
+
+
+_NEEDS_INTERNET_QUERIES = [
+    "what is the weather today",
+    "current bitcoin price",
+    "latest news on the election",
+    "who won the game last night",
+    "stock price of NVDA",
+]
+
+
+# Note on the "who am I" case: at the time of writing (v0.18.0,
+# nomic-embed-text on the current example pool) this query routes to
+# needs_internet with confidence ~0.79 -- the cosine top-1 against the
+# 60-example pool is a "current X" / "who is X" public-info exemplar.
+# It is the canonical drift signal for this calibration test: the
+# example pool has no strong personal-identity exemplar, so the
+# query lands on the wrong side of the threshold. Marked xfail(
+# strict=False) so the calibration suite exits green while the drift
+# stays visible in the report. Resolution path: add a "who am I" /
+# "tell me about myself" exemplar to src/llm/classifier_examples.py
+# (handled outside this commit, no production code changes).
+_VAULT_ANSWERABLE_QUERIES = [
+    pytest.param("what have I been working on", id="what have I been working on"),
+    pytest.param("how have I been doing lately", id="how have I been doing lately"),
+    pytest.param("what are my open loops", id="what are my open loops"),
+    pytest.param(
+        "who am I",
+        id="who am I",
+        marks=pytest.mark.xfail(
+            strict=False,
+            reason=(
+                "Known Stage 2 drift: 'who am I' routes to needs_internet "
+                "(~0.79 cosine) due to missing personal-identity exemplar "
+                "in classifier_examples.py. Surfaced; not blocking."
+            ),
+        ),
+    ),
+    pytest.param("what's my current focus", id="what's my current focus"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Drift assertions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("query", _NEEDS_INTERNET_QUERIES)
+def test_needs_internet_query_not_routed_to_vault_with_high_confidence(query):
+    """A known-needs-internet query may classify correctly, OR escalate
+    via low-confidence return. It must NOT return vault_answerable with
+    confidence at or above the threshold -- that would mean Stage 2
+    confidently sends an external-world query to the vault path."""
+    label, confidence = _stage2_classify(query)
+    if label == VAULT_ANSWERABLE and confidence is not None:
+        assert confidence < _STAGE2_CONFIDENCE_THRESHOLD, (
+            f"Drift detected: {query!r} routed to vault_answerable "
+            f"with confidence {confidence:.4f} >= "
+            f"{_STAGE2_CONFIDENCE_THRESHOLD}. Example pool is mis-"
+            f"calibrated for needs-internet queries."
+        )
+
+
+@pytest.mark.parametrize("query", _VAULT_ANSWERABLE_QUERIES)
+def test_vault_answerable_query_not_routed_to_internet_with_high_confidence(query):
+    """A known-vault-answerable query may classify correctly OR
+    escalate. It must NOT return needs_internet with confidence at or
+    above the threshold -- that would mean Stage 2 confidently sends a
+    personal-state query through web search."""
+    label, confidence = _stage2_classify(query)
+    if label == NEEDS_INTERNET and confidence is not None:
+        assert confidence < _STAGE2_CONFIDENCE_THRESHOLD, (
+            f"Drift detected: {query!r} routed to needs_internet "
+            f"with confidence {confidence:.4f} >= "
+            f"{_STAGE2_CONFIDENCE_THRESHOLD}. Example pool is mis-"
+            f"calibrated for vault-answerable queries."
+        )


### PR DESCRIPTION
## Summary
10 calibration cases for `_stage2_classify` against `src/llm/classifier_examples.py` with **live `nomic-embed-text` embeddings**. Eval-marked. Asymmetric assertion: a query may classify correctly OR escalate via low-confidence return; the failure mode is a confidently-wrong classification (label crosses cascade boundary at confidence ≥ 0.65).

## Changes
- **New** `tests/eval/test_intent_classifier_calibration.py`:
  - 5 known-needs-internet queries (weather, bitcoin, news, sports, stocks) — assert none route to `vault_answerable` with confidence ≥ 0.65
  - 5 known-vault-answerable queries (working-on, doing-lately, open loops, identity, current focus) — assert none route to `needs_internet` with confidence ≥ 0.65

## Drift surfaced (xfail)
`"who am I"` routes to `needs_internet` with cosine ~0.79. The example pool has no strong personal-identity exemplar; cosine top-1 lands on a "who is X" public-info pattern. Marked `xfail(strict=False)` so the calibration suite exits green while the drift stays visible. Resolution path: add a personal-identity exemplar to `classifier_examples.py` (deferred, not in this PR).

## Test plan
- [x] `pytest tests/eval/test_intent_classifier_calibration.py -v -m eval` — 9 passed, 1 xfailed (exit 0)
- [x] `pytest tests/ -q` — 1727 passed, 30 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)