### PR TITLE
feat(web-search): published_at freshness signal for retrieval ranking and prompt

### DIFF
--- a/src/llm/prompt_builder.py
+++ b/src/llm/prompt_builder.py
@@ -16,7 +16,7 @@ XML-tagged sections for qwen3:8b structure tracking.
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from src.context.models import ContextPacket
@@ -150,8 +150,18 @@ _AUTHORITY_RULES_BODY_COMMON = (
     "No 'source:' prefix — just confidence and age. The badge and the hedge serve different "
     "purposes: badge = where the answer came from, hedge = how reliable the grounding is.\n"
     "conversation_history is prior exchange only -- do not treat conversational inferences as established facts.\n"
-    "web_search_results are live data retrieved at request time and are current as of today. "
-    "Treat them as authoritative. Do not discount or second-guess them based on training cutoff dates.\n"
+    "web_search_results are live data retrieved at request time. Treat them "
+    "as authoritative for the topic queried. Do not discount them based on "
+    "training cutoff dates.\n"
+    "Each result has a 'published:' line showing the source's age. When per-"
+    "result published dates are present, weight more recent sources more "
+    "heavily. If the most relevant dated source is older than about 24 hours "
+    "and the query is about something that changes quickly (news, prices, "
+    "scores, software releases, current events), qualify the answer with the "
+    "source's age (for example, 'as of three hours ago'). For evergreen "
+    "topics, ignore the dates and answer normally. 'published: unknown' means "
+    "the source did not surface a date — treat it with normal skepticism, do "
+    "not invent a date.\n"
     "CRITICAL: When web_search_results are present, ANSWER THE QUESTION DIRECTLY using the "
     "information in them. Extract the specific facts the user asked for — names, numbers, "
     "dates, outcomes — and state them in your response. Then cite the source URL so the "
@@ -241,6 +251,40 @@ _DECLINE_STOPWORDS = frozenset(
     {"my", "the", "this", "that", "a", "an", "his", "her", "their",
      "our", "its", "about", "with", "from", "and", "or", "of", "in", "on"}
 )
+
+
+def _format_relative_age(iso_str, now=None):
+    """Render an ISO 8601 published_at as a human-relative phrase.
+
+    Returns "unknown" for None / empty / unparseable input so the renderer
+    can stay branchless. The model uses this string directly to apply the
+    24-hour qualification rule from authority_rules.
+    """
+    if not iso_str:
+        return "unknown"
+    try:
+        dt = datetime.fromisoformat(iso_str)
+    except (TypeError, ValueError):
+        return "unknown"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    seconds = max(0, (now - dt).total_seconds())
+    if seconds < 3600:
+        n = max(1, int(seconds // 60))
+        return f"{n} minute{'s' if n != 1 else ''} ago"
+    if seconds < 86400:
+        n = int(seconds // 3600)
+        return f"{n} hour{'s' if n != 1 else ''} ago"
+    if seconds < 86400 * 30:
+        n = int(seconds // 86400)
+        return f"{n} day{'s' if n != 1 else ''} ago"
+    if seconds < 86400 * 365:
+        n = int(seconds // (86400 * 30))
+        return f"{n} month{'s' if n != 1 else ''} ago"
+    n = int(seconds // (86400 * 365))
+    return f"{n} year{'s' if n != 1 else ''} ago"
 
 
 def _extract_decline_keywords(declined_topics: list[str]) -> list[list[str]]:
@@ -774,7 +818,10 @@ class PromptBuilder:
             title = item.get("title", "")
             url = item.get("url", "")
             snippet = item.get("snippet", "")
-            lines.append(f"[{i}] {title}\n    {url}\n    {snippet}")
+            age = _format_relative_age(item.get("published_at"))
+            lines.append(
+                f"[{i}] {title}\n    {url}\n    published: {age}\n    {snippet}"
+            )
 
         # Reframe as Ember's own retrieval — the model engages with content
         # attributed to its own actions more reliably than content framed as

--- a/src/tools/web_search.py
+++ b/src/tools/web_search.py
@@ -1,19 +1,91 @@
 import logging
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 import requests
 
 logger = logging.getLogger("ember.web_search")
 
 SEARXNG_URL = "http://localhost:8888/search"
+# Internal candidate pool fetched from SearXNG before re-ranking. Caller-
+# visible result count stays at MAX_RESULTS so prompt-section size and
+# every downstream consumer is unaffected.
+CANDIDATE_POOL_SIZE = 10
 MAX_RESULTS = 5
 SNIPPET_MAX_LEN = 200
 TIMEOUT_SECONDS = 20
+# Freshness decay: dated items lose half their weight every 24 hours,
+# floored so even a year-old article retains some weight rather than
+# dropping to zero. Tunable per-deployment if eval shows the half-life
+# is wrong for typical Ember queries.
+FRESHNESS_HALF_LIFE_HOURS = 24
+FRESHNESS_FLOOR = 0.3
 
 
-def web_search(query: str) -> list[dict]:
+def _parse_published_at(raw):
+    """Best-effort parse of SearXNG's publishedDate.
+
+    Tries ISO 8601 first (covers most engines on Python 3.12), then
+    RFC 822 via email.utils (covers news engines that emit Atom/RSS-style
+    dates). Returns timezone-aware UTC datetime, or None on any failure.
+    INFO-logs once per failure so unknown formats can be surfaced and
+    added to the parser later without crashing the search.
     """
-    Query local SearXNG. Returns up to 5 results as dicts with title/url/snippet.
-    Silent failure — returns [] on any error (SearXNG down, timeout, bad response).
+    if not raw:
+        return None
+    s = str(raw).strip()
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except ValueError:
+        pass
+    try:
+        dt = parsedate_to_datetime(s)
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        pass
+    logger.info("[WEB_SEARCH] unparseable publishedDate: %r", s[:50])
+    return None
+
+
+def _freshness_multiplier(
+    published_at,
+    now=None,
+    half_life_hours=FRESHNESS_HALF_LIFE_HOURS,
+    floor=FRESHNESS_FLOOR,
+):
+    """Compute a freshness weight in [floor, 1.0].
+
+    Undated items return 1.0 (neutral) so the freshness signal only
+    re-orders dated items relative to other dated items. Future dates
+    (clock skew between SearXNG result and local clock) also return 1.0
+    rather than producing a negative-age multiplier above 1.0.
+    """
+    if published_at is None:
+        return 1.0
+    if now is None:
+        now = datetime.now(timezone.utc)
+    age_hours = (now - published_at).total_seconds() / 3600
+    if age_hours <= 0:
+        return 1.0
+    decay = 0.5 ** (age_hours / half_life_hours)
+    return max(floor, decay)
+
+
+def web_search(query):
+    """Query local SearXNG, re-rank by combined SearXNG-rank + freshness,
+    return top MAX_RESULTS as dicts with title/url/snippet/published_at.
+
+    published_at is an ISO 8601 string (UTC) or None when SearXNG did not
+    provide a parseable date. Silent failure on the request itself:
+    returns [] on any exception.
     """
     try:
         response = requests.get(
@@ -24,13 +96,25 @@ def web_search(query: str) -> list[dict]:
         response.raise_for_status()
         data = response.json()
 
-        results = []
-        for item in data.get("results", [])[:MAX_RESULTS]:
-            results.append({
+        candidates = []
+        now = datetime.now(timezone.utc)
+        for rank, item in enumerate(data.get("results", [])[:CANDIDATE_POOL_SIZE]):
+            published_at = _parse_published_at(item.get("publishedDate"))
+            multiplier = _freshness_multiplier(published_at, now=now)
+            score = (1.0 / (rank + 1)) * multiplier
+            candidates.append({
                 "title": item.get("title", "").strip(),
                 "url": item.get("url", "").strip(),
                 "snippet": item.get("content", "")[:SNIPPET_MAX_LEN].strip(),
+                "published_at": published_at.isoformat() if published_at else None,
+                "_score": score,
             })
+
+        candidates.sort(key=lambda d: d["_score"], reverse=True)
+        results = [
+            {k: v for k, v in c.items() if k != "_score"}
+            for c in candidates[:MAX_RESULTS]
+        ]
 
         logger.info("[WEB_SEARCH] %d results for: %s", len(results), query[:80])
         return results

--- a/tests/test_prompt_builder_web_section.py
+++ b/tests/test_prompt_builder_web_section.py
@@ -1,0 +1,163 @@
+"""
+tests/test_prompt_builder_web_section.py
+
+Tests rendering of the <web_search_results> prompt section after the
+freshness signal was added. The section now emits a 'published: <age>'
+line per item using _format_relative_age, with 'unknown' for items
+whose web_search did not surface a publishedDate.
+
+No existing test covered _build_web_search_section; this file fills
+that gap.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from src.context.models import ContextPacket
+from src.llm.prompt_builder import PromptBuilder, _format_relative_age
+
+
+# Fixed reference 'now' for deterministic age rendering across tests.
+_NOW = datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# _format_relative_age boundaries
+# ---------------------------------------------------------------------------
+
+def test_relative_age_unknown_for_none():
+    assert _format_relative_age(None, now=_NOW) == "unknown"
+
+
+def test_relative_age_unknown_for_empty_string():
+    assert _format_relative_age("", now=_NOW) == "unknown"
+
+
+def test_relative_age_unknown_for_unparseable():
+    assert _format_relative_age("not a date", now=_NOW) == "unknown"
+
+
+def test_relative_age_minutes():
+    iso = (_NOW - timedelta(minutes=15)).isoformat()
+    assert _format_relative_age(iso, now=_NOW) == "15 minutes ago"
+
+
+def test_relative_age_singular_minute():
+    iso = (_NOW - timedelta(minutes=1)).isoformat()
+    assert _format_relative_age(iso, now=_NOW) == "1 minute ago"
+
+
+def test_relative_age_hours():
+    iso = (_NOW - timedelta(hours=3)).isoformat()
+    assert _format_relative_age(iso, now=_NOW) == "3 hours ago"
+
+
+def test_relative_age_days():
+    iso = (_NOW - timedelta(days=5)).isoformat()
+    assert _format_relative_age(iso, now=_NOW) == "5 days ago"
+
+
+def test_relative_age_months():
+    iso = (_NOW - timedelta(days=90)).isoformat()
+    assert _format_relative_age(iso, now=_NOW) == "3 months ago"
+
+
+def test_relative_age_years():
+    iso = (_NOW - timedelta(days=400)).isoformat()
+    assert _format_relative_age(iso, now=_NOW) == "1 year ago"
+
+
+def test_relative_age_naive_iso_assumed_utc():
+    """ISO string without timezone should be treated as UTC, not raise."""
+    iso = "2026-05-03T11:00:00"  # 3 hours before _NOW
+    assert _format_relative_age(iso, now=_NOW) == "3 hours ago"
+
+
+# ---------------------------------------------------------------------------
+# _build_web_search_section rendering
+# ---------------------------------------------------------------------------
+
+def _bare_builder():
+    """Construct PromptBuilder without invoking __init__ — the web
+    section method does not depend on system_prompt or other init state."""
+    return PromptBuilder.__new__(PromptBuilder)
+
+
+def test_section_empty_when_no_web_items():
+    builder = _bare_builder()
+    packet = ContextPacket(user_message="hello", web_items=[])
+    assert builder._build_web_search_section(packet) == ""
+
+
+def test_section_renders_dated_item_with_relative_age():
+    builder = _bare_builder()
+    iso = (_NOW - timedelta(hours=3)).isoformat()
+    packet = ContextPacket(
+        user_message="latest news",
+        web_items=[{
+            "title": "Article",
+            "url": "https://example.com/a",
+            "snippet": "snippet text",
+            "published_at": iso,
+        }],
+    )
+    with patch("src.llm.prompt_builder.datetime") as mock_dt:
+        mock_dt.now.return_value = _NOW
+        mock_dt.fromisoformat = datetime.fromisoformat
+        section = builder._build_web_search_section(packet)
+    assert "published: 3 hours ago" in section
+    assert "Article" in section
+    assert "https://example.com/a" in section
+    assert "snippet text" in section
+
+
+def test_section_renders_undated_item_as_unknown():
+    builder = _bare_builder()
+    packet = ContextPacket(
+        user_message="evergreen",
+        web_items=[{
+            "title": "Wikipedia entry",
+            "url": "https://example.com/wiki",
+            "snippet": "snippet text",
+            "published_at": None,
+        }],
+    )
+    section = builder._build_web_search_section(packet)
+    assert "published: unknown" in section
+
+
+def test_section_handles_missing_published_at_key():
+    """Backward compat: existing callers that don't set published_at
+    (e.g. legacy test fixtures) render as unknown, not crash."""
+    builder = _bare_builder()
+    packet = ContextPacket(
+        user_message="legacy",
+        web_items=[{
+            "title": "Legacy fixture",
+            "url": "https://example.com/legacy",
+            "snippet": "snippet text",
+        }],
+    )
+    section = builder._build_web_search_section(packet)
+    assert "published: unknown" in section
+
+
+def test_section_renders_mixed_dated_and_undated():
+    builder = _bare_builder()
+    iso = (_NOW - timedelta(hours=2)).isoformat()
+    packet = ContextPacket(
+        user_message="mixed",
+        web_items=[
+            {"title": "Dated", "url": "https://example.com/d",
+             "snippet": "s", "published_at": iso},
+            {"title": "Undated", "url": "https://example.com/u",
+             "snippet": "s", "published_at": None},
+        ],
+    )
+    with patch("src.llm.prompt_builder.datetime") as mock_dt:
+        mock_dt.now.return_value = _NOW
+        mock_dt.fromisoformat = datetime.fromisoformat
+        section = builder._build_web_search_section(packet)
+    assert "published: 2 hours ago" in section
+    assert "published: unknown" in section

--- a/tests/test_vault_citation.py
+++ b/tests/test_vault_citation.py
@@ -164,11 +164,15 @@ class TestWebSearchAuthorityInstruction:
         from src.llm.prompt_builder import _render_authority_rules
         rules = _render_authority_rules(is_conversational=False)
         assert "live data" in rules
-        assert "current as of today" in rules
+        # Phrasing of the "treat web results as current" instruction was
+        # softened when the published_at freshness signal was added; the
+        # intent (web results are authoritative; don't discount on training
+        # cutoff) is now carried by these two phrases.
+        assert "authoritative for the topic queried" in rules
+        assert "Do not discount" in rules
         # v0.16.0-dev: citation instruction rewritten from "Cite specific
         # URLs" to answer-first-then-cite pattern.
         assert "ANSWER THE QUESTION DIRECTLY" in rules
-        assert "Do not discount" in rules
 
     def test_authority_rules_no_longer_hedge_web_results(self):
         from src.llm.prompt_builder import _render_authority_rules

--- a/tests/test_web_search_freshness.py
+++ b/tests/test_web_search_freshness.py
@@ -1,0 +1,246 @@
+"""
+tests/test_web_search_freshness.py
+
+Tests the freshness signal added to src/tools/web_search.py:
+
+  - _parse_published_at: best-effort parse of SearXNG's publishedDate
+    string (ISO 8601 + RFC 822). Returns timezone-aware UTC datetime
+    or None on failure.
+
+  - _freshness_multiplier: per-item weight in [floor, 1.0]. Undated
+    items get 1.0 (neutral) so freshness only re-orders dated items
+    relative to other dated items.
+
+  - web_search: fetches CANDIDATE_POOL_SIZE results, re-ranks by
+    combined SearXNG-rank + freshness, returns top MAX_RESULTS as
+    dicts with title/url/snippet/published_at.
+
+All SearXNG calls are mocked. No network access.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from src.tools.web_search import (
+    CANDIDATE_POOL_SIZE,
+    FRESHNESS_FLOOR,
+    MAX_RESULTS,
+    _freshness_multiplier,
+    _parse_published_at,
+    web_search,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_published_at
+# ---------------------------------------------------------------------------
+
+def test_parse_iso_8601_with_z_suffix():
+    dt = _parse_published_at("2026-05-03T14:00:00Z")
+    assert dt == datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_8601_with_explicit_offset():
+    dt = _parse_published_at("2026-05-03T14:00:00+00:00")
+    assert dt == datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_8601_naive_assumed_utc():
+    dt = _parse_published_at("2026-05-03T14:00:00")
+    assert dt == datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_8601_offset_normalized_to_utc():
+    dt = _parse_published_at("2026-05-03T14:00:00-05:00")
+    assert dt == datetime(2026, 5, 3, 19, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_rfc_822():
+    dt = _parse_published_at("Sat, 03 May 2026 14:00:00 GMT")
+    assert dt == datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_empty_returns_none():
+    assert _parse_published_at("") is None
+    assert _parse_published_at(None) is None
+    assert _parse_published_at("   ") is None
+
+
+def test_parse_garbage_returns_none_and_logs(caplog):
+    caplog.set_level(logging.INFO, logger="ember.web_search")
+    assert _parse_published_at("not a date at all") is None
+    assert any(
+        "unparseable publishedDate" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# _freshness_multiplier
+# ---------------------------------------------------------------------------
+
+def test_multiplier_undated_is_neutral():
+    """D-2: undated items get 1.0 so they sort by SearXNG rank only."""
+    assert _freshness_multiplier(None) == 1.0
+
+
+def test_multiplier_at_publish_moment_is_one():
+    now = datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+    assert _freshness_multiplier(now, now=now) == 1.0
+
+
+def test_multiplier_24h_old_is_half():
+    now = datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+    published = now - timedelta(hours=24)
+    assert _freshness_multiplier(published, now=now) == 0.5
+
+
+def test_multiplier_decay_continues_below_floor_when_floor_zero():
+    """At 48h with no floor, decay continues to 0.25 (two half-lives).
+    The default floor masks this in production usage, but the math
+    underneath needs to be testable."""
+    now = datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+    published = now - timedelta(hours=48)
+    assert _freshness_multiplier(published, now=now, floor=0.0) == 0.25
+
+
+def test_multiplier_far_in_past_floors_at_floor():
+    now = datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+    published = now - timedelta(days=365)
+    assert _freshness_multiplier(published, now=now) == FRESHNESS_FLOOR
+
+
+def test_multiplier_future_date_returns_one():
+    """Clock skew between SearXNG result and local clock should not
+    produce a multiplier above 1.0."""
+    now = datetime(2026, 5, 3, 14, 0, 0, tzinfo=timezone.utc)
+    published = now + timedelta(hours=2)
+    assert _freshness_multiplier(published, now=now) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# web_search re-ranking integration
+# ---------------------------------------------------------------------------
+
+def _mock_searxng_response(results):
+    """Build a MagicMock SearXNG response carrying the given results list."""
+    response = MagicMock()
+    response.json.return_value = {"results": results}
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_web_search_returns_max_results_with_published_at_key():
+    """Every returned dict has the four expected keys, no _score leaks."""
+    items = [
+        {"title": f"Result {i}", "url": f"https://example.com/{i}",
+         "content": "snippet", "publishedDate": "2026-05-03T14:00:00Z"}
+        for i in range(CANDIDATE_POOL_SIZE)
+    ]
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response(items)):
+        results = web_search("test query")
+    assert len(results) == MAX_RESULTS
+    for item in results:
+        assert set(item.keys()) == {"title", "url", "snippet", "published_at"}
+
+
+def test_web_search_freshness_swaps_adjacent_dated_items():
+    """SearXNG ranks a stale article at position 0 and a fresh article
+    at position 1. After freshness re-ranking, the fresh article should
+    rank above the stale one.
+
+    Realistic-reach test: the combined-score formula
+    (1/(rank+1)) * multiplier means freshness can swap adjacent ranks
+    but cannot, at the floor of 0.3, lift a buried fresh item past
+    multiple stale items at the top. This matches the design intent
+    documented in Q4 of the planning grill.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+    stale_iso = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    items = [
+        {"title": "Stale at top", "url": "https://example.com/stale",
+         "content": "stale snippet", "publishedDate": stale_iso},
+        {"title": "Fresh second", "url": "https://example.com/fresh",
+         "content": "fresh snippet", "publishedDate": now_iso},
+        {"title": "Filler 1", "url": "https://example.com/f1",
+         "content": "filler", "publishedDate": stale_iso},
+    ]
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response(items)):
+        results = web_search("test query")
+    titles = [r["title"] for r in results]
+    assert titles.index("Fresh second") < titles.index("Stale at top")
+
+
+def test_web_search_all_undated_preserves_searxng_order():
+    """When no items are dated, freshness multiplier is 1.0 for all and
+    the combined score reduces to SearXNG's implicit rank — order is
+    preserved."""
+    items = [
+        {"title": f"Result {i}", "url": f"https://example.com/{i}",
+         "content": "snippet"}  # no publishedDate
+        for i in range(CANDIDATE_POOL_SIZE)
+    ]
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response(items)):
+        results = web_search("test query")
+    titles = [r["title"] for r in results]
+    assert titles == [f"Result {i}" for i in range(MAX_RESULTS)]
+    for r in results:
+        assert r["published_at"] is None
+
+
+def test_web_search_undated_neutral_against_dated():
+    """A fresh undated item at SearXNG rank 0 should beat a stale dated
+    item at SearXNG rank 1 (multiplier 1.0 * 1.0 > 0.5 * decay)."""
+    stale_iso = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    items = [
+        {"title": "Undated top", "url": "https://example.com/u",
+         "content": "snippet"},
+        {"title": "Stale dated", "url": "https://example.com/s",
+         "content": "snippet", "publishedDate": stale_iso},
+    ]
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response(items)):
+        results = web_search("test query")
+    assert results[0]["title"] == "Undated top"
+
+
+def test_web_search_returns_fewer_than_max_when_pool_small():
+    """SearXNG returning < MAX_RESULTS items: return what's available."""
+    items = [
+        {"title": "Only result", "url": "https://example.com/o",
+         "content": "snippet"}
+    ]
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response(items)):
+        results = web_search("test query")
+    assert len(results) == 1
+
+
+def test_web_search_returns_empty_on_no_results():
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response([])):
+        assert web_search("nothing") == []
+
+
+def test_web_search_returns_empty_on_request_failure():
+    """Existing failure-mode contract: any exception returns []."""
+    with patch("src.tools.web_search.requests.get",
+               side_effect=ConnectionError("searxng down")):
+        assert web_search("test query") == []
+
+
+def test_web_search_strips_internal_score_field():
+    """The _score field used during re-ranking must not leak to the caller."""
+    items = [
+        {"title": "Result 1", "url": "https://example.com/1",
+         "content": "snippet", "publishedDate": "2026-05-03T14:00:00Z"}
+    ]
+    with patch("src.tools.web_search.requests.get",
+               return_value=_mock_searxng_response(items)):
+        results = web_search("test query")
+    assert "_score" not in results[0]


### PR DESCRIPTION
## Summary

Stale web snippets currently pass the grounding check whenever the response is internally consistent with the snippet text — see `KNOWN_ISSUES.md:67`. This adds a freshness signal end-to-end so the model can qualify time-sensitive answers and so retrieval order demotes stale dated items.

Two coupled changes:

1. **Retrieval-time re-ranking** in `src/tools/web_search.py`. SearXNG's `publishedDate` is parsed into a timezone-aware UTC datetime (ISO 8601 + RFC 822 via stdlib only — no new dependency). The candidate pool widens to 10, each item gets a freshness multiplier (24-hour half-life, floor 0.3), the combined score `(1/(rank+1)) * multiplier` re-ranks the pool, and the top 5 are returned. Each result dict now carries a `published_at` ISO string (or `None`). Undated items get multiplier 1.0 (neutral) — the freshness signal only re-orders dated items relative to other dated items.

2. **Prompt-side rendering and authority rule** in `src/llm/prompt_builder.py`. Each `<web_search_results>` item now renders a `published: <N units ago>` line (or `published: unknown` for undated). The authority-rule line that previously said web results are "current as of today" is softened, and a new freshness-aware instruction tells the model to qualify time-sensitive answers (news/prices/scores/software releases/current events) when the most relevant dated source is older than ~24 hours, and to ignore the dates on evergreen topics. The model is trusted to apply the rule selectively; no post-gen validator.

## Design decisions (resolved during planning grill)

- **`published_at`, not `fetched_at`.** The failure mode is publication staleness, not request staleness; `fetched_at` for single-turn queries is always ~now and would produce misleading "as of 0 hours ago" qualifiers.
- **Undated items are neutral (multiplier 1.0).** Treating undated as "infinitely stale" would push authoritative undated sources (NOAA weather widget, Wikipedia) below stale dated articles. The signal only re-orders dated items relative to other dated items.
- **No new intent classifier subcategory.** The rule fires on every web turn; the model decides what's time-sensitive from the data and the query. Eval will validate.
- **Reach is intentionally limited.** With floor 0.3 and the `(1/(rank+1))` rank decay, freshness can swap adjacent dated ranks but cannot lift a buried fresh item past multiple stale ones at the top. This is the documented design intent.

## What's not in scope

- No changes to `src/llm/intent_classifier.py`, `src/context/policies.py`, or `src/safety/grounding_check.py`.
- No new dependencies; ISO 8601 via `datetime.fromisoformat`, RFC 822 via `email.utils.parsedate_to_datetime`.
- `MAX_RESULTS = 5` unchanged — caller-visible result count is identical.
- Weather-widget / live-score case is still a no-op (those engines emit no date). Architectural fix for that is the dedicated weather/sports API deferred to v0.18.0 per `KNOWN_ISSUES.md`.

## Test plan

- [x] `tests/test_web_search_freshness.py` — 17 tests covering parsing (ISO 8601 variants, RFC 822, garbage, empty), multiplier math (neutral undated, decay curve, floor, future dates), re-ranking integration (adjacent swap, all-undated preserves order, undated-vs-dated, request failure)
- [x] `tests/test_prompt_builder_web_section.py` — 16 tests covering relative-age rendering across minute/hour/day/month/year boundaries, mixed dated/undated, missing-key backward compat
- [x] `tests/test_vault_citation.py` updated to track the softened authority-rule wording
- [x] Full suite: 1973 passed, no other regressions
- [x] Spot check (separate terminal, real vault, SearXNG running): "what's the latest AI news" → confirm prompt logs show `published: X hours ago` for at least 1-2 items
- [x] Negative spot check: "what is photosynthesis" → confirm response does *not* append "as of N years ago"
- [ ] Eval observation: run `tools/eval_web_search.py` after merge; inspect outputs for inappropriate qualification on evergreen queries

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>