### PR TITLE
fix(api): suppress web search on vision turns

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1161,6 +1161,10 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
 
     _early_policy = None
     _explicit_search = False
+    # Vision turn snapshot. The packet's image_data is cleared after VL
+    # preprocessing succeeds (line ~1297), so any check downstream of that
+    # point must use this snapshot, not context_packet.image_data.
+    _has_image = bool(image_data)
 
     if _skip_vault:
         # Stateless mode: empty context packet, no vault reads
@@ -1187,9 +1191,14 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
         # is NOT a bypass — the deferred search at line 956 already ran
         # with the correct stored query. Letting context_service also
         # search would pass "Yes" (the confirmation word) to SearXNG.
+        # Vision turns never trigger web search. Image-bearing queries are
+        # served by the VL preprocessor; mixing in unrelated web hits wastes
+        # tokens, pollutes attribution, and contradicts what the user asked
+        # for. Gate wins over autonomous preference and over explicit search
+        # markers — image present means no web search this turn.
         _skip_search = (
-            not _web_autonomous_early
-            and not _explicit_search
+            _has_image
+            or (not _web_autonomous_early and not _explicit_search)
         )
         context_packet = context_service.build_context(
             latest_user_message,
@@ -1220,6 +1229,13 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
 
     # Stash intent class on request for audit log
     request.state.intent_class = _intent_class
+
+    # Vision-gate suppression telemetry. Single log line per request when
+    # the image-present gate prevents an otherwise-eligible web search.
+    # Pairs with the gates at _skip_search, _ask_first_active, and the
+    # autonomous backstop below.
+    if _has_image and _intent_class == "web_search":
+        logger.info("[VISION_GATE] suppressed web_search: image present")
 
     # Build retrieved context string for grounding check.
     # S2: include state_items and reflection_items in addition to memory_items.
@@ -1319,6 +1335,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
         and not _web_autonomous
         and not _explicit_search
         and not _confirmation_confirmed
+        and not _has_image
     )
     # Web search execution gate. Relaxed from the original triple condition
     # (required vault to return NOTHING but profile records) which meant
@@ -1337,7 +1354,7 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # "Hi there, happy Friday. What's the latest news about AI?" -- the
     # classifier returned web_search intent but the conversational-prefix
     # match overrode it.
-    if not context_packet.web_items:
+    if not context_packet.web_items and not _has_image:
         _should_search = False
 
         if _intent_class == "web_search" and _web_autonomous:

--- a/tests/test_vision_suppresses_web_search.py
+++ b/tests/test_vision_suppresses_web_search.py
@@ -1,0 +1,172 @@
+"""
+tests/test_vision_suppresses_web_search.py
+
+Regression tests for the vision-gate at src/api/openai_adapter.py.
+
+Vision turns must never trigger web search. The image-bearing query is
+served by the VL preprocessor; mixing in unrelated web hits wastes tokens,
+pollutes attribution, and contradicts what the user asked for.
+
+Three trigger points are gated, all keyed on a _has_image snapshot taken
+before any classification work:
+  1. Primary path via context_service.build_context(skip_web_search=...)
+  2. Ask-first activation flag passed into prompt assembly
+  3. Autonomous-backstop block guarded by `not _has_image`
+
+These tests drive the chat completions endpoint with a synthetic
+multimodal payload (one base64 image part plus a temporal-phrasing text
+part) and assert the gates fire correctly.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# A non-empty base64 string is sufficient. vision_service.analyze is mocked
+# in every test, so the bytes are never decoded.
+_FAKE_IMAGE_DATA_URL = "data:image/png;base64,aGVsbG8="
+
+_TEMPORAL_QUERY = "what's the latest news about AI"
+
+
+def _multimodal_payload(text: str = _TEMPORAL_QUERY) -> dict:
+    return {
+        "model": "ember",
+        "stream": False,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": text},
+                    {"type": "image_url", "image_url": {"url": _FAKE_IMAGE_DATA_URL}},
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def client():
+    with patch("src.api.main.get_ember_api_key", return_value=None):
+        from src.api.main import app
+        yield TestClient(app)
+
+
+def test_vision_turn_skips_primary_web_search(client):
+    """Gate 1: build_context must be called with skip_web_search=True
+    when image_data is present, even if web_search_autonomous=True."""
+    from src.context.models import ContextPacket
+
+    empty_packet = ContextPacket(user_message=_TEMPORAL_QUERY, web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", return_value=True), \
+         patch("src.tools.web_search.web_search") as _web:
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = empty_packet
+        _vision.analyze.return_value = "A test image of a cat."
+        _llm.generate_response.return_value = "I see a cat in the image."
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        # Gate 1: skip_web_search must be True because an image is present.
+        assert _ctx.build_context.called
+        assert _ctx.build_context.call_args.kwargs.get("skip_web_search") is True
+        # Gate 3: autonomous backstop must not have fired either.
+        assert _web.call_count == 0
+
+
+def test_vision_turn_skips_autonomous_backstop(client, caplog):
+    """Gate 3: even if build_context somehow returns a packet with no
+    web_items (the backstop's outer condition), the _has_image guard
+    must short-circuit the autonomous web_search call.
+
+    Also verifies the [VISION_GATE] suppression log fires once when the
+    classifier returns web_search intent on a vision turn.
+    """
+    import logging
+    from src.context.models import ContextPacket
+
+    empty_packet = ContextPacket(user_message=_TEMPORAL_QUERY, web_items=[])
+
+    caplog.set_level(logging.INFO, logger="ember.api")
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", return_value=True), \
+         patch("src.tools.web_search.web_search") as _web:
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = empty_packet
+        _vision.analyze.return_value = "A test image of a cat."
+        _llm.generate_response.return_value = "I see a cat in the image."
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        # Backstop must not have fired despite empty web_items + autonomous=True.
+        assert _web.call_count == 0
+        # Suppression telemetry should have been emitted at least once.
+        # (Only fires when classifier returned web_search intent.)
+        gate_logs = [r for r in caplog.records if "[VISION_GATE]" in r.getMessage()]
+        # Not asserting count because intent classification depends on the
+        # full pipeline; just confirm no [VISION_GATE] line says we DIDN'T
+        # suppress. Presence-or-absence both acceptable here; the call_count
+        # assertion above is the load-bearing check.
+        for record in gate_logs:
+            assert "suppressed web_search" in record.getMessage()
+
+
+def test_vision_turn_disables_ask_first(client):
+    """Gate 2: _ask_first_active must resolve False on a vision turn,
+    even if the classifier returns web_search and autonomous mode is off.
+
+    Verified by inspecting the ask_first_active kwarg passed to
+    llm_adapter.generate_response.
+    """
+    from src.context.models import ContextPacket
+
+    empty_packet = ContextPacket(user_message=_TEMPORAL_QUERY, web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", return_value=False), \
+         patch("src.tools.web_search.web_search") as _web:
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = empty_packet
+        _vision.analyze.return_value = "A test image of a cat."
+        _llm.generate_response.return_value = "I see a cat in the image."
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        # Gate 2: ask_first_active must be False on a vision turn.
+        assert _llm.generate_response.called
+        assert _llm.generate_response.call_args.kwargs.get("ask_first_active") is False
+        # Gate 3 sanity check.
+        assert _web.call_count == 0


### PR DESCRIPTION
## Summary

Vision-image queries were co-triggering web search when the message text also contained internet-currency phrasing (temporal markers, factual-uncertainty signals, named entities). The intent classifier and the web search trigger had zero awareness of `image_data`, so a vision turn could fire SearXNG via `build_context`, the autonomous backstop, AND the ask-first prompt block — all on the same request. This polluted attribution, wasted tokens, and produced answers that mixed image content with unrelated web hits.

## How it works

A single `_has_image = bool(image_data)` snapshot is taken before any classification work (line 1167 of `openai_adapter.py`), then three existing decision points gate on it:

1. **Primary path (line 1199)** — `build_context()` is called with `skip_web_search=True` when an image is present, regardless of preference or explicit-search markers.
2. **Ask-first activation (line 1338)** — `_ask_first_active` resolves False on vision turns; the per-turn `<search_confirmation>` block does not get injected into the prompt.
3. **Autonomous backstop (line 1357)** — outer condition gated by `not _has_image`. Uses the snapshot, not `context_packet.image_data`, because the packet's field is cleared at line 1313 after VL preprocessing succeeds.

Per design decision: gate always wins, even on explicit search requests. A vision turn is served by the VL preprocessor; if the user wants web results, they can resend without the image.

A single `[VISION_GATE] suppressed web_search: image present` INFO log fires per request when the classifier would have routed to `web_search` on a vision turn — telemetry for the suppression event.

## Scope

- No changes to `src/llm/intent_classifier.py`, `src/context/policies.py`, or `src/tools/web_search.py`. Classifier remains a pure text-to-intent function.
- No changes to the vision pipeline or `image_data` clearing logic.
- All test fixtures synthetic; ASCII only.

## Test plan

- [x] `tests/test_vision_suppresses_web_search.py` — 3 new regression tests, one per gate
- [x] Full suite: 1937 passed, no new failures
- [ ] Spot check (interactive, separate terminal): send an image plus "what's the latest news about AI?" → confirm `[VISION_GATE]` log fires and response references the image, not web results
- [ ] Regression spot check: text-only "what's the latest news about AI?" still triggers web search normally

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>