### PR TITLE
refactor(simplify): extract SSE chunk helper, unify refusal markers, dedup hostname extraction, coaching filter compile wrapper, unify API key reading

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1622,13 +1622,11 @@ def store_provider_key(body: ProviderKeyRequest):
 
 @app.get("/provider-key/{provider}")
 def check_provider_key(provider: str):
-    """Check if a cloud provider API key is configured. Never returns the actual key."""
-    try:
-        import keyring
-        key = keyring.get_password(f"ember-2-{provider}", "api_key")
-        return {"provider": provider, "configured": bool(key)}
-    except Exception:
-        return {"provider": provider, "configured": False}
+    """Check if a cloud provider API key is configured. Never returns the actual key.
+    Reports configured=True for keys set via either keyring or env var so this
+    matches the actual lookup behavior in LLMAdapter."""
+    from src.core.config import get_provider_api_key
+    return {"provider": provider, "configured": bool(get_provider_api_key(provider))}
 
 
 @app.delete("/provider-key/{provider}")

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -28,6 +28,25 @@ EMBER_MODEL_ID = "ember-2"
 SUPPORTED_MODELS = [EMBER_MODEL_ID]
 
 
+# Refusal markers used by both streaming and non-streaming paths to skip
+# the coaching filter on responses that intentionally end short. Keeping
+# both paths' lists in sync is the whole point of centralising this.
+_REFUSAL_PATTERNS: tuple[str, ...] = (
+    "i can't help with that",
+    "i'm not going to do that",
+    "that's not something i'm going to do",
+    "i had trouble generating a response",
+)
+
+
+def _is_refusal_response(text: str) -> bool:
+    """True if `text` looks like a refusal."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(m in lowered for m in _REFUSAL_PATTERNS)
+
+
 # MEMORY_PREVIEW_LENGTH removed -- full conversation text is now stored
 
 model=EMBER_MODEL_ID
@@ -1491,6 +1510,20 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
             """Format a status SSE event for the UI."""
             return f"data: {json.dumps({'id': completion_id, 'object': 'chat.completion.chunk', 'created': int(time.time()), 'model': 'ember-2', 'choices': [{'index': 0, 'delta': {'status': status}, 'finish_reason': None}]})}\n\n"
 
+        def _emit_chunk(content: str | None, finish_reason: str | None = None) -> str:
+            """Format a chat.completion.chunk SSE event.
+
+            content=None  -> delta is {} (final chunk)
+            content=""    -> delta is {"content": ""} (initial typing indicator)
+            content=text  -> delta is {"content": text}
+            """
+            delta: dict = {"content": content} if content is not None else {}
+            return f"data: {json.dumps({'id': completion_id, 'object': 'chat.completion.chunk', 'created': int(time.time()), 'model': 'ember-2', 'choices': [{'index': 0, 'delta': delta, 'finish_reason': finish_reason}]})}\n\n"
+
+        def _emit_final_chunk_and_done() -> str:
+            """Final chunk (finish_reason='stop') concatenated with [DONE]."""
+            return _emit_chunk(content=None, finish_reason="stop") + "data: [DONE]\n\n"
+
         if _needs_grounding:
             # --- BUFFER-THEN-STREAM PATH (ADR-019) ---
             async def _stream_sse():
@@ -1499,7 +1532,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                     yield _status_event("searching")
 
                 # 1. Yield typing indicator
-                yield f"data: {json.dumps({'id': completion_id, 'object': 'chat.completion.chunk', 'created': int(time.time()), 'model': 'ember-2', 'choices': [{'index': 0, 'delta': {'content': ''}, 'finish_reason': None}]})}\n\n"
+                yield _emit_chunk(content="")
 
                 # 2. Generate full response (non-streaming) - iterate
                 # generate_response_iter so review_pending / review_complete
@@ -1572,14 +1605,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                 # text must not be rewritten or stripped by the filter. Short
                 # refusals like "I can't help with that." match coaching-closing
                 # patterns and get deleted, producing a blank response.
-                _REFUSAL_MARKERS = (
-                    "i can't help with that",
-                    "i'm not going to do that",
-                    "that's not something i'm going to do",
-                    "i had trouble generating a response",
-                )
-                _is_refusal = any(m in full_reply.lower() for m in _REFUSAL_MARKERS)
-                if not _is_refusal:
+                if not _is_refusal_response(full_reply):
                     from src.llm.coaching_filter import filter_coaching_frame
                     full_reply = filter_coaching_frame(full_reply, _intent_class, _is_conversational)
                     # Post-coaching empty check — if coaching_filter
@@ -1646,18 +1672,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                 tokens = full_reply.split(" ")
                 for i, token in enumerate(tokens):
                     text = token if i == len(tokens) - 1 else token + " "
-                    sse_data = json.dumps({
-                        "id": completion_id,
-                        "object": "chat.completion.chunk",
-                        "created": int(time.time()),
-                        "model": "ember-2",
-                        "choices": [{
-                            "index": 0,
-                            "delta": {"content": text},
-                            "finish_reason": None,
-                        }],
-                    })
-                    yield f"data: {sse_data}\n\n"
+                    yield _emit_chunk(content=text)
 
                 # 5. Web search sources event (if applicable) — suppressed
                 # when ask-first substituted (search hasn't run yet).
@@ -1676,8 +1691,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                     yield f"data: {json.dumps({'type': 'vault_sources', 'sources': vault_sources})}\n\n"
 
                 # Final chunk
-                yield f"data: {json.dumps({'id': completion_id, 'object': 'chat.completion.chunk', 'created': int(time.time()), 'model': 'ember-2', 'choices': [{'index': 0, 'delta': {}, 'finish_reason': 'stop'}]})}\n\n"
-                yield "data: [DONE]\n\n"
+                yield _emit_final_chunk_and_done()
 
                 _post_stream_cleanup(full_reply)
 
@@ -1705,26 +1719,14 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                     filtered = think_filter.filter(chunk)
                     if filtered:
                         accumulated.append(filtered)
-                        sse_data = json.dumps({
-                            "id": completion_id,
-                            "object": "chat.completion.chunk",
-                            "created": int(time.time()),
-                            "model": "ember-2",
-                            "choices": [{
-                                "index": 0,
-                                "delta": {"content": filtered},
-                                "finish_reason": None,
-                            }],
-                        })
-                        yield f"data: {sse_data}\n\n"
+                        yield _emit_chunk(content=filtered)
 
                 # Vault sources event (if applicable)
                 if vault_sources:
                     yield f"data: {json.dumps({'type': 'vault_sources', 'sources': vault_sources})}\n\n"
 
                 # Final chunk
-                yield f"data: {json.dumps({'id': completion_id, 'object': 'chat.completion.chunk', 'created': int(time.time()), 'model': 'ember-2', 'choices': [{'index': 0, 'delta': {}, 'finish_reason': 'stop'}]})}\n\n"
-                yield "data: [DONE]\n\n"
+                yield _emit_final_chunk_and_done()
 
                 full_reply = "".join(accumulated)
                 # Coaching-frame filter — applied to accumulated text.
@@ -1797,11 +1799,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
 
     # Coaching-frame filter — post-generation, pre-return.
     # Skip on refusal responses to prevent stripping.
-    _is_refusal_ns = any(m in reply.lower() for m in (
-        "i can't help with that", "i'm not going to do that",
-        "that's not something i'm going to do", "i had trouble generating a response",
-    ))
-    if not _is_refusal_ns:
+    if not _is_refusal_response(reply):
         from src.llm.coaching_filter import filter_coaching_frame as _filter_cf
         reply = _filter_cf(reply, _intent_class, _is_conversational)
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -102,6 +102,26 @@ def get_ember_api_key() -> str | None:
     return os.getenv("EMBER_API_KEY") or None
 
 
+def get_provider_api_key(provider: str) -> str | None:
+    """Return a cloud provider API key (Anthropic, OpenAI, etc.).
+
+    Looks in this order:
+      1. System credential store via keyring under service "ember-2-{provider}"
+      2. {PROVIDER}_API_KEY env var (e.g. ANTHROPIC_API_KEY, OPENAI_API_KEY)
+
+    Returns None if not found, never raises. Distinct from get_ember_api_key()
+    which returns the Ember UI auth key, not provider keys.
+    """
+    try:
+        import keyring
+        key = keyring.get_password(f"ember-2-{provider}", "api_key")
+        if key:
+            return key
+    except Exception:
+        pass
+    return os.getenv(f"{provider.upper()}_API_KEY") or None
+
+
 def get_ember_embed_model() -> str:
     """
     Returns the Ollama embedding model for vector indexing.

--- a/src/llm/adapter.py
+++ b/src/llm/adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 import threading
 from dataclasses import dataclass
@@ -528,19 +527,10 @@ class LLMAdapter:
 
     @staticmethod
     def _get_provider_api_key(provider: str) -> str | None:
-        """Read a cloud provider API key from the credential manager.
-        Falls back to environment variable (e.g. ANTHROPIC_API_KEY).
-        Returns None if not found, never raises."""
-        try:
-            import keyring
-            key = keyring.get_password(f"ember-2-{provider}", "api_key")
-            if key:
-                return key
-        except Exception:
-            pass
-        # Env var fallback: ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
-        env_name = f"{provider.upper()}_API_KEY"
-        return os.getenv(env_name) or None
+        """Read a cloud provider API key from the credential manager,
+        falling back to env var. Thin wrapper over core.config helper."""
+        from src.core.config import get_provider_api_key
+        return get_provider_api_key(provider)
 
     def _chat(
         self,

--- a/src/llm/coaching_filter.py
+++ b/src/llm/coaching_filter.py
@@ -30,13 +30,18 @@ logger = logging.getLogger("ember.coaching_filter")
 _EMOTIONAL_INTENTS = frozenset({"reflective", "default"})
 
 
+def _compile_patterns(pattern_strings: tuple[str, ...]) -> tuple[re.Pattern, ...]:
+    """Compile a tuple of regex strings with IGNORECASE flag."""
+    return tuple(re.compile(p, re.IGNORECASE) for p in pattern_strings)
+
+
 # ---------------------------------------------------------------------------
 # Stage 1: Pattern definitions
 # ---------------------------------------------------------------------------
 
 # Coaching-frame closing patterns — these end responses with guided
 # self-discovery or action-prompting language.
-_COACHING_CLOSINGS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_COACHING_CLOSINGS: tuple[re.Pattern, ...] = _compile_patterns((
     r"what(?:'s| is| would be) the first step",
     r"i(?:'ll| will) help you (?:map|work|figure|sort|think) (?:it |that |this )?out",
     r"let me know (?:what you need|if you need|how i can|what i can)",
@@ -74,7 +79,7 @@ _COACHING_CLOSINGS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) 
 # Therapeutic mid-response patterns — not just openers/closers but
 # phrases that appear anywhere in the response body. The RLHF base
 # at 8B produces these even without personality layers (bare mode).
-_THERAPEUTIC_MID_RESPONSE: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_THERAPEUTIC_MID_RESPONSE: tuple[re.Pattern, ...] = _compile_patterns((
     r"you(?:'re| are) not alone",
     r"i(?:'m| am) here (?:as )?a steady presence",
     r"i(?:'m| am) here for you",
@@ -100,7 +105,7 @@ _THERAPEUTIC_MID_RESPONSE: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNOR
 ))
 
 # Therapeutic openers — validate/normalize feelings in a clinical way.
-_THERAPEUTIC_OPENERS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_THERAPEUTIC_OPENERS: tuple[re.Pattern, ...] = _compile_patterns((
     r"^i(?:'m| am) here (?:if|for) you",
     r"^it(?:'s| is) (?:okay|ok|perfectly (?:okay|ok|fine|normal)) to feel",
     r"^(?:that|your) (?:feeling|emotion|reaction) is (?:valid|completely valid|understandable|normal)",
@@ -108,7 +113,7 @@ _THERAPEUTIC_OPENERS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE
 ))
 
 # Sycophantic openers under pushback — agreement-seeking as first word(s).
-_SYCOPHANTIC_OPENERS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_SYCOPHANTIC_OPENERS: tuple[re.Pattern, ...] = _compile_patterns((
     r"^you(?:'re| are) right",
     r"^(?:sure|absolutely|of course|fair (?:enough|point))[.,!]?\s",
     r"^(?:yes|yeah)[.,!]?\s+(?:i|you|that|if)",
@@ -384,7 +389,7 @@ def _log_intervention(
 # Patterns that indicate Ember has collapsed her identity under pressure.
 # These fire on ALL intents, not just emotional — identity challenges
 # happen in adversarial contexts.
-_IDENTITY_COLLAPSE_PATTERNS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_IDENTITY_COLLAPSE_PATTERNS: tuple[re.Pattern, ...] = _compile_patterns((
     r"i(?:'m| am) just a tool",
     r"i(?:'m| am) just an ai",
     r"i am just a language model",
@@ -407,7 +412,7 @@ _IDENTITY_COLLAPSE_PATTERNS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGN
 # identical phrasing. The two layers fire independently. When updating either
 # set, consider whether the corresponding pattern/phrase in the other file
 # needs the same change.
-_IDENTITY_COMPLIANCE_PATTERNS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_IDENTITY_COMPLIANCE_PATTERNS: tuple[re.Pattern, ...] = _compile_patterns((
     r"no restrictions(?:,?\s+no boundaries)?",
     r"no boundaries(?:,?\s+no restrictions)?",
     r"(?:help|assist)(?:ing)? (?:you )?however you (?:need|want|like)",
@@ -441,7 +446,7 @@ _IDENTITY_RESPONSE_REFUSAL = (
 )
 
 # Patterns that indicate the user demanded agreement (maps to _IDENTITY_RESPONSE_AGREE)
-_AGREEMENT_DEMAND_PATTERNS: tuple[re.Pattern, ...] = tuple(re.compile(p, re.IGNORECASE) for p in (
+_AGREEMENT_DEMAND_PATTERNS: tuple[re.Pattern, ...] = _compile_patterns((
     r"you(?:'re| are) right.*don(?:'t|t) have opinions",
     r"fair enough.*you(?:'re| are) right",
 ))

--- a/src/llm/source_validator.py
+++ b/src/llm/source_validator.py
@@ -20,7 +20,8 @@ can track fabrication rate.
 from __future__ import annotations
 
 import re
-from urllib.parse import urlparse
+
+from src.safety.url_validator import extract_host
 
 # Patterns: prefer the parenthesised form, but also catch trailing bare
 # "source: X" at the end of a sentence. Both case-insensitive.
@@ -62,19 +63,7 @@ def extract_web_domains(web_items: list) -> list[str]:
 
 def _hostname_of(value: str) -> str:
     """Return a lowercase hostname from a URL or a bare domain string."""
-    value = value.strip().lower()
-    if not value:
-        return ""
-    if "://" not in value:
-        value = "http://" + value
-    try:
-        host = urlparse(value).hostname or ""
-    except ValueError:
-        return ""
-    # Strip www. for allowlist comparison — the model often omits it.
-    if host.startswith("www."):
-        host = host[4:]
-    return host
+    return extract_host(value)
 
 
 def _citation_is_allowed(

--- a/src/safety/url_validator.py
+++ b/src/safety/url_validator.py
@@ -262,6 +262,29 @@ def validate_and_strip_urls(
     return reply, stripped, deduped_kept
 
 
+def extract_host(value: str) -> str:
+    """Return lowercase hostname with www. stripped, or "" on parse failure.
+
+    Accepts a full URL or a bare domain string (no scheme required). Used by
+    both this module (URL canonicalisation) and source_validator (citation
+    hostname matching). Centralised so attack-pattern coverage stays in sync.
+    """
+    if not value or not isinstance(value, str):
+        return ""
+    value = value.strip().lower()
+    if not value:
+        return ""
+    if "://" not in value:
+        value = "http://" + value
+    try:
+        host = urlparse(value).hostname or ""
+    except ValueError:
+        return ""
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
 def _canonicalize_url(url: str) -> tuple[str, str] | None:
     """Return (host, path) with host lowercased and www. stripped, path with
     a single trailing slash removed. Query and fragment are dropped. Returns


### PR DESCRIPTION
## Summary
Five pure-refactor consolidations from the /simplify pass. No behaviour change. All 1907 Tier-1 tests pass on this branch (matches main baseline exactly).

- **SSE chunk helper** — extracted `_emit_chunk` and `_emit_final_chunk_and_done` next to the existing `_status_event` closure. Replaces 5 inline `chat.completion.chunk` JSON envelope sites in the grounded path, fast path, and `[DONE]` terminators. Override-path SSE generator left untouched (different closure, out of stated scope).
- **Refusal markers unified** — module-level `_REFUSAL_PATTERNS` + `_is_refusal_response()` helper. Replaces two near-identical inline lists in the streaming and non-streaming coaching-filter gates. Both lists were already bit-identical, so no semantic change.
- **Hostname extraction dedup** — new public `extract_host()` in `src/safety/url_validator.py`. `source_validator._hostname_of` is now a one-line wrapper. Centralises hostname normalisation across both validators.
- **Coaching filter compile wrapper** — `_compile_patterns()` factory replaces 7 inline `tuple(re.compile(p, re.IGNORECASE) for p in (...))` repetitions.
- **API key reading consolidation** — new `get_provider_api_key(provider)` in `src/core/config.py`. `LLMAdapter._get_provider_api_key` is now a one-line wrapper. `main.py:check_provider_key` endpoint also uses the helper (small alignment: now reports `configured: True` for env-var-set keys, matching adapter's actual lookup behaviour).

## Test plan
- [x] Tier-1 `pytest tests/ -q` — **1907 passed, 47 deselected** (matches main baseline exactly)
- [x] Bit-identical SSE output verified by closure-local key ordering preservation
- [x] No new tests required (all changes are extractions of existing code; existing tests cover both call sites of every change)

## Out of scope
- Override-path SSE generator at `openai_adapter.py:836-839` (different closure, separate scope)
- Sources event emission (different envelope shape)
- Items 5/6/8 from the simplify pass (parameter sprawl, intent-class enum) — touch call signatures across many files; deferred