### PR TITLE
docs(tdd): coaching_frame ceiling — training artifact generalization note + OpenAI goblin post citation

### DIFF
--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -3153,9 +3153,11 @@ These are known limitations of the current model (qwen3:8b) that cannot be fully
 
 ## coaching_frame
 
-The model produces coaching-frame closings ("Remember, you deserve...", "I'm here for you whenever...") on emotional and relational intent classes. Post-generation filter (ADR-030) catches and rewrites most instances. Prompt-level suppression reduces frequency but does not eliminate the pattern. This is a trained behavior in the base model that persists through instruction tuning.
+The model produces coaching-frame closings ("Remember, you deserve...", "I'm here for you whenever...") on emotional and relational intent classes. Post-generation filter (ADR-030) catches and rewrites most instances. Prompt-level suppression reduces frequency but does not eliminate the pattern. This is a trained behavior in the base model that persists through instruction tuning. Mechanism: RLHF reward signals shaped for one persona context generalize into default model behavior, so the therapeutic register surfaces on technical and relational queries alike — the same training-artifact generalization OpenAI documented in their post-mortem on the GPT-4o sycophancy regression.
 
 **Mitigation:** Post-generation coaching filter (Stage 1 deletion + Stage 2 rewrite). Eval baseline: 7/13 golden cases passing.
+
+Reference: OpenAI. Where the goblins came from (April 29, 2026). https://openai.com/index/where-the-goblins-came-from/
 
 ## therapeutic_register
 


### PR DESCRIPTION
## Summary

In `docs/Ember2_TDD.md` §51 "Known Capability Ceilings", `## coaching_frame` entry, adds one sentence attributing the failure mode to RLHF training artifact generalization (the same mechanism documented in OpenAI's "Where the goblins came from" post-mortem on the GPT-4o sycophancy regression). Adds a `Reference:` citation following the §42 precedent.

## Commits

| Commit | What |
|---|---|
| `279345f` | (Shared parent) Correct prior model name errors in §50.1 and log the v0.18.0 comparison result |
| `99946e4` | The coaching_frame note + OpenAI citation |

## Notes

- Rebased onto `origin/main` after PRs #47 and #48 merged.
- `279345f` is also the parent of PRs #50 and #51 (the building-ember-merge PR). Once one of those merges, this PR rebases to a single commit (`99946e4` only).
- No architectural change. Documentation only.
- One-sentence addition; `## therapeutic_register` entry directly below was not touched.

## Test plan

- [x] No code changes; documentation only
- [x] Citation format matches the existing `Reference:` style at §42 in the same file
- [x] Em dashes used in the new sentence are within the existing TDD prose convention (allowed in `docs/`; ASCII-only rule applies to `src/`/`tests/`/`tools/`/`scripts/`/`prompts/` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)