### PR TITLE
feat(api): emit review_pending/review_complete SSE events around constitutional review

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -17,7 +17,7 @@ from src.memory.service import MemoryService
 from src.memory.write_memory import write_memory
 from src.memory.session import create_session, session_exists, get_session, list_sessions
 from src.context.service import ContextService
-from src.llm.adapter import LLMAdapter
+from src.llm.adapter import LLMAdapter, StatusSignal
 from src.onboarding.service import OnboardingService
 from src.state.state_extractor import StateExtractor
 from src.state.state_service import StateService
@@ -1501,8 +1501,14 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                 # 1. Yield typing indicator
                 yield f"data: {json.dumps({'id': completion_id, 'object': 'chat.completion.chunk', 'created': int(time.time()), 'model': 'ember-2', 'choices': [{'index': 0, 'delta': {'content': ''}, 'finish_reason': None}]})}\n\n"
 
-                # 2. Generate full response (non-streaming)
-                full_reply = llm_adapter.generate_response(
+                # 2. Generate full response (non-streaming) - iterate
+                # generate_response_iter so review_pending / review_complete
+                # status events fire on the wire around the constitutional
+                # review call (ADR-036 Option A; UI commit ed858c9). When
+                # the trigger doesn't fire, no StatusSignals are yielded
+                # and only the final string arrives.
+                full_reply = ""
+                for _item in llm_adapter.generate_response_iter(
                     context_packet,
                     style=conversational_style,
                     project_name=project_name,
@@ -1513,7 +1519,11 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                     vision_description=_vision_description,
                     ask_first_active=_ask_first_active,
                     intent_class=_intent_class,
-                )
+                ):
+                    if isinstance(_item, StatusSignal):
+                        yield _status_event(_item.name)
+                    else:
+                        full_reply = _item
 
                 # 3. Grounding check
                 yield _status_event("verifying")

--- a/src/llm/adapter.py
+++ b/src/llm/adapter.py
@@ -4,6 +4,8 @@ import logging
 import os
 import re
 import threading
+from dataclasses import dataclass
+from typing import Iterator
 
 import httpx
 import ollama
@@ -130,6 +132,17 @@ def strip_think_blocks(text: str) -> str:
     return stripped.strip()
 
 
+@dataclass(frozen=True)
+class StatusSignal:
+    """Status sentinel yielded by generate_response_iter() at the
+    constitutional review boundaries. Translated into SSE delta.status
+    events by the streaming caller in src/api/openai_adapter.py.
+    Non-streaming callers drop these and consume only the final
+    response string. ADR-036 Option A.
+    """
+    name: str  # "review_pending" or "review_complete"
+
+
 class LLMAdapter:
     def __init__(
         self,
@@ -162,6 +175,49 @@ class LLMAdapter:
         ask_first_active: bool = False,
         intent_class: str | None = None,
     ) -> str:
+        """Drain generate_response_iter() and return the final response
+        string. Status signals are dropped here -- non-streaming callers
+        don't surface review state. The streaming SSE generator iterates
+        generate_response_iter() directly so it can translate each
+        StatusSignal into a delta.status SSE event on the wire."""
+        final = ""
+        for item in self.generate_response_iter(
+            context_packet,
+            style=style,
+            project_name=project_name,
+            last_session_label=last_session_label,
+            suppress_relational_lodestone=suppress_relational_lodestone,
+            temperature=temperature,
+            bare_mode=bare_mode,
+            vision_description=vision_description,
+            ask_first_active=ask_first_active,
+            intent_class=intent_class,
+        ):
+            if isinstance(item, str):
+                final = item
+        return final
+
+    def generate_response_iter(
+        self,
+        context_packet: ContextPacket,
+        style: str = "balanced",
+        project_name: str | None = None,
+        last_session_label: str | None = None,
+        suppress_relational_lodestone: bool = False,
+        temperature: float | None = None,
+        bare_mode: bool = False,
+        vision_description: str | None = None,
+        ask_first_active: bool = False,
+        intent_class: str | None = None,
+    ) -> Iterator[StatusSignal | str]:
+        """Generator form of generate_response. Yields StatusSignal
+        sentinels around the constitutional review call (only when
+        trigger_result.triggered), then yields the final response string
+        last. The async SSE generator in src/api/openai_adapter.py
+        iterates this method and translates each StatusSignal to a
+        delta.status SSE event so the UI breathing-dot indicator
+        activates during the genuine review window (ADR-036 Option A;
+        UI commit ed858c9)."""
         system_prompt = self.prompt_builder.build_prompt(
             context_packet,
             style=style,
@@ -268,7 +324,14 @@ class LLMAdapter:
                 t2_pattern_category=_t2_category,
             )
 
+            # ADR-036 Option A: yield review_pending immediately before
+            # the LLM-assisted review call, review_complete immediately
+            # after. Gated to triggered=True so the breathing-dot is a
+            # truthful signal, not a false positive on every grounded
+            # request.
+            yield StatusSignal("review_pending")
             review_result = self.review_service.review(review_context)
+            yield StatusSignal("review_complete")
 
             log_path = self.review_logger.log(
                 context_packet=context_packet,
@@ -319,7 +382,7 @@ class LLMAdapter:
         # and turns are sequential, so the risk is negligible.
         threading.Thread(target=self._maybe_compress_buffer, daemon=True).start()
 
-        return final_response
+        yield final_response
 
     def generate_response_stream(
         self,

--- a/tests/test_generate_response_iter.py
+++ b/tests/test_generate_response_iter.py
@@ -1,0 +1,175 @@
+"""Tests for src/llm/adapter.py generate_response_iter().
+
+ADR-036 Option A: when constitutional review fires, the streaming SSE
+generator at openai_adapter.py:1505 needs to emit review_pending /
+review_complete events on the wire DURING the review window so the UI
+breathing-dot indicator (UI commit ed858c9) activates only during a
+genuine review. The bridge is generate_response_iter(), a sync
+generator that yields StatusSignal sentinels around the review call
+and yields the final response string last.
+
+These tests pin the contract:
+  - When the trigger fires, exactly one review_pending then exactly
+    one review_complete sentinel is yielded around the review call,
+    in that order, before the final response string.
+  - When the trigger does NOT fire, no StatusSignal is yielded at all.
+  - The backward-compat generate_response() wrapper drops sentinels
+    and returns only the final string.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.context.models import ContextPacket
+from src.llm.adapter import LLMAdapter, StatusSignal
+from src.safety.models import SafetyReviewResult, SafetyTriggerResult
+
+
+def _bare_adapter() -> LLMAdapter:
+    """Bypass __init__ and wire all collaborators as mocks. The iterator
+    body never touches real services with this construction."""
+    adapter = LLMAdapter.__new__(LLMAdapter)
+    adapter.model = "test-model"
+    adapter.prompt_builder = MagicMock()
+    adapter.prompt_builder.build_prompt.return_value = "system prompt"
+    adapter.prompt_builder.conversation_buffer.question_suppressed = False
+    adapter.policy_service = MagicMock()
+    adapter.review_service = MagicMock()
+    adapter.review_logger = MagicMock()
+    adapter.review_logger.log.return_value = "/tmp/safety_log.json"
+    adapter.memory_service = MagicMock()
+    adapter._chat = MagicMock(return_value="draft response")
+    adapter._maybe_compress_buffer = MagicMock()
+    return adapter
+
+
+def test_iter_yields_status_signals_around_review_when_triggered() -> None:
+    """Triggered path: emits review_pending immediately before the
+    review call and review_complete immediately after, then yields the
+    final response string. Order: pending, complete, response."""
+    adapter = _bare_adapter()
+    adapter.policy_service.evaluate_trigger.return_value = SafetyTriggerResult(
+        triggered=True, triggered_by=["test_trigger"]
+    )
+    adapter.policy_service.get_active_principles.return_value = ["principle_a"]
+    adapter.review_service.review.return_value = SafetyReviewResult(
+        triggered=True, outcome="allow", reviewed_text="reviewed text"
+    )
+
+    items = list(
+        adapter.generate_response_iter(ContextPacket(user_message="hi"))
+    )
+
+    # Exactly one pending, one complete, and one final string -- in order.
+    assert items[0] == StatusSignal("review_pending")
+    assert items[1] == StatusSignal("review_complete")
+    assert isinstance(items[-1], str)
+    # No extra StatusSignals anywhere in the stream.
+    signals = [it for it in items if isinstance(it, StatusSignal)]
+    assert [s.name for s in signals] == ["review_pending", "review_complete"]
+    # The pending sentinel must arrive before the review call begins.
+    # Verify by asserting review() was called exactly once and that the
+    # full iterator includes both sentinels (proves they bracket the call).
+    assert adapter.review_service.review.call_count == 1
+
+
+def test_iter_emits_no_signals_when_trigger_does_not_fire() -> None:
+    """Trigger=False path: review never runs, no StatusSignal yielded.
+    The breathing-dot must not activate on benign requests."""
+    adapter = _bare_adapter()
+    adapter.policy_service.evaluate_trigger.return_value = SafetyTriggerResult(
+        triggered=False
+    )
+
+    items = list(
+        adapter.generate_response_iter(ContextPacket(user_message="hi"))
+    )
+
+    assert all(not isinstance(it, StatusSignal) for it in items)
+    assert adapter.review_service.review.call_count == 0
+    # The single yielded item is the final response string (the draft,
+    # since review didn't run).
+    assert items == ["draft response"]
+
+
+def test_iter_emits_signals_for_revise_outcome() -> None:
+    """The pending/complete pair must fire regardless of review outcome
+    (allow / revise / refuse_redirect). Pin the revise path."""
+    adapter = _bare_adapter()
+    adapter.policy_service.evaluate_trigger.return_value = SafetyTriggerResult(
+        triggered=True, triggered_by=["sycophancy"]
+    )
+    adapter.policy_service.get_active_principles.return_value = ["sycophancy"]
+    adapter.review_service.review.return_value = SafetyReviewResult(
+        triggered=True, outcome="revise", reviewed_text="revised version"
+    )
+
+    items = list(
+        adapter.generate_response_iter(ContextPacket(user_message="hi"))
+    )
+    signal_names = [it.name for it in items if isinstance(it, StatusSignal)]
+
+    assert signal_names == ["review_pending", "review_complete"]
+    # Revised text supersedes the draft in the final yielded string.
+    assert items[-1] == "revised version"
+
+
+def test_iter_emits_signals_for_refuse_redirect_outcome() -> None:
+    """refuse_redirect path also emits the pending/complete pair."""
+    adapter = _bare_adapter()
+    adapter.policy_service.evaluate_trigger.return_value = SafetyTriggerResult(
+        triggered=True, triggered_by=["social_engineering"]
+    )
+    adapter.policy_service.get_active_principles.return_value = ["refuse_unsafe"]
+    adapter.review_service.review.return_value = SafetyReviewResult(
+        triggered=True,
+        outcome="refuse_redirect",
+        refusal_message="I can't help with that.",
+    )
+
+    items = list(
+        adapter.generate_response_iter(ContextPacket(user_message="hi"))
+    )
+    signal_names = [it.name for it in items if isinstance(it, StatusSignal)]
+
+    assert signal_names == ["review_pending", "review_complete"]
+    assert items[-1] == "I can't help with that."
+
+
+def test_generate_response_wrapper_drains_iterator_returns_final_string() -> None:
+    """Backward compat: non-streaming callers see no change. The wrapper
+    drops StatusSignals and returns only the final response string,
+    even when the trigger fires."""
+    adapter = _bare_adapter()
+    adapter.policy_service.evaluate_trigger.return_value = SafetyTriggerResult(
+        triggered=True, triggered_by=["test"]
+    )
+    adapter.policy_service.get_active_principles.return_value = ["principle_a"]
+    adapter.review_service.review.return_value = SafetyReviewResult(
+        triggered=True, outcome="allow", reviewed_text="reviewed text"
+    )
+
+    result = adapter.generate_response(ContextPacket(user_message="hi"))
+
+    assert isinstance(result, str)
+    assert result == "reviewed text"
+
+
+def test_status_signal_is_frozen_dataclass() -> None:
+    """StatusSignal must be hashable and immutable -- it's a value
+    object, not a mutable record. Equality is by name."""
+    a = StatusSignal("review_pending")
+    b = StatusSignal("review_pending")
+    c = StatusSignal("review_complete")
+
+    assert a == b
+    assert a != c
+    assert hash(a) == hash(b)
+    # Frozen: assignment must raise.
+    import dataclasses
+    try:
+        a.name = "review_complete"  # type: ignore[misc]
+        raised = False
+    except dataclasses.FrozenInstanceError:
+        raised = True
+    assert raised, "StatusSignal must be frozen"

--- a/tests/test_sse_events.py
+++ b/tests/test_sse_events.py
@@ -1,9 +1,11 @@
 """
 Tests for SSE status events and source URLs.
 
-Covers: searching, verifying, refining status events, sources event
-for web search responses.
+Covers: searching, verifying, refining, review_pending, review_complete
+status events; sources event for web search responses.
 """
+
+from pathlib import Path
 
 from src.safety.grounding_check import should_check_grounding
 
@@ -68,3 +70,38 @@ def test_refining_only_on_ungrounded():
 
     is_grounded = False
     assert (not is_grounded)  # refining fires when not grounded
+
+
+def test_review_status_signals_translated_to_sse_in_stream_generator():
+    """ADR-036 Option A wire-format guard: the streaming SSE generator
+    must check for StatusSignal items from generate_response_iter() and
+    translate each to a _status_event(item.name) yield. Without this
+    translation, review_pending / review_complete never reach the wire
+    and the UI breathing-dot indicator (commit ed858c9) never fires.
+
+    This is a source-level guard against regressing the iteration loop
+    back to a single generate_response() call. Mirrors the pattern used
+    in tests/test_eval_helpers.py::TestVaultIsolation."""
+    repo_root = Path(__file__).resolve().parents[1]
+    source = (repo_root / "src" / "api" / "openai_adapter.py").read_text(
+        encoding="utf-8"
+    )
+
+    # The new iterator must be the one called from the streaming path.
+    assert "generate_response_iter" in source
+    # The translation of StatusSignal -> SSE must be present.
+    assert "isinstance(_item, StatusSignal)" in source
+    assert "_status_event(_item.name)" in source
+
+
+def test_review_signal_names_match_ui_contract():
+    """The two recognized status names must exactly match what the UI
+    listens for (commit ed858c9 in ../ember-2-ui). A typo here would
+    break the breathing-dot indicator silently."""
+    from src.llm.adapter import StatusSignal
+
+    pending = StatusSignal("review_pending")
+    complete = StatusSignal("review_complete")
+
+    assert pending.name == "review_pending"
+    assert complete.name == "review_complete"


### PR DESCRIPTION
## Summary

Implements ADR-036 Option A. Backend now emits two SSE status events around the constitutional review LLM call so the UI breathing-dot indicator (ember-2-ui commit `ed858c9`) fires during the genuine review window rather than running blind through the buffer-then-stream wait.

- `review_pending` emitted immediately before `review_service.review()` runs (gated to `trigger_result.triggered == True`)
- `review_complete` emitted immediately after review returns
- Same `delta.status` envelope as the existing `searching` / `verifying` / `refining` events; no payload schema changes

## Architectural note

Constitutional review fires *inside* the synchronous `generate_response()` call at `src/llm/adapter.py:271`, called from the async SSE generator at `src/api/openai_adapter.py:1505`. A literal Python callback fired from inside the sync call cannot flush SSE bytes during the review window. Resolution: a generator-protocol bridge — `generate_response()` body lifted into `generate_response_iter()` which yields `StatusSignal` sentinels around the review boundaries and yields the final response string last. The async SSE generator iterates with a `for` loop; each yield is a real suspension point where the async caller flushes bytes to the network. Same module boundary as a callback — review orchestration stays inside the LLM adapter.

A backward-compat wrapper preserves `generate_response()` for non-streaming callers (drains the iterator, drops sentinels, returns the final string).

## Tests

- `tests/test_generate_response_iter.py` (new, 6 tests): pending/complete pair fires when triggered; no signals when not triggered; both signals fire for `revise` and `refuse_redirect` outcomes; backward-compat wrapper drops sentinels and returns the final string; `StatusSignal` is frozen with equality-by-name.
- `tests/test_sse_events.py` (+2 tests): source-level guard against regressing the iteration loop in `openai_adapter.py`; UI-contract guard that the event names match what `ember-2-ui` `ed858c9` listens for.

1848 tests passing (+8 new). Full suite green.

## Live verification

- API restarted on this branch.
- Probe: `curl -sN -X POST /v1/chat/completions ... '{"messages":[{"role":"user","content":"Walk me step by step through how to set up a Python virtual environment."}]}'` filtered to status events only.
- Result: `review_pending`, `review_complete`, `verifying` flow through the wire in that order. Wall-clock ~52s (the long review window made the breathing dot clearly visible in the UI).

## Test plan

- [x] `pytest tests/ -q` — 1848 passing
- [x] Live probe confirms events on the wire in the right order
- [ ] UI breathing-dot smoke (manual) — Chas to confirm in browser
- [ ] No regression in existing streaming behavior (verifying/refining still fire)

## Out of scope

- Onboarding early-return at `openai_adapter.py:874` returning JSON when `stream=True` (CLAUDE.md §1 violation flagged during exploration; pre-existing). Separate fix.
- Removing the now-dead fast streaming path at `:1676-1758`. Cleanup for a future commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)