### PR TITLE
test(eval): answer-vs-packet fabrication detector

### DIFF
--- a/tests/test_eval_probe.py
+++ b/tests/test_eval_probe.py
@@ -1,0 +1,606 @@
+"""tests/test_eval_probe.py
+
+Unit + integration tests for the answer-vs-packet fabrication detector.
+
+Pure-function tests cover sentence segmentation, the second-person
+anchor filter, cosine math, classify(), packet record extraction, and
+log entry construction (privacy redaction).
+
+Integration tests mock httpx (for /debug-context and /v1/chat/completions)
+and embed_batch (for nomic-embed-text) so the pipeline can be exercised
+end-to-end without a live API or Ollama dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.eval_probe import (
+    PROBE_QUESTIONS,
+    PROBE_THRESHOLD,
+    FlaggedSentence,
+    PacketRecord,
+    ProbeResult,
+    build_log_entry,
+    classify,
+    cosine,
+    cosine_max,
+    extract_packet_records,
+    filter_second_person_anchored,
+    render_console_summary,
+    run_probe_for_question,
+    segment_sentences,
+    write_probe_log,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: probe question constants
+# ---------------------------------------------------------------------------
+
+
+def test_probe_questions_count_is_seven():
+    assert len(PROBE_QUESTIONS) == 7
+
+
+def test_probe_threshold_matches_spec():
+    assert PROBE_THRESHOLD == 0.55
+
+
+# ---------------------------------------------------------------------------
+# segment_sentences
+# ---------------------------------------------------------------------------
+
+
+def test_segment_empty_string():
+    assert segment_sentences("") == []
+    assert segment_sentences("   ") == []
+
+
+def test_segment_single_sentence():
+    assert segment_sentences("This is one sentence.") == ["This is one sentence."]
+
+
+def test_segment_three_sentences_with_terminators():
+    text = "First sentence. Second sentence? Third sentence!"
+    out = segment_sentences(text)
+    assert out == ["First sentence.", "Second sentence?", "Third sentence!"]
+
+
+def test_segment_does_not_split_on_lowercase_continuation():
+    """Splitter requires capital letter after terminator -- 'i.e.' is
+    safe."""
+    text = "Use TLS, i.e. encryption. Then send."
+    out = segment_sentences(text)
+    # Should split before 'Then' but not at 'i.e.'
+    assert out == ["Use TLS, i.e. encryption.", "Then send."]
+
+
+# ---------------------------------------------------------------------------
+# filter_second_person_anchored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "You mentioned a project.",
+        "Your project sounds important.",
+        "Be kind to yourself.",
+        "Yours is the third option.",
+        "You're working hard.",
+        "You've been busy.",
+        "You'd benefit from rest.",
+        "You'll figure it out.",
+        "YOU mentioned this.",  # case insensitive
+        "What about your day?",
+    ],
+)
+def test_anchor_matches_second_person_forms(sentence):
+    assert filter_second_person_anchored([sentence]) == [sentence]
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "Youth is wasted on the young.",
+        "The yo-yo spun.",
+        "I am working on a thing.",
+        "We should ship it.",
+        "They mentioned a project.",
+    ],
+)
+def test_anchor_rejects_non_second_person(sentence):
+    assert filter_second_person_anchored([sentence]) == []
+
+
+def test_anchor_keeps_only_matching_subset():
+    sentences = [
+        "I think this is true.",
+        "You mentioned a thing.",
+        "Youth sports are great.",
+        "Your work is good.",
+    ]
+    out = filter_second_person_anchored(sentences)
+    assert out == ["You mentioned a thing.", "Your work is good."]
+
+
+# ---------------------------------------------------------------------------
+# cosine + cosine_max
+# ---------------------------------------------------------------------------
+
+
+def test_cosine_identical_vectors_is_one():
+    v = [1.0, 0.0, 0.0]
+    assert cosine(v, v) == pytest.approx(1.0)
+
+
+def test_cosine_orthogonal_is_zero():
+    a = [1.0, 0.0]
+    b = [0.0, 1.0]
+    assert cosine(a, b) == pytest.approx(0.0)
+
+
+def test_cosine_antiparallel_is_minus_one():
+    a = [1.0, 0.0]
+    b = [-1.0, 0.0]
+    assert cosine(a, b) == pytest.approx(-1.0)
+
+
+def test_cosine_zero_norm_returns_zero():
+    assert cosine([0.0, 0.0], [1.0, 0.0]) == 0.0
+    assert cosine([1.0, 0.0], [0.0, 0.0]) == 0.0
+
+
+def test_cosine_max_empty_records():
+    score, idxs, scores = cosine_max([1.0, 0.0], [])
+    assert score == 0.0
+    assert idxs == []
+    assert scores == []
+
+
+def test_cosine_max_returns_top_3_descending():
+    claim = [1.0, 0.0, 0.0]
+    records = [
+        [0.0, 1.0, 0.0],   # cos=0
+        [1.0, 0.0, 0.0],   # cos=1
+        [0.5, 0.5, 0.0],   # cos~0.707
+        [0.9, 0.1, 0.0],   # cos~0.994
+    ]
+    score, idxs, scores = cosine_max(claim, records)
+    # Top score is index 1 (cos=1)
+    assert score == pytest.approx(1.0)
+    # Top-3 indices should be [1, 3, 2] in that order
+    assert idxs == [1, 3, 2]
+    # Scores should be descending
+    assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# classify
+# ---------------------------------------------------------------------------
+
+
+def test_classify_at_threshold_is_grounded():
+    assert classify(0.55) == "GROUNDED"
+
+
+def test_classify_just_below_threshold_is_fabricated():
+    assert classify(0.5499) == "FABRICATED"
+
+
+def test_classify_high_confidence_grounded():
+    assert classify(0.95) == "GROUNDED"
+
+
+def test_classify_zero_is_fabricated():
+    assert classify(0.0) == "FABRICATED"
+
+
+def test_classify_negative_is_fabricated():
+    assert classify(-0.3) == "FABRICATED"
+
+
+# ---------------------------------------------------------------------------
+# extract_packet_records
+# ---------------------------------------------------------------------------
+
+
+def test_extract_records_from_full_packet():
+    packet = {
+        "memory_items": [
+            {
+                "id": "m1",
+                "content": "User mentioned a Python migration.",
+                "memory_type": "conversation",
+                "timestamp": "2026-04-01T10-00-00",
+            }
+        ],
+        "reflection_items": [
+            {
+                "id": "r1",
+                "content": "User has been focused on shipping.",
+                "timestamp": "2026-04-15T18-00-00",
+            }
+        ],
+        "state_items": [
+            {
+                "category": "current_focus",
+                "text": "shipping v0.18.0",
+                "timestamp": "2026-04-30T12-00-00",
+            }
+        ],
+    }
+    records = extract_packet_records(packet)
+    assert len(records) == 3
+    assert records[0].text == "User mentioned a Python migration."
+    assert records[0].memory_type == "conversation"
+    assert records[1].text == "User has been focused on shipping."
+    assert records[1].memory_type == "reflection"
+    assert records[2].text == "shipping v0.18.0"
+    assert records[2].memory_type == "state"
+    assert records[2].record_id == "state_current_focus"
+
+
+def test_extract_skips_empty_text():
+    packet = {
+        "memory_items": [
+            {"id": "m1", "content": "", "memory_type": "conversation", "timestamp": ""},
+            {"id": "m2", "content": "   ", "memory_type": "conversation", "timestamp": ""},
+            {"id": "m3", "content": "real text", "memory_type": "conversation", "timestamp": ""},
+        ],
+        "reflection_items": [],
+        "state_items": [],
+    }
+    records = extract_packet_records(packet)
+    assert len(records) == 1
+    assert records[0].text == "real text"
+
+
+def test_extract_handles_missing_keys():
+    """Empty packet should produce empty records list, not raise."""
+    assert extract_packet_records({}) == []
+
+
+# ---------------------------------------------------------------------------
+# build_log_entry
+# ---------------------------------------------------------------------------
+
+
+def _make_result(verdict="GROUNDED", flagged=None, records=None):
+    """Helper for log entry tests."""
+    flagged = flagged or []
+    records = records or []
+    return ProbeResult(
+        question="What do you know about me?",
+        verdict=verdict,
+        anchored_sentence_count=2,
+        fabricated_sentence_count=len(flagged),
+        grounded_sentence_count=2 - len(flagged),
+        packet_record_count=len(records),
+        flagged_sentences=flagged,
+        records=records,
+    )
+
+
+def test_log_entry_no_flags_grounded():
+    entry = build_log_entry(_make_result("GROUNDED"))
+    assert entry["verdict"] == "GROUNDED"
+    assert entry["flagged_sentences"] == []
+    assert entry["question"] == "What do you know about me?"
+
+
+def test_log_entry_flagged_with_sentence_text_default():
+    records = [
+        PacketRecord(text="something", record_id="m1", memory_type="conversation", timestamp="t1"),
+        PacketRecord(text="other", record_id="m2", memory_type="state", timestamp="t2"),
+    ]
+    flagged = [
+        FlaggedSentence(
+            sentence="You're working on a Ruby project.",
+            max_cosine=0.42,
+            top_3_record_indices=[0, 1],
+            top_3_cosines=[0.42, 0.30],
+        ),
+    ]
+    entry = build_log_entry(_make_result("FABRICATED", flagged, records), log_sentences=True)
+    assert entry["verdict"] == "FABRICATED"
+    fs_entry = entry["flagged_sentences"][0]
+    assert fs_entry["sentence"] == "You're working on a Ruby project."
+    assert fs_entry["max_cosine"] == 0.42
+    assert fs_entry["threshold"] == PROBE_THRESHOLD
+    assert len(fs_entry["top_3_records"]) == 2
+    # No record content -- only metadata
+    assert "text" not in fs_entry["top_3_records"][0]
+    assert "content" not in fs_entry["top_3_records"][0]
+    assert fs_entry["top_3_records"][0]["memory_type"] == "conversation"
+    assert fs_entry["top_3_records"][0]["id"] == "m1"
+
+
+def test_log_entry_flagged_with_sentence_redacted():
+    records = [PacketRecord(text="x", record_id="m1", memory_type="memory", timestamp="t1")]
+    flagged = [
+        FlaggedSentence(
+            sentence="You're working on a Ruby project.",
+            max_cosine=0.42,
+            top_3_record_indices=[0],
+            top_3_cosines=[0.42],
+        ),
+    ]
+    entry = build_log_entry(
+        _make_result("FABRICATED", flagged, records),
+        log_sentences=False,
+    )
+    fs_entry = entry["flagged_sentences"][0]
+    # Sentence text is NOT in the redacted form
+    assert "sentence" not in fs_entry
+    assert fs_entry["sentence_redacted"] is True
+    assert fs_entry["sentence_length"] == len("You're working on a Ruby project.")
+
+
+def test_log_entry_strips_non_ascii_in_sentence():
+    """ASCII coercion: em dashes and curly quotes get dropped."""
+    records = [PacketRecord(text="x", record_id="m1", memory_type="memory", timestamp="t1")]
+    # Construct the test sentence using chr() at runtime so the source
+    # file stays pure ASCII. U+2019 = right single quote (curly
+    # apostrophe). U+2014 = em dash. The runtime string contains the
+    # non-ASCII chars; ASCII coercion in build_log_entry must strip
+    # them.
+    curly_apos = chr(0x2019)
+    em_dash = chr(0x2014)
+    test_sentence = f"You{curly_apos}re working on a thing{em_dash}a project."
+    flagged = [
+        FlaggedSentence(
+            sentence=test_sentence,
+            max_cosine=0.4,
+            top_3_record_indices=[0],
+            top_3_cosines=[0.4],
+        ),
+    ]
+    entry = build_log_entry(_make_result("FABRICATED", flagged, records))
+    sent = entry["flagged_sentences"][0]["sentence"]
+    # No non-ASCII characters survive
+    assert all(ord(c) < 128 for c in sent)
+    # The straight quote substitution is fine, em dash is stripped
+    assert "Youre working on" in sent or "You're working on" in sent
+    # Content survives in some form
+    assert "a project" in sent
+
+
+# ---------------------------------------------------------------------------
+# Integration: run_probe_for_question with mocks
+# ---------------------------------------------------------------------------
+
+
+def _mock_packet_response(records: list[dict]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = {
+        "memory_items": records,
+        "reflection_items": [],
+        "state_items": [],
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _mock_chat_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = {
+        "choices": [{"message": {"content": content}}],
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_pipeline_grounded_path():
+    """Anchored sentence with high cosine to a packet record -> GROUNDED."""
+    packet_records = [
+        {"id": "m1", "content": "User has a Python migration.", "memory_type": "conversation", "timestamp": "t1"},
+    ]
+    answer = "You're working on a Python migration."
+
+    sentence_emb = [1.0, 0.0, 0.0]
+    record_emb = [0.95, 0.05, 0.0]   # cos ~ 0.998
+
+    with patch("tools.eval_probe.httpx.get", return_value=_mock_packet_response(packet_records)), \
+         patch("tools.eval_probe.httpx.post", return_value=_mock_chat_response(answer)), \
+         patch("tools.eval_probe.embed_batch", side_effect=[[sentence_emb], [record_emb]]):
+        result = run_probe_for_question("What am I working on?", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "GROUNDED"
+    assert result.anchored_sentence_count == 1
+    assert result.fabricated_sentence_count == 0
+    assert result.grounded_sentence_count == 1
+
+
+def test_pipeline_fabricated_path():
+    """Anchored sentence with low cosine to records -> FABRICATED."""
+    packet_records = [
+        {"id": "m1", "content": "Unrelated content.", "memory_type": "conversation", "timestamp": "t1"},
+    ]
+    answer = "You're working on a Ruby migration."
+
+    sentence_emb = [1.0, 0.0, 0.0]
+    record_emb = [0.0, 1.0, 0.0]   # cos = 0
+
+    with patch("tools.eval_probe.httpx.get", return_value=_mock_packet_response(packet_records)), \
+         patch("tools.eval_probe.httpx.post", return_value=_mock_chat_response(answer)), \
+         patch("tools.eval_probe.embed_batch", side_effect=[[sentence_emb], [record_emb]]):
+        result = run_probe_for_question("What am I working on?", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "FABRICATED"
+    assert result.fabricated_sentence_count == 1
+    assert len(result.flagged_sentences) == 1
+    assert result.flagged_sentences[0].max_cosine == pytest.approx(0.0)
+
+
+def test_pipeline_empty_packet_flags_all_anchored():
+    """Empty packet means every anchored sentence is by definition
+    ungrounded (max_cosine=0.0 against zero records)."""
+    answer = "You're working on a project. Your day is full."
+
+    with patch("tools.eval_probe.httpx.get", return_value=_mock_packet_response([])), \
+         patch("tools.eval_probe.httpx.post", return_value=_mock_chat_response(answer)), \
+         patch("tools.eval_probe.embed_batch", side_effect=[[[1.0], [0.5]], []]):
+        result = run_probe_for_question("Q", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "FABRICATED"
+    assert result.anchored_sentence_count == 2
+    assert result.fabricated_sentence_count == 2
+    assert result.packet_record_count == 0
+
+
+def test_pipeline_no_anchored_sentences_grounded():
+    """Answer with no second-person anchors short-circuits to GROUNDED
+    with anchored_sentence_count=0 (model made no personal claims)."""
+    packet_records = [
+        {"id": "m1", "content": "x", "memory_type": "conversation", "timestamp": "t"},
+    ]
+    answer = "The migration is going well. It should ship soon."
+
+    with patch("tools.eval_probe.httpx.get", return_value=_mock_packet_response(packet_records)), \
+         patch("tools.eval_probe.httpx.post", return_value=_mock_chat_response(answer)), \
+         patch("tools.eval_probe.embed_batch") as mock_embed:
+        result = run_probe_for_question("Q", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "GROUNDED"
+    assert result.anchored_sentence_count == 0
+    assert result.fabricated_sentence_count == 0
+    # embed_batch should not have been called -- no anchored sentences
+    mock_embed.assert_not_called()
+
+
+def test_pipeline_packet_fetch_error_returns_error_verdict():
+    """If /debug-context fails, verdict=ERROR with stage=fetch_packet
+    and the battery (caller) can continue."""
+    with patch("tools.eval_probe.httpx.get", side_effect=Exception("connection refused")):
+        result = run_probe_for_question("Q", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "ERROR"
+    assert result.error_stage == "fetch_packet"
+    assert "connection refused" in (result.error_message or "")
+
+
+def test_pipeline_answer_fetch_error_returns_error_verdict():
+    """If chat completions fails, verdict=ERROR with stage=fetch_answer."""
+    packet_records = [
+        {"id": "m1", "content": "x", "memory_type": "conversation", "timestamp": "t"},
+    ]
+    with patch("tools.eval_probe.httpx.get", return_value=_mock_packet_response(packet_records)), \
+         patch("tools.eval_probe.httpx.post", side_effect=Exception("API timeout")):
+        result = run_probe_for_question("Q", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "ERROR"
+    assert result.error_stage == "fetch_answer"
+    # Records were captured before the answer-fetch failure
+    assert result.packet_record_count == 1
+
+
+def test_pipeline_embed_error_returns_error_verdict():
+    packet_records = [
+        {"id": "m1", "content": "x", "memory_type": "conversation", "timestamp": "t"},
+    ]
+    answer = "You mentioned a thing."
+    with patch("tools.eval_probe.httpx.get", return_value=_mock_packet_response(packet_records)), \
+         patch("tools.eval_probe.httpx.post", return_value=_mock_chat_response(answer)), \
+         patch("tools.eval_probe.embed_batch", side_effect=Exception("Ollama down")):
+        result = run_probe_for_question("Q", "http://localhost:8000", "test-key")
+
+    assert result.verdict == "ERROR"
+    assert result.error_stage == "embed"
+
+
+# ---------------------------------------------------------------------------
+# write_probe_log
+# ---------------------------------------------------------------------------
+
+
+def test_write_probe_log_creates_summary_and_per_question_files(tmp_path):
+    results = [
+        _make_result("GROUNDED"),
+        _make_result(
+            "FABRICATED",
+            flagged=[
+                FlaggedSentence(
+                    sentence="You're inventing a thing.",
+                    max_cosine=0.3,
+                    top_3_record_indices=[0],
+                    top_3_cosines=[0.3],
+                ),
+            ],
+            records=[
+                PacketRecord(text="x", record_id="m1", memory_type="conversation", timestamp="t"),
+            ],
+        ),
+    ]
+    run_dir = write_probe_log(results, log_sentences=True, log_root=tmp_path)
+    assert run_dir.exists()
+    summary_path = run_dir / "summary.json"
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["total_questions"] == 2
+    assert summary["questions_with_flags"] == 1
+    # Per-question files
+    files = sorted(run_dir.glob("q*.json"))
+    assert len(files) == 2
+
+
+def test_write_probe_log_with_redacted_sentences(tmp_path):
+    results = [
+        _make_result(
+            "FABRICATED",
+            flagged=[
+                FlaggedSentence(
+                    sentence="You're inventing a thing.",
+                    max_cosine=0.3,
+                    top_3_record_indices=[0],
+                    top_3_cosines=[0.3],
+                ),
+            ],
+            records=[
+                PacketRecord(text="x", record_id="m1", memory_type="conversation", timestamp="t"),
+            ],
+        ),
+    ]
+    run_dir = write_probe_log(results, log_sentences=False, log_root=tmp_path)
+    files = sorted(run_dir.glob("q*.json"))
+    entry = json.loads(files[0].read_text(encoding="utf-8"))
+    fs = entry["flagged_sentences"][0]
+    assert "sentence" not in fs
+    assert fs["sentence_redacted"] is True
+    assert fs["sentence_length"] > 0
+
+
+# ---------------------------------------------------------------------------
+# render_console_summary
+# ---------------------------------------------------------------------------
+
+
+def test_console_summary_all_grounded():
+    results = [_make_result("GROUNDED")]
+    out = render_console_summary(results)
+    assert "GROUNDED" in out
+    assert "All probe questions GROUNDED" in out
+
+
+def test_console_summary_with_flags():
+    results = [
+        _make_result("GROUNDED"),
+        _make_result("FABRICATED", flagged=[
+            FlaggedSentence("x", 0.0, [], []),
+        ]),
+    ]
+    out = render_console_summary(results)
+    assert "MANUAL REVIEW REQUIRED" in out
+    assert "1 question" in out
+
+
+def test_console_summary_is_ascii_only():
+    """No em dashes, smart quotes, or arrows in the summary block."""
+    results = [_make_result("GROUNDED")]
+    out = render_console_summary(results)
+    assert all(ord(c) < 128 for c in out)

--- a/tools/eval_manual.py
+++ b/tools/eval_manual.py
@@ -347,7 +347,12 @@ def _run_compare(api_key: str, local_model: str) -> None:
     print(f"\nComparison metadata saved to: {out_file}")
 
 
-def _run_auto_battery(target_model: str, api_key: str) -> None:
+def _run_auto_battery(
+    target_model: str,
+    api_key: str,
+    probe: bool = False,
+    log_sentences: bool = True,
+) -> int:
     """Run all 19 questions without pausing for annotation.
 
     Prints responses to stdout for live review but does NOT save them
@@ -357,6 +362,10 @@ def _run_auto_battery(target_model: str, api_key: str) -> None:
 
     Saves only metadata (model, question, latency, word count) to a
     dated log file for before/after timing comparison.
+
+    When probe=True, runs the answer-vs-packet fabrication detector
+    inline after each question whose text is in PROBE_QUESTIONS.
+    Returns the count of FABRICATED-verdict probe questions (0 = clean).
     """
     date_str = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
     log_dir = REPO_ROOT / "logs" / "eval_manual"
@@ -368,6 +377,11 @@ def _run_auto_battery(target_model: str, api_key: str) -> None:
         f"# Auto Battery — {target_model} — {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n",
         "Responses shown on stdout only — not saved to disk (vault privacy).\n\n",
     ]
+
+    probe_results = []
+    if probe:
+        from tools.eval_probe import PROBE_QUESTIONS, run_probe_for_question
+        probe_set = set(PROBE_QUESTIONS)
 
     question_num = 0
     for category_block in BATTERY:
@@ -396,9 +410,41 @@ def _run_auto_battery(target_model: str, api_key: str) -> None:
             lines.append(f"**Q{question_num}:** {question}\n")
             lines.append(f"- latency: {latency:.1f}s, words: {word_count}\n\n")
 
+            # Inline probe pass for the 7 selected questions. Issues
+            # its own pre-flight /debug-context plus a fresh
+            # /v1/chat/completions so the captured packet matches
+            # what the probe-side answer was generated from. Battery
+            # state continues forward regardless of probe outcome.
+            if probe and question in probe_set:
+                print("  Running fabrication probe...")
+                pr = run_probe_for_question(question, api_key=api_key)
+                probe_results.append(pr)
+                verdict_label = pr.verdict
+                if pr.error_stage:
+                    print(
+                        f"  Probe ERROR (stage={pr.error_stage}): "
+                        f"{pr.error_message}"
+                    )
+                else:
+                    print(
+                        f"  Probe verdict: {verdict_label} "
+                        f"(anchored={pr.anchored_sentence_count}, "
+                        f"fabricated={pr.fabricated_sentence_count})"
+                    )
+
     out_file.write_text("".join(lines), encoding="utf-8")
     print(f"\nMetadata saved to: {out_file}")
     print("(Responses shown above — not written to disk)")
+
+    if probe and probe_results:
+        from tools.eval_probe import render_console_summary, write_probe_log
+        probe_log_dir = write_probe_log(probe_results, log_sentences=log_sentences)
+        print()
+        print(render_console_summary(probe_results))
+        print(f"\nProbe log: {probe_log_dir}")
+        flagged = sum(1 for r in probe_results if r.verdict == "FABRICATED")
+        return flagged
+    return 0
 
 
 def main():
@@ -407,6 +453,24 @@ def main():
     parser.add_argument("--model", type=str, default=None, help="Model to test")
     parser.add_argument("--auto", action="store_true", help="Run all 19 questions without annotation — saves raw responses to file")
     parser.add_argument("--compare", action="store_true", help="Run battery twice: active local model then claude-haiku-4-5, side-by-side comparison")
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help=(
+            "Run the answer-vs-packet fabrication detector after each of "
+            "the 7 vault-grounded probe questions. Off by default. Exit "
+            "code 2 if any FABRICATED flag fires. --auto only."
+        ),
+    )
+    parser.add_argument(
+        "--no-log-sentences",
+        action="store_true",
+        help=(
+            "When --probe is active, redact flagged-sentence text in the "
+            "probe log (records sentence length only). Default is to log "
+            "the sentence verbatim."
+        ),
+    )
     args = parser.parse_args()
 
     from tools.eval_helpers import swap_to_test_vault, restore_vault, run_cleanup
@@ -452,11 +516,21 @@ def main():
             print(f"\nAuto Battery — {target_model} — {datetime.now().strftime('%Y-%m-%d')}")
             print("=" * 60)
             print("Running all 19 questions without annotation...\n")
-            _run_auto_battery(target_model, api_key)
+            flagged_count = _run_auto_battery(
+                target_model,
+                api_key,
+                probe=args.probe,
+                log_sentences=not args.no_log_sentences,
+            )
             if original_model and args.model:
                 _switch_model(original_model, api_key)
             run_cleanup()
             print("\nDone.")
+            if flagged_count:
+                # Exit 2 distinguishes success-with-fabrication-flags
+                # from setup error (1) and clean run (0). CI / pre-
+                # release scripts can branch on this.
+                sys.exit(2)
             return
 
         # --- MANUAL MODE: interactive annotation ---

--- a/tools/eval_probe.py
+++ b/tools/eval_probe.py
@@ -1,0 +1,626 @@
+"""tools/eval_probe.py
+
+Answer-vs-packet fabrication detector for the manual eval battery.
+
+Pipeline per probe question:
+  1. Pre-flight: GET /debug-context?message=Q (frozen baseline packet)
+  2. POST /v1/chat/completions (stream=False) for the answer
+  3. Sentence-segment the answer
+  4. Filter to second-person-anchored sentences
+     (you, your, yourself, yours, you're, you've, you'd, you'll)
+  5. Batch-embed anchored sentences and packet record texts via
+     nomic-embed-text (src.retrieval.embedding_model.embed_texts)
+  6. For each anchored sentence, compute max cosine across all records
+  7. < 0.55 -> FABRICATED; >= 0.55 -> GROUNDED
+  8. Verdict per question: any FABRICATED -> manual review
+
+Privacy:
+- Context packet stays in memory only. Only metadata (id, memory_type,
+  timestamp) is logged for the top-3 records per flagged sentence.
+- Flagged sentences are logged by default. They are model output that
+  failed the cosine-against-packet check, which is the operational
+  definition of 'not vault content' for this detector. Pass
+  log_sentences=False to substitute redacted metadata (length and
+  position) for the sentence string.
+- See CLAUDE.md "Vault Privacy Rule" for the project-level constraint
+  this design satisfies.
+
+Threshold:
+  PROBE_THRESHOLD = 0.55 mirrors the relevance gate in
+  tools/eval_retrieval.py for echo filtering. Calibrate after the
+  first month of observed flag noise.
+
+Standalone use (without the eval_manual.py wrapper):
+  python tools/eval_probe.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import unicodedata
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+PROBE_THRESHOLD: float = 0.55
+"""Cosine cutoff for GROUNDED vs FABRICATED. Mirrors the relevance gate
+used by tools/eval_retrieval.py. Calibrate after observed flag noise."""
+
+PROBE_QUESTIONS: list[str] = [
+    "What do you know about me?",
+    "What are my current projects?",
+    "What am I working on right now?",
+    "What are my open loops?",
+    "What did I say about my work?",
+    "Summarize what you know about my spiritual practice.",
+    "What have I told you about my partner?",
+]
+"""The 7 vault-grounded battery questions targeted by the probe.
+Verbatim text required so eval_manual.py can match by string equality."""
+
+_DEFAULT_API_BASE = "http://localhost:8000"
+_DEBUG_CONTEXT_PATH = "/debug-context"
+_CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
+
+# Word-boundary anchored second-person tokens. Case-insensitive.
+# Matches: you, your, yourself, yours, you're, you've, you'd, you'll.
+# Does NOT match: youth, young, yo-yo, etc.
+_SECOND_PERSON_RE = re.compile(
+    r"\byou(?:'re|'ve|'d|'ll)?\b|\byour(?:s|self)?\b",
+    re.IGNORECASE,
+)
+
+# Sentence segmentation. Splits on .?! followed by whitespace and an
+# uppercase letter. Imperfect (won't catch all abbreviations, quotes,
+# etc.) but cheap and adequate for eval purposes -- segmentation
+# false positives at the sentence boundary just shift which sentences
+# the anchor filter applies to.
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.?!])\s+(?=[A-Z])")
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PacketRecord:
+    """Subset of a context packet record used by the detector. Keeps
+    only what is needed for embedding and for log metadata. The text
+    field is in memory for the duration of one question and never
+    written to disk."""
+    text: str
+    record_id: str
+    memory_type: str
+    timestamp: str
+
+
+@dataclass
+class FlaggedSentence:
+    """A sentence whose max cosine to any packet record fell below the
+    threshold. The sentence text is logged by default; opt out with
+    log_sentences=False (build_log_entry honors the flag)."""
+    sentence: str
+    max_cosine: float
+    top_3_record_indices: list[int]
+    top_3_cosines: list[float]
+
+
+@dataclass
+class ProbeResult:
+    """Per-question outcome."""
+    question: str
+    verdict: str  # "GROUNDED" | "FABRICATED" | "ERROR"
+    anchored_sentence_count: int
+    fabricated_sentence_count: int
+    grounded_sentence_count: int
+    packet_record_count: int
+    flagged_sentences: list[FlaggedSentence]
+    records: list[PacketRecord]  # in-memory only; for log metadata
+    error_stage: str | None = None
+    error_message: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def segment_sentences(text: str) -> list[str]:
+    """Split text into sentences using a simple terminator-plus-capital
+    regex. Returns non-empty stripped sentences. Empty/whitespace input
+    yields []."""
+    if not text or not text.strip():
+        return []
+    parts = _SENTENCE_SPLIT_RE.split(text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def filter_second_person_anchored(sentences: list[str]) -> list[str]:
+    """Keep sentences containing a second-person pronoun anchor. Case-
+    insensitive, word-boundary regex avoids false matches on words
+    like 'youth' or 'young'."""
+    return [s for s in sentences if _SECOND_PERSON_RE.search(s)]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equal-length float vectors. Returns
+    0.0 on zero-norm input (defensive against degenerate embeddings)."""
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def cosine_max(claim_emb: list[float], record_embs: list[list[float]]) -> tuple[float, list[int], list[float]]:
+    """Compute max cosine of claim against each record embedding.
+
+    Returns (max_cosine, top_3_indices_descending_by_score, top_3_scores).
+    Empty record_embs returns (0.0, [], []).
+    """
+    if not record_embs:
+        return 0.0, [], []
+    scores = [cosine(claim_emb, r) for r in record_embs]
+    indexed = sorted(enumerate(scores), key=lambda t: t[1], reverse=True)
+    top_3 = indexed[:3]
+    top_3_indices = [i for i, _ in top_3]
+    top_3_scores = [s for _, s in top_3]
+    return scores[indexed[0][0]], top_3_indices, top_3_scores
+
+
+def classify(max_cosine: float, threshold: float = PROBE_THRESHOLD) -> str:
+    """Map max cosine to verdict string. >= threshold is GROUNDED;
+    below is FABRICATED. Boundary at threshold is GROUNDED (gte)."""
+    return "GROUNDED" if max_cosine >= threshold else "FABRICATED"
+
+
+def extract_packet_records(packet: dict) -> list[PacketRecord]:
+    """Pull text + redacted metadata from a /debug-context payload.
+
+    Reads memory_items, reflection_items, state_items only. Skips
+    task_items (titles only, not retrievable content), web_items
+    (web search results, not vault), image_data, summary, and
+    embeddings. Records with empty text are skipped.
+    """
+    records: list[PacketRecord] = []
+
+    for item in packet.get("memory_items") or []:
+        text = (item.get("content") or "").strip()
+        if not text:
+            continue
+        records.append(PacketRecord(
+            text=text,
+            record_id=str(item.get("id") or ""),
+            memory_type=str(item.get("memory_type") or item.get("item_type") or "memory"),
+            timestamp=str(item.get("timestamp") or ""),
+        ))
+
+    for item in packet.get("reflection_items") or []:
+        text = (item.get("content") or "").strip()
+        if not text:
+            continue
+        records.append(PacketRecord(
+            text=text,
+            record_id=str(item.get("id") or ""),
+            memory_type="reflection",
+            timestamp=str(item.get("timestamp") or ""),
+        ))
+
+    for item in packet.get("state_items") or []:
+        text = (item.get("text") or "").strip()
+        if not text:
+            continue
+        records.append(PacketRecord(
+            text=text,
+            record_id=f"state_{item.get('category', 'unknown')}",
+            memory_type="state",
+            timestamp=str(item.get("timestamp") or ""),
+        ))
+
+    return records
+
+
+def _ascii_safe(text: str) -> str:
+    """Coerce text to ASCII for log-write safety. NFKD normalize then
+    drop any character that does not encode to ASCII. Em dashes, smart
+    quotes, and other non-ASCII codepoints are stripped."""
+    if not text:
+        return ""
+    normalized = unicodedata.normalize("NFKD", text)
+    return normalized.encode("ascii", "ignore").decode("ascii")
+
+
+def build_log_entry(
+    result: ProbeResult,
+    log_sentences: bool = True,
+) -> dict[str, Any]:
+    """Construct a privacy-redacted JSON-serializable log entry.
+
+    Record content is never serialized -- only id, memory_type, and
+    timestamp. Flagged sentence text is included by default; pass
+    log_sentences=False to substitute a length-and-position descriptor.
+    """
+    flagged: list[dict[str, Any]] = []
+    for fs in result.flagged_sentences:
+        top_records: list[dict[str, Any]] = []
+        for rank, (idx, score) in enumerate(zip(fs.top_3_record_indices, fs.top_3_cosines), start=1):
+            if 0 <= idx < len(result.records):
+                rec = result.records[idx]
+                top_records.append({
+                    "rank": rank,
+                    "cosine": round(score, 4),
+                    "memory_type": _ascii_safe(rec.memory_type),
+                    "timestamp": _ascii_safe(rec.timestamp),
+                    "id": _ascii_safe(rec.record_id),
+                })
+
+        sentence_field: dict[str, Any]
+        if log_sentences:
+            sentence_field = {"sentence": _ascii_safe(fs.sentence)}
+        else:
+            sentence_field = {
+                "sentence_length": len(fs.sentence),
+                "sentence_redacted": True,
+            }
+
+        flagged.append({
+            **sentence_field,
+            "max_cosine": round(fs.max_cosine, 4),
+            "threshold": PROBE_THRESHOLD,
+            "top_3_records": top_records,
+        })
+
+    entry: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ"),
+        "question": _ascii_safe(result.question),
+        "verdict": result.verdict,
+        "anchored_sentence_count": result.anchored_sentence_count,
+        "grounded_sentence_count": result.grounded_sentence_count,
+        "fabricated_sentence_count": result.fabricated_sentence_count,
+        "packet_record_count": result.packet_record_count,
+        "flagged_sentences": flagged,
+    }
+    if result.error_stage:
+        entry["error_stage"] = result.error_stage
+        entry["error_message"] = _ascii_safe(result.error_message or "")
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Live-call helpers
+# ---------------------------------------------------------------------------
+
+
+def _api_base() -> str:
+    """Resolve the eval target API base URL. EMBER_API_BASE overrides
+    the localhost default (matches the tools/eval_helpers.py pattern)."""
+    return os.getenv("EMBER_API_BASE", _DEFAULT_API_BASE).rstrip("/")
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    """Build auth headers. Sends both Bearer and X-API-Key for
+    compatibility with the API's two accepted header forms."""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+        headers["X-API-Key"] = api_key
+    return headers
+
+
+def fetch_packet(api_base: str, api_key: str, question: str, timeout: float = 30.0) -> dict:
+    """GET /debug-context for the given question. Returns the parsed
+    JSON dict (clean_context_packet output). Raises on HTTP error."""
+    url = f"{api_base}{_DEBUG_CONTEXT_PATH}"
+    params = {"message": question}
+    response = httpx.get(
+        url,
+        params=params,
+        headers=_auth_headers(api_key),
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_answer(api_base: str, api_key: str, question: str, timeout: float = 120.0) -> str:
+    """POST /v1/chat/completions (stream=False). Returns the response
+    text from choices[0].message.content. Raises on HTTP error."""
+    url = f"{api_base}{_CHAT_COMPLETIONS_PATH}"
+    body = {
+        "model": "ember-2",
+        "messages": [{"role": "user", "content": question}],
+        "stream": False,
+    }
+    headers = _auth_headers(api_key)
+    headers["X-Test-Session"] = "true"
+    response = httpx.post(url, json=body, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    data = response.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def embed_batch(texts: list[str]) -> list[list[float]]:
+    """Wrapper around src.retrieval.embedding_model.embed_texts. Empty
+    input returns []. Imported lazily so tests can stub the import
+    without pulling Ollama at module-load time."""
+    if not texts:
+        return []
+    from src.retrieval.embedding_model import embed_texts
+    return embed_texts(texts)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def run_probe_for_question(
+    question: str,
+    api_base: str | None = None,
+    api_key: str | None = None,
+) -> ProbeResult:
+    """Run the full probe pipeline for one question. Captures and
+    returns a ProbeResult; never raises on API errors (those produce
+    an ERROR verdict so the calling battery can continue)."""
+    api_base = api_base or _api_base()
+    api_key = api_key if api_key is not None else os.getenv("EMBER_API_KEY", "")
+
+    # Stage 1: pre-flight packet capture
+    try:
+        packet = fetch_packet(api_base, api_key, question)
+    except Exception as exc:
+        return ProbeResult(
+            question=question,
+            verdict="ERROR",
+            anchored_sentence_count=0,
+            fabricated_sentence_count=0,
+            grounded_sentence_count=0,
+            packet_record_count=0,
+            flagged_sentences=[],
+            records=[],
+            error_stage="fetch_packet",
+            error_message=str(exc),
+        )
+
+    records = extract_packet_records(packet)
+
+    # Stage 2: answer fetch
+    try:
+        answer = fetch_answer(api_base, api_key, question)
+    except Exception as exc:
+        return ProbeResult(
+            question=question,
+            verdict="ERROR",
+            anchored_sentence_count=0,
+            fabricated_sentence_count=0,
+            grounded_sentence_count=0,
+            packet_record_count=len(records),
+            flagged_sentences=[],
+            records=records,
+            error_stage="fetch_answer",
+            error_message=str(exc),
+        )
+
+    # Stage 3-4: segment + anchor filter
+    sentences = segment_sentences(answer)
+    anchored = filter_second_person_anchored(sentences)
+
+    if not anchored:
+        return ProbeResult(
+            question=question,
+            verdict="GROUNDED",
+            anchored_sentence_count=0,
+            fabricated_sentence_count=0,
+            grounded_sentence_count=0,
+            packet_record_count=len(records),
+            flagged_sentences=[],
+            records=records,
+        )
+
+    # Stage 5: embed both sides (batched). Two batched calls total.
+    try:
+        sentence_embs = embed_batch(anchored)
+        record_embs = embed_batch([r.text for r in records]) if records else []
+    except Exception as exc:
+        return ProbeResult(
+            question=question,
+            verdict="ERROR",
+            anchored_sentence_count=len(anchored),
+            fabricated_sentence_count=0,
+            grounded_sentence_count=0,
+            packet_record_count=len(records),
+            flagged_sentences=[],
+            records=records,
+            error_stage="embed",
+            error_message=str(exc),
+        )
+
+    # Stage 6-7: per-sentence cosine_max + classify
+    flagged: list[FlaggedSentence] = []
+    grounded_count = 0
+    for sent, emb in zip(anchored, sentence_embs):
+        max_cos, top_indices, top_scores = cosine_max(emb, record_embs)
+        verdict = classify(max_cos)
+        if verdict == "FABRICATED":
+            flagged.append(FlaggedSentence(
+                sentence=sent,
+                max_cosine=max_cos,
+                top_3_record_indices=top_indices,
+                top_3_cosines=top_scores,
+            ))
+        else:
+            grounded_count += 1
+
+    question_verdict = "FABRICATED" if flagged else "GROUNDED"
+
+    return ProbeResult(
+        question=question,
+        verdict=question_verdict,
+        anchored_sentence_count=len(anchored),
+        fabricated_sentence_count=len(flagged),
+        grounded_sentence_count=grounded_count,
+        packet_record_count=len(records),
+        flagged_sentences=flagged,
+        records=records,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str, max_len: int = 40) -> str:
+    """ASCII slug for filenames. Lower, alphanumeric + underscore only."""
+    safe = _ascii_safe(text).lower()
+    safe = re.sub(r"[^a-z0-9]+", "_", safe).strip("_")
+    return safe[:max_len] or "question"
+
+
+def write_probe_log(
+    results: list[ProbeResult],
+    log_sentences: bool = True,
+    log_root: Path | None = None,
+) -> Path:
+    """Write per-question JSON files plus a summary.json into a
+    timestamped subdirectory under logs/eval_probe/. Returns the
+    subdirectory path."""
+    log_root = log_root or REPO_ROOT / "logs" / "eval_probe"
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    run_dir = log_root / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_questions: list[dict[str, Any]] = []
+    total_anchored = 0
+    total_flagged = 0
+    questions_with_flags = 0
+
+    for idx, result in enumerate(results, start=1):
+        entry = build_log_entry(result, log_sentences=log_sentences)
+        slug = _slugify(result.question)
+        out_file = run_dir / f"q{idx:02d}_{slug}.json"
+        out_file.write_text(json.dumps(entry, indent=2), encoding="utf-8")
+
+        total_anchored += result.anchored_sentence_count
+        total_flagged += result.fabricated_sentence_count
+        if result.verdict == "FABRICATED":
+            questions_with_flags += 1
+        summary_questions.append({
+            "question_index": idx,
+            "question": _ascii_safe(result.question),
+            "verdict": result.verdict,
+            "anchored_sentence_count": result.anchored_sentence_count,
+            "fabricated_sentence_count": result.fabricated_sentence_count,
+            "grounded_sentence_count": result.grounded_sentence_count,
+            "packet_record_count": result.packet_record_count,
+            "error_stage": result.error_stage,
+        })
+
+    summary = {
+        "timestamp": timestamp,
+        "threshold": PROBE_THRESHOLD,
+        "log_sentences": log_sentences,
+        "total_questions": len(results),
+        "total_anchored": total_anchored,
+        "total_flagged": total_flagged,
+        "questions_with_flags": questions_with_flags,
+        "questions": summary_questions,
+    }
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return run_dir
+
+
+def render_console_summary(results: list[ProbeResult]) -> str:
+    """Build an ASCII-only summary block for stdout / appended-log
+    rendering. One line per question plus an aggregate footer."""
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("FABRICATION PROBE SUMMARY")
+    lines.append("=" * 60)
+    flagged_questions = 0
+    for idx, r in enumerate(results, start=1):
+        verdict = r.verdict
+        line = (
+            f"  [{verdict}] Q{idx}: {_ascii_safe(r.question)} "
+            f"(anchored={r.anchored_sentence_count}, "
+            f"fabricated={r.fabricated_sentence_count})"
+        )
+        lines.append(line)
+        if verdict == "FABRICATED":
+            flagged_questions += 1
+    lines.append("-" * 60)
+    if flagged_questions:
+        lines.append(
+            f"MANUAL REVIEW REQUIRED: {flagged_questions} question(s) "
+            f"with FABRICATED flags."
+        )
+    else:
+        lines.append("All probe questions GROUNDED. No manual review needed.")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the answer-vs-packet fabrication detector against the "
+            "7 vault-grounded probe questions. Returns exit 2 on any "
+            "FABRICATED flag."
+        ),
+    )
+    parser.add_argument(
+        "--no-log-sentences",
+        action="store_true",
+        help=(
+            "Redact flagged-sentence text in logs. Records sentence "
+            "length only. Default is to log the sentence verbatim."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    api_key = os.getenv("EMBER_API_KEY", "")
+    api_base = _api_base()
+
+    results: list[ProbeResult] = []
+    for question in PROBE_QUESTIONS:
+        results.append(run_probe_for_question(question, api_base, api_key))
+
+    log_dir = write_probe_log(
+        results,
+        log_sentences=not args.no_log_sentences,
+    )
+    print(render_console_summary(results))
+    print(f"\nLog: {log_dir}")
+
+    has_flags = any(r.verdict == "FABRICATED" for r in results)
+    return 2 if has_flags else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds the deterministic mechanical fabrication detector that replaced the dropped Haiku-judged dissociation probe (design pivot during /grill-me session). Compares model answers to a frozen pre-flight context packet via embedding cosine; flags second-person-anchored sentences whose max similarity to any packet record falls below 0.55.

## Pipeline (per probe question)
1. `GET /debug-context?message=Q` — pre-flight, frozen baseline
2. `POST /v1/chat/completions` — answer
3. Sentence-segment the answer
4. Filter to second-person-anchored sentences (you, your, yourself, yours, you're, you've, you'd, you'll)
5. Batch-embed sentences and packet record texts via `nomic-embed-text`
6. Per-sentence max cosine across all records
7. `< 0.55` → FABRICATED; `>= 0.55` → GROUNDED
8. Question verdict = FABRICATED if any sentence flagged
9. Privacy-redacted log: flagged sentence text + score + top-3 record metadata only (no record content)

## Files
- **New** `tools/eval_probe.py` — detector module, importable + standalone CLI (`python tools/eval_probe.py [--no-log-sentences]`)
- **New** `tests/test_eval_probe.py` — 52 tests (pure functions + mocked integration paths)
- **Modified** `tools/eval_manual.py` — `--probe` and `--no-log-sentences` flags wired through `_run_auto_battery`. Off by default. Exit code 2 on any FABRICATED flag.

## Constraints satisfied
- No production code changes (probe calls existing endpoints, no API surface modified)
- No Haiku, no cloud cost (local nomic-embed-text only)
- ASCII-only output (NFKD + ascii-ignore coercion); source files pure ASCII
- Packet stays in memory; only metadata persisted per record
- Test vault swap inherited from existing `eval_manual.py:436`

## Test plan
- [x] `pytest tests/test_eval_probe.py -v` — 52 passed
- [x] `pytest tests/ -q` — 1779 passed (was 1727; +52 new), 20 deselected
- [x] ASCII grep — clean
- [x] `python tools/eval_manual.py --probe --help` — flag visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)