### PR TITLE
fix(intent): add personal-identity examples and counter-anchors to Stage 2 classifier pool

### DIFF
--- a/src/llm/classifier_examples.py
+++ b/src/llm/classifier_examples.py
@@ -79,6 +79,16 @@ _NEEDS_INTERNET: list[LabeledExample] = [
     {"query": "help me figure out when the next iPhone is releasing", "label": "needs_internet"},
     {"query": "help me find out the current price of Tesla stock", "label": "needs_internet"},
     {"query": "find me the latest news about the AI industry", "label": "needs_internet"},
+    # General-knowledge counter-anchors: ensure the "tell me about X",
+    # "describe X", and "what do you know about X" openings have ground
+    # truth on the needs_internet side too. Without these, queries about
+    # external concepts route to vault_answerable because the only
+    # "tell me about X" / "describe X" exemplars in the pool are personal
+    # ("tell me about my goals", "describe me"). Paired with personal-
+    # identity exemplars in _VAULT_ANSWERABLE to prevent mirror drift.
+    {"query": "tell me about quantum computing", "label": "needs_internet"},
+    {"query": "describe how transformers work", "label": "needs_internet"},
+    {"query": "what do you know about Rust", "label": "needs_internet"},
 ]
 
 
@@ -141,6 +151,17 @@ _VAULT_ANSWERABLE: list[LabeledExample] = [
     {"query": "I keep going back and forth on it", "label": "vault_answerable"},
     {"query": "I haven't been able to work that out", "label": "vault_answerable"},
     {"query": "that's what I've been trying to understand", "label": "vault_answerable"},
+    # Personal-identity exemplars (G6 drift fix). The pool previously had
+    # no strong "who am I" / "describe me" anchors; "who am I" was
+    # cosine-matching needs_internet "who is X" patterns at ~0.79.
+    # Paired with general-knowledge counter-anchors in _NEEDS_INTERNET
+    # to prevent mirror drift on "tell me about X" / "describe X" /
+    # "what do you know about X" general queries.
+    {"query": "who am I", "label": "vault_answerable"},
+    {"query": "describe me", "label": "vault_answerable"},
+    {"query": "what kind of person am I", "label": "vault_answerable"},
+    {"query": "tell me about myself", "label": "vault_answerable"},
+    {"query": "what do you know about who I am", "label": "vault_answerable"},
 ]
 
 

--- a/tests/eval/test_intent_classifier_calibration.py
+++ b/tests/eval/test_intent_classifier_calibration.py
@@ -59,33 +59,17 @@ _NEEDS_INTERNET_QUERIES = [
 ]
 
 
-# Note on the "who am I" case: at the time of writing (v0.18.0,
-# nomic-embed-text on the current example pool) this query routes to
-# needs_internet with confidence ~0.79 -- the cosine top-1 against the
-# 60-example pool is a "current X" / "who is X" public-info exemplar.
-# It is the canonical drift signal for this calibration test: the
-# example pool has no strong personal-identity exemplar, so the
-# query lands on the wrong side of the threshold. Marked xfail(
-# strict=False) so the calibration suite exits green while the drift
-# stays visible in the report. Resolution path: add a "who am I" /
-# "tell me about myself" exemplar to src/llm/classifier_examples.py
-# (handled outside this commit, no production code changes).
+# The earlier xfail on "who am I" (Stage 2 drift to needs_internet at
+# ~0.79 cosine) was resolved by adding personal-identity exemplars to
+# classifier_examples.py along with general-knowledge counter-anchors
+# on the needs_internet side. The query now routes correctly. Plain
+# string entry restored; if the calibration regresses, the test will
+# fail strictly rather than xfail.
 _VAULT_ANSWERABLE_QUERIES = [
     pytest.param("what have I been working on", id="what have I been working on"),
     pytest.param("how have I been doing lately", id="how have I been doing lately"),
     pytest.param("what are my open loops", id="what are my open loops"),
-    pytest.param(
-        "who am I",
-        id="who am I",
-        marks=pytest.mark.xfail(
-            strict=False,
-            reason=(
-                "Known Stage 2 drift: 'who am I' routes to needs_internet "
-                "(~0.79 cosine) due to missing personal-identity exemplar "
-                "in classifier_examples.py. Surfaced; not blocking."
-            ),
-        ),
-    ),
+    pytest.param("who am I", id="who am I"),
     pytest.param("what's my current focus", id="what's my current focus"),
 ]
 


### PR DESCRIPTION
## Summary
- Adds 5 personal-identity exemplars (`who am I`, `describe me`, `what kind of person am I`, `tell me about myself`, `what do you know about who I am`) to `_VAULT_ANSWERABLE`.
- Adds 3 general-knowledge counter-anchors (`tell me about quantum computing`, `describe how transformers work`, `what do you know about Rust`) to `_NEEDS_INTERNET` to prevent mirror drift on `tell me about X` / `describe X` openings.
- Removes the `xfail(strict=False)` block on `"who am I"` in `tests/eval/test_intent_classifier_calibration.py` — the case now routes correctly.

## Why
Before this change, `"who am I"` was cosine-matching `needs_internet` `who is X` patterns at ~0.79. The pool had no strong personal-identity anchor, so the query landed on the wrong side of the threshold. The G6 drift xfail was the canonical surface for this gap.

## Test plan
- [x] Tier 1: `pytest tests/ -q` — 1995 passed, 47 deselected
- [x] Targeted: `pytest tests/eval/test_intent_classifier_calibration.py tests/test_intent_classifier.py -q` — 108 passed
- [x] Eval gate before merge (retrieval eval)

## Notes
Rebased onto current main (PR #64 added introspective-uncertainty + imperative-help-with-factual-anchor families to the same lists). Conflict resolved by keeping both sets of additions; ordering preserved (PR #64's blocks first, then this PR's).