### PR TITLE
fix(eval): fatal-exit swap_to_test_vault on missing test-vault config

### DIFF
--- a/tests/test_eval_helpers.py
+++ b/tests/test_eval_helpers.py
@@ -40,23 +40,28 @@ def _make_response(status_code: int = 200, payload: dict | None = None) -> Magic
 
 class TestSwapToTestVault:
 
-    def test_swap_returns_none_when_not_configured(self, tmp_path, monkeypatch):
-        """No VAULT_PATH_TEST set: skip the API call and return None."""
+    def test_swap_exits_when_not_configured(self, tmp_path, monkeypatch):
+        """No VAULT_PATH_TEST set: must fail closed with SystemExit, not
+        silently fall through. The original 2026-04-30 leak was a silent
+        return None when env var was absent in the eval subprocess."""
         monkeypatch.delenv("VAULT_PATH_TEST", raising=False)
         with patch("tools.eval_helpers.httpx.post") as mock_post:
             from tools.eval_helpers import swap_to_test_vault
-            prev = swap_to_test_vault()
-        assert prev is None
+            with pytest.raises(SystemExit) as exc_info:
+                swap_to_test_vault()
+            assert exc_info.value.code == 1
         assert mock_post.call_count == 0
 
-    def test_swap_returns_none_when_dir_missing(self, tmp_path, monkeypatch):
-        """VAULT_PATH_TEST points at nonexistent dir: skip API, return None."""
+    def test_swap_exits_when_dir_missing(self, tmp_path, monkeypatch):
+        """VAULT_PATH_TEST points at nonexistent dir: must fail closed
+        with SystemExit. Same privacy reasoning as the unset-env case."""
         missing = str(tmp_path / "nonexistent")
         monkeypatch.setenv("VAULT_PATH_TEST", missing)
         with patch("tools.eval_helpers.httpx.post") as mock_post:
             from tools.eval_helpers import swap_to_test_vault
-            prev = swap_to_test_vault()
-        assert prev is None
+            with pytest.raises(SystemExit) as exc_info:
+                swap_to_test_vault()
+            assert exc_info.value.code == 1
         assert mock_post.call_count == 0
 
     def test_swap_calls_api_with_test_label(self, tmp_path, monkeypatch):

--- a/tools/eval_helpers.py
+++ b/tools/eval_helpers.py
@@ -11,9 +11,13 @@ Shared helpers for eval tools: test vault isolation and post-run cleanup.
   fixed 2026-04-30.
 
 - Privacy posture: swap_to_test_vault fails closed via sys.exit(1) on
-  any swap failure (connection refused, 403 dev-mode disabled, 400
-  unknown label, 5xx). Refusing to proceed prevents leaking live-vault
-  content to eval judges.
+  any path that would let the eval proceed against the live vault.
+  This includes: missing VAULT_PATH_TEST env var, missing test-vault
+  directory, and any swap-call failure (connection refused, 403
+  dev-mode disabled, 400 unknown label, 5xx). Silent-return-None was
+  the original 2026-04-30 leak: callers cannot distinguish "swap
+  skipped" from "swap succeeded," so any None path is treated as a
+  privacy regression and made fatal.
 
 - run_cleanup: invoke the same logic as cleanup_test_artifacts.py
   --confirm to archive eval artifacts from the active vault silently.
@@ -54,26 +58,38 @@ def _swap_headers() -> dict:
     return headers
 
 
-def swap_to_test_vault() -> str | None:
+def swap_to_test_vault() -> str:
     """Switch the running API to the test vault for eval isolation.
 
-    Returns "test" on successful swap, None when skipped (test vault not
-    configured locally). On any swap failure, prints a fatal message and
-    exits the process to prevent eval running against the live vault.
+    Returns "test" on successful swap. On any failure path - missing
+    VAULT_PATH_TEST env var, missing test-vault directory, or a failed
+    swap call - prints a fatal message and exits the process. This
+    prevents the caller from proceeding against the live vault.
 
-    Local pre-flight gate (VAULT_PATH_TEST + dir exists) avoids a noisy
-    API call when the test vault simply isn't configured. The API also
-    enforces dev-mode and known-label gates server-side; failures from
-    those gates are fatal.
+    Missing env / missing dir are configuration errors, not "graceful
+    skip" conditions. The PR #37 design intent is that no eval ever
+    runs against the live vault by accident; any None return from this
+    helper would re-open that hole.
     """
     test_path = os.getenv("VAULT_PATH_TEST")
     if not test_path:
-        return None
+        print(
+            "FATAL: VAULT_PATH_TEST is not set. Eval tools require an "
+            "explicit test vault to fail closed against the live vault. "
+            "Set VAULT_PATH_TEST in .env and export it into the shell "
+            "before invoking eval (load_dotenv runs inside the API, not "
+            "in eval-tool subprocesses)."
+        )
+        sys.exit(1)
 
     resolved = Path(test_path).resolve()
     if not resolved.is_dir():
-        print(f"WARNING: VAULT_PATH_TEST ({resolved}) does not exist. Skipping swap.")
-        return None
+        print(
+            f"FATAL: VAULT_PATH_TEST ({resolved}) does not exist or is "
+            "not a directory. Refusing to proceed against the live vault. "
+            "Create the test vault directory or correct VAULT_PATH_TEST."
+        )
+        sys.exit(1)
 
     url = f"{_api_base()}{_VAULT_SWAP_PATH}"
     try:


### PR DESCRIPTION
## Summary
- `swap_to_test_vault()` now `sys.exit(1)`s on missing `VAULT_PATH_TEST` env var or missing test-vault directory, instead of silently returning `None` and letting the eval proceed against the live vault.
- Closes the remaining hole left by PR #37 (which fenced API-reachable swap failures but not config-missing skips).
- Tests updated to assert `SystemExit` on both unset-env and missing-dir paths.

## Why
A model comparison eval earlier today silently ran against the live vault. Cause: bash subprocess invoking the eval did not have `VAULT_PATH_TEST` exported (it only lives in `.env`, and `load_dotenv` fires inside `src.core.config` which imports *after* the swap helper executes in the subprocess). The swap silent-no-op'd. PR #37's "fails closed" intent only catches API-reachable failures, not missing-env-var skips.

## Test plan
- [x] `pytest tests/test_eval_helpers.py -q` — 18/18 green
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)