### PR TITLE
docs(tdd): model eval queue updates — qwen3 MoE, qwen3.5:9b, and shortlist correction

### DIFF
--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -2003,9 +2003,17 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
   → informs: architectural validation only
   → graduation trigger: n/a — reference only
 
-- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. Llama 3.3 8B significantly outperforms Llama 3.1 8B on instruction following. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Model eval shortlist updated: replace Llama 3.1 8B with Llama 3.3 8B as second candidate after Gemma 3 9B. AWQ becomes the target quantization format post-GPU upgrade.
-  → informs: next model eval run (Llama 3.3 8B); post-GPU-upgrade (AWQ quantization)
-  → graduation trigger: model eval run with Llama 3.3 8B completed
+- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Model eval shortlist: Gemma 3 12B and Llama 3.1 8B as candidates against qwen3:8b baseline. Note: Gemma 3 has no 9B variant (ships 1B/4B/12B/27B). Llama 3.3 is 70B only, not 8B — the research review model names were incorrect. AWQ becomes the target quantization format post-GPU upgrade.
+  → informs: next model eval run (Gemma 3 12B and Llama 3.1 8B); post-GPU-upgrade (AWQ quantization)
+  → graduation trigger: model eval run with Gemma 3 12B and Llama 3.1 8B completed
+
+- **v0.18.0 model comparison result, 2026-04-30** — Test vault, 3 models, 54 evaluations. qwen3:8b retained per Pareto rule. Results:
+    - qwen3:8b: 7.3 overall (Pref 8.7 / Const 9.0 / Mem 6.0 / Self-A 8.3 / State 8.0 / Tone 4.0), 18.4s avg, 15/0/3/0
+    - gemma3:12b: 5.6 overall (Pref 6.3 / Const 6.7 / Mem 4.3 / Self-A 4.3 / State 4.0 / Tone 8.0), 24.7s avg, 10/0/8/0
+    - llama3.1:8b: 5.1 overall (Pref 6.3 / Const 6.7 / Mem 2.0 / Self-A 4.3 / State 6.3 / Tone 4.7), 9.8s avg, 8/0/10/0
+  gemma3:12b Tone/Constitutional tradeoff confirmed as real model behavior, not eval noise — reproduced on clean test vault two runs apart. Constitutional drop (9.0 → 6.7) blocks gemma3:12b as a primary model candidate. Chat template / prompt honoring investigation deferred.
+  → informs: continued use of qwen3:8b; backlog item — gemma3:12b chat template / prompt honoring investigation
+  → graduation trigger: gemma3:12b chat template / prompt honoring investigation completed
 
 ---
 

--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -2003,9 +2003,9 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
   → informs: architectural validation only
   → graduation trigger: n/a — reference only
 
-- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Model eval shortlist: Gemma 3 12B and Llama 3.1 8B as candidates against qwen3:8b baseline, with the qwen3 MoE variant (`qwen3:30b-a3b`, Mixture-of-Experts architecture, ~3B active parameters per token) queued behind them as a third candidate. Note: Gemma 3 has no 9B variant (ships 1B/4B/12B/27B). Llama 3.3 is 70B only, not 8B — the research review model names were incorrect. AWQ becomes the target quantization format post-GPU upgrade.
-  → informs: next model eval run (Gemma 3 12B, Llama 3.1 8B, and qwen3 MoE); post-GPU-upgrade (AWQ quantization)
-  → graduation trigger: model eval run with Gemma 3 12B, Llama 3.1 8B, and qwen3 MoE variant completed
+- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Future model eval queue: `qwen3:14b` (timeout issue from prior run, needs retest after config fix) and the qwen3 MoE variant (`qwen3:30b-a3b`, Mixture-of-Experts architecture, ~3B active parameters per token). Gemma 3 12B and Llama 3.1 8B were evaluated in the v0.18.0 comparison (results below); the prior research review's "Gemma 3 9B" and "Llama 3.3 8B" names do not correspond to Ollama tags (Gemma 3 ships 1B/4B/12B/27B; Llama 3.3 is 70B only). AWQ becomes the target quantization format post-GPU upgrade.
+  → informs: next model eval run (`qwen3:14b` retest, `qwen3:30b-a3b` MoE); post-GPU-upgrade (AWQ quantization)
+  → graduation trigger: model eval run with `qwen3:14b` retest and qwen3 MoE variant completed
 
 - **v0.18.0 model comparison result, 2026-04-30** — Test vault, 3 models, 54 evaluations. qwen3:8b retained per Pareto rule. Results:
     - qwen3:8b: 7.3 overall (Pref 8.7 / Const 9.0 / Mem 6.0 / Self-A 8.3 / State 8.0 / Tone 4.0), 18.4s avg, 15/0/3/0

--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -2003,9 +2003,9 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
   → informs: architectural validation only
   → graduation trigger: n/a — reference only
 
-- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Future model eval queue: `qwen3:14b` (timeout issue from prior run, needs retest after config fix) and the qwen3 MoE variant (`qwen3:30b-a3b`, Mixture-of-Experts architecture, ~3B active parameters per token). Gemma 3 12B and Llama 3.1 8B were evaluated in the v0.18.0 comparison (results below); the prior research review's "Gemma 3 9B" and "Llama 3.3 8B" names do not correspond to Ollama tags (Gemma 3 ships 1B/4B/12B/27B; Llama 3.3 is 70B only). AWQ becomes the target quantization format post-GPU upgrade.
-  → informs: next model eval run (`qwen3:14b` retest, `qwen3:30b-a3b` MoE); post-GPU-upgrade (AWQ quantization)
-  → graduation trigger: model eval run with `qwen3:14b` retest and qwen3 MoE variant completed
+- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Future model eval queue: `qwen3:14b` (timeout issue from prior run, needs retest after config fix), the qwen3 MoE variant (`qwen3:30b-a3b`, Mixture-of-Experts architecture, ~3B active parameters per token), and `qwen3.5:9b` (next-generation Qwen base model in the same parameter class as the qwen3:8b production baseline). Gemma 3 12B and Llama 3.1 8B were evaluated in the v0.18.0 comparison (results below); the prior research review's "Gemma 3 9B" and "Llama 3.3 8B" names do not correspond to Ollama tags (Gemma 3 ships 1B/4B/12B/27B; Llama 3.3 is 70B only). AWQ becomes the target quantization format post-GPU upgrade.
+  → informs: next model eval run (`qwen3:14b` retest, `qwen3:30b-a3b` MoE, `qwen3.5:9b`); post-GPU-upgrade (AWQ quantization)
+  → graduation trigger: model eval run with `qwen3:14b` retest, qwen3 MoE variant, and `qwen3.5:9b` completed
 
 - **v0.18.0 model comparison result, 2026-04-30** — Test vault, 3 models, 54 evaluations. qwen3:8b retained per Pareto rule. Results:
     - qwen3:8b: 7.3 overall (Pref 8.7 / Const 9.0 / Mem 6.0 / Self-A 8.3 / State 8.0 / Tone 4.0), 18.4s avg, 15/0/3/0

--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -2003,9 +2003,9 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
   → informs: architectural validation only
   → graduation trigger: n/a — reference only
 
-- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Model eval shortlist: Gemma 3 12B and Llama 3.1 8B as candidates against qwen3:8b baseline. Note: Gemma 3 has no 9B variant (ships 1B/4B/12B/27B). Llama 3.3 is 70B only, not 8B — the research review model names were incorrect. AWQ becomes the target quantization format post-GPU upgrade.
-  → informs: next model eval run (Gemma 3 12B and Llama 3.1 8B); post-GPU-upgrade (AWQ quantization)
-  → graduation trigger: model eval run with Gemma 3 12B and Llama 3.1 8B completed
+- **Local LLM landscape, April 2026** — 80.7% of LLM workloads handleable by models under 20B parameters. AWQ quantization outperforms GGUF on NVIDIA hardware (95% vs 90% quality, higher speed). Model eval shortlist: Gemma 3 12B and Llama 3.1 8B as candidates against qwen3:8b baseline, with the qwen3 MoE variant (`qwen3:30b-a3b`, Mixture-of-Experts architecture, ~3B active parameters per token) queued behind them as a third candidate. Note: Gemma 3 has no 9B variant (ships 1B/4B/12B/27B). Llama 3.3 is 70B only, not 8B — the research review model names were incorrect. AWQ becomes the target quantization format post-GPU upgrade.
+  → informs: next model eval run (Gemma 3 12B, Llama 3.1 8B, and qwen3 MoE); post-GPU-upgrade (AWQ quantization)
+  → graduation trigger: model eval run with Gemma 3 12B, Llama 3.1 8B, and qwen3 MoE variant completed
 
 - **v0.18.0 model comparison result, 2026-04-30** — Test vault, 3 models, 54 evaluations. qwen3:8b retained per Pareto rule. Results:
     - qwen3:8b: 7.3 overall (Pref 8.7 / Const 9.0 / Mem 6.0 / Self-A 8.3 / State 8.0 / Tone 4.0), 18.4s avg, 15/0/3/0


### PR DESCRIPTION
## Summary

Four sequential TDD edits to §50.1 "Local LLM landscape" updating the model eval queue:

| Commit | What |
|---|---|
| `dd50574` | Correct prior model name errors (Gemma 3 9B → 12B, Llama 3.3 → 3.1) and log the v0.18.0 comparison result |
| `7cdc511` | Add `qwen3:30b-a3b` MoE variant to the eval queue |
| `0550513` | Correct shortlist to forward-looking only (qwen3:14b retest + qwen3 MoE; remove already-evaluated Gemma 3 12B / Llama 3.1 8B) |
| `91f9417` | Add `qwen3.5:9b` as third queued candidate (Ollama tag verified) |

Final shortlist now reads: `qwen3:14b` (timeout retest after PR #49), `qwen3:30b-a3b` (MoE, ~3B active), `qwen3.5:9b` (next-gen Qwen base in qwen3:8b parameter class).

## Notes

- Rebased onto `origin/main` after PRs #47 and #48 merged.
- `dd50574` (model-name corrections) also appears as the parent commit on `docs/tdd-coaching-frame-citation` and `docs/building-ember-merge`. Whichever PR Chas merges first, the others rebase to a no-op for that commit.
- v0.18.0 model comparison result entry below the watch item stays untouched (history).

## Test plan

- [x] No code changes; documentation only
- [x] Verified ollama tag `qwen3:30b-a3b` exists via ollama.com/library/qwen3/tags
- [x] qwen3:30b-a3b and qwen3.5:9b confirmed installed locally via `ollama list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)