### PR TITLE
fix(privacy): gate diagnostic logs behind EMBER_DEBUG and classifier telemetry flag

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 logger = logging.getLogger("ember.openai_adapter")
 
 from src.api.limiter import limiter
+from src.core.config import get_ember_debug
 from src.memory.service import MemoryService
 from src.memory.write_memory import write_memory
 from src.memory.session import create_session, session_exists, get_session, list_sessions
@@ -45,6 +46,60 @@ def _is_refusal_response(text: str) -> bool:
         return False
     lowered = text.lower()
     return any(m in lowered for m in _REFUSAL_PATTERNS)
+
+
+def _log_payload_diagnostics(raw_json: dict) -> None:
+    """Log incoming chat completion payload structure for diagnostics.
+
+    Defensive gate: callers should already check get_ember_debug() before
+    invoking this helper, but the helper re-checks so that no payload
+    content can leak via a future caller that forgets to gate.
+    """
+    if not get_ember_debug():
+        return
+    logger.warning("[PAYLOAD] top-level keys: %s", list(raw_json.keys()))
+    for i, msg in enumerate(raw_json.get("messages", [])):
+        role = msg.get("role")
+        content = msg.get("content")
+        if isinstance(content, list):
+            logger.warning(
+                "[PAYLOAD] messages[%d] role=%s content=LIST len=%d parts=%s",
+                i, role, len(content),
+                [p.get("type") for p in content if isinstance(p, dict)],
+            )
+            for j, part in enumerate(content):
+                if isinstance(part, dict):
+                    part_type = part.get("type", "unknown")
+                    if part_type == "text":
+                        logger.warning(
+                            "[PAYLOAD]   part[%d] type=text len=%d content=%s",
+                            j, len(part.get("text", "")), part.get("text", "")[:120],
+                        )
+                    elif part_type == "image_url":
+                        img = part.get("image_url", {})
+                        url_val = img.get("url", "")
+                        logger.warning(
+                            "[PAYLOAD]   part[%d] type=image_url image_url.keys=%s url.len=%d url.prefix=%s",
+                            j, list(img.keys()), len(url_val), url_val[:80],
+                        )
+                    else:
+                        logger.warning(
+                            "[PAYLOAD]   part[%d] type=%s keys=%s snippet=%s",
+                            j, part_type, list(part.keys()), str(part)[:200],
+                        )
+        else:
+            content_len = len(content) if content else 0
+            if role == "system":
+                logger.warning(
+                    "[PAYLOAD] messages[%d] role=system len=%d FULL_CONTENT=%s",
+                    i, content_len, repr(content),
+                )
+            else:
+                snippet = str(content)[:120] if content else ""
+                logger.warning(
+                    "[PAYLOAD] messages[%d] role=%s content=STR len=%s snippet=%s",
+                    i, role, content_len, snippet,
+                )
 
 
 # MEMORY_PREVIEW_LENGTH removed -- full conversation text is now stored
@@ -760,55 +815,15 @@ def _ensure_session(session_id: str, first_user_message: str, *, test: bool = Fa
 @limiter.limit("30/minute")
 async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # --- FILE UPLOAD DIAGNOSTIC LOGGING ---
-    try:
-        raw_body = await request.body()
-        raw_json = json.loads(raw_body)
-        logger.warning("[PAYLOAD] top-level keys: %s", list(raw_json.keys()))
-        for i, msg in enumerate(raw_json.get("messages", [])):
-            role = msg.get("role")
-            content = msg.get("content")
-            if isinstance(content, list):
-                logger.warning(
-                    "[PAYLOAD] messages[%d] role=%s content=LIST len=%d parts=%s",
-                    i, role, len(content),
-                    [p.get("type") for p in content if isinstance(p, dict)],
-                )
-                for j, part in enumerate(content):
-                    if isinstance(part, dict):
-                        part_type = part.get("type", "unknown")
-                        if part_type == "text":
-                            logger.warning(
-                                "[PAYLOAD]   part[%d] type=text len=%d content=%s",
-                                j, len(part.get("text", "")), part.get("text", "")[:120],
-                            )
-                        elif part_type == "image_url":
-                            img = part.get("image_url", {})
-                            url_val = img.get("url", "")
-                            logger.warning(
-                                "[PAYLOAD]   part[%d] type=image_url image_url.keys=%s url.len=%d url.prefix=%s",
-                                j, list(img.keys()), len(url_val), url_val[:80],
-                            )
-                        else:
-                            logger.warning(
-                                "[PAYLOAD]   part[%d] type=%s keys=%s snippet=%s",
-                                j, part_type, list(part.keys()), str(part)[:200],
-                            )
-            else:
-                content_len = len(content) if content else 0
-                # Log full content for system messages so we can see injected context
-                if role == "system":
-                    logger.warning(
-                        "[PAYLOAD] messages[%d] role=system len=%d FULL_CONTENT=%s",
-                        i, content_len, repr(content),
-                    )
-                else:
-                    snippet = str(content)[:120] if content else ""
-                    logger.warning(
-                        "[PAYLOAD] messages[%d] role=%s content=STR len=%s snippet=%s",
-                        i, role, content_len, snippet,
-                    )
-    except Exception as exc:
-        logger.warning("[PAYLOAD] failed to log raw request: %s", exc)
+    # Gated behind EMBER_DEBUG so query/payload content does not enter
+    # stdout by default. See CLAUDE.md vault privacy rule.
+    if get_ember_debug():
+        try:
+            raw_body = await request.body()
+            raw_json = json.loads(raw_body)
+            _log_payload_diagnostics(raw_json)
+        except Exception as exc:
+            logger.warning("[PAYLOAD] failed to log raw request: %s", exc)
     # --- END DIAGNOSTIC LOGGING ---
 
     # --- SESSION ID ---

--- a/src/context/policies.py
+++ b/src/context/policies.py
@@ -4,6 +4,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 
+from src.core.config import get_ember_debug
 from src.llm.intent_classifier import NEEDS_INTERNET, classify_intent
 
 logger = logging.getLogger("ember.policies")
@@ -136,7 +137,10 @@ def classify_query(user_message: str) -> ContextPolicy:
     # Normalize curly apostrophes to straight so markers like "what's" match
     # regardless of input source (Open WebUI, mobile keyboards, etc.)
     q = q.replace("\u2018", "'").replace("\u2019", "'")
-    logger.warning("[CLASSIFY] normalized query: %s", q[:120])
+    if get_ember_debug():
+        # Gated behind EMBER_DEBUG: query content is vault-adjacent and must
+        # not enter stdout by default. See CLAUDE.md vault privacy rule.
+        logger.warning("[CLASSIFY] normalized query: %s", q[:120])
 
     # Stage 0: explicit web-search request. User-stated instruction, not
     # intent inference — bypass ask-first and skip the intent classifier.

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -171,6 +171,28 @@ def get_intent_classifier_timeout_ms() -> int:
     return int(os.getenv("INTENT_CLASSIFIER_TIMEOUT_MS", "800"))
 
 
+def get_ember_debug() -> bool:
+    """Return True when EMBER_DEBUG is enabled.
+
+    Gates diagnostic logs that may include query, response, or vault
+    content. Evaluated at call time so toggling the env var without an
+    API restart still takes effect on the next call. Default is False so
+    privacy-sensitive diagnostics stay off unless an operator opts in.
+    """
+    return os.getenv("EMBER_DEBUG", "").lower() in ("1", "true", "yes")
+
+
+def get_ember_classifier_telemetry() -> bool:
+    """Return True when EMBER_CLASSIFIER_TELEMETRY is enabled.
+
+    Gates the per-call intent classification training-pipeline log line
+    (ADR-034 Upgrade Path). Separate from EMBER_DEBUG so the SetFit
+    training feed can run with scrubbed query telemetry independently of
+    full diagnostic logging. Default False.
+    """
+    return os.getenv("EMBER_CLASSIFIER_TELEMETRY", "").lower() in ("1", "true", "yes")
+
+
 def get_ember_vision_model() -> str | None:
     """
     Returns the Ollama vision model for image analysis, or None if not configured.

--- a/src/llm/classifier_examples.py
+++ b/src/llm/classifier_examples.py
@@ -10,8 +10,13 @@ examples designed to span the classification failure modes Stage 2 must
 handle.
 
 As production traffic accumulates in the [INTENT_CLASSIFY] log pipeline,
-real representative queries can be added to this list (with any personal
-content paraphrased / stripped). Target: 80 per class for stable accuracy;
+real representative queries can be added to this list. Note: the
+telemetry log line is gated behind EMBER_CLASSIFIER_TELEMETRY and the
+query is scrubbed via _scrub_for_telemetry before logging — multi-word
+Title Case sequences, 4+ digit runs, and emails are replaced with
+placeholders. Single-word proper nouns and most surface phrasing are
+preserved. Operators may want to paraphrase further before promoting a
+scrubbed query into this pool. Target: 80 per class for stable accuracy;
 upgrade to SetFit at 150 per class per ADR-034 Upgrade Path.
 """
 

--- a/src/llm/intent_classifier.py
+++ b/src/llm/intent_classifier.py
@@ -30,7 +30,12 @@ import re
 import numpy as np
 import ollama
 
-from src.core.config import get_ember_model, get_intent_classifier_timeout_ms
+from src.core.config import (
+    get_ember_classifier_telemetry,
+    get_ember_debug,
+    get_ember_model,
+    get_intent_classifier_timeout_ms,
+)
 from src.retrieval.embed_memory import embed_text, embed_texts
 
 logger = logging.getLogger("ember.intent_classifier")
@@ -185,10 +190,13 @@ def _get_example_embeddings() -> tuple[list[str], np.ndarray] | None:
         _example_embeddings = (labels, matrix)
         return _example_embeddings
     except Exception as exc:
-        logger.warning(
-            "[INTENT_CLASSIFY] Stage 2 example embedding load failed (non-fatal): %s",
-            exc,
-        )
+        if get_ember_debug():
+            # Exception payload may include text from the example pool; gate
+            # behind EMBER_DEBUG so it does not enter stdout by default.
+            logger.warning(
+                "[INTENT_CLASSIFY] Stage 2 example embedding load failed (non-fatal): %s",
+                exc,
+            )
         return None
 
 
@@ -210,10 +218,12 @@ def _stage2_classify(query: str) -> tuple[str | None, float | None]:
     try:
         query_emb = embed_text(query)
     except Exception as exc:
-        logger.warning(
-            "[INTENT_CLASSIFY] Stage 2 query embed failed (non-fatal): %s",
-            exc,
-        )
+        if get_ember_debug():
+            # Exception payload may echo the query; gate behind EMBER_DEBUG.
+            logger.warning(
+                "[INTENT_CLASSIFY] Stage 2 query embed failed (non-fatal): %s",
+                exc,
+            )
         return None, None
 
     query_vec = np.asarray(query_emb, dtype=np.float32)
@@ -278,13 +288,18 @@ def _stage3_llm_call(query: str) -> str:
         label = data.get("label")
         if label in _VALID_LABELS:
             return label
-        logger.warning(
-            "[INTENT_CLASSIFY] Stage 3 returned unknown label: %r", label
-        )
+        if get_ember_debug():
+            logger.warning(
+                "[INTENT_CLASSIFY] Stage 3 returned unknown label: %r", label
+            )
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
-        logger.warning("[INTENT_CLASSIFY] Stage 3 JSON parse failed: %s", exc)
+        if get_ember_debug():
+            # Exception may include raw LLM output that echoes the query.
+            logger.warning("[INTENT_CLASSIFY] Stage 3 JSON parse failed: %s", exc)
     except Exception as exc:
-        logger.warning("[INTENT_CLASSIFY] Stage 3 LLM call failed: %s", exc)
+        if get_ember_debug():
+            # Exception may include the request payload sent to Ollama.
+            logger.warning("[INTENT_CLASSIFY] Stage 3 LLM call failed: %s", exc)
     return _SAFE_DEFAULT
 
 
@@ -338,16 +353,52 @@ def classify_intent(query: str) -> str:
     return stage3_label
 
 
+_PROPER_NOUN_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b")
+_DIGIT_RUN_RE = re.compile(r"\b\d{4,}\b")
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w.-]+\.\w+\b")
+
+
+def _scrub_for_telemetry(query: str) -> str:
+    """Strip PII-like tokens from a query before logging to telemetry.
+
+    Preserves intent-discriminative structure (interrogative words, verbs,
+    possessive markers) while replacing multi-word Title Case sequences
+    with [PROPER], 4+ digit runs with [NUM], and email addresses with
+    [EMAIL]. Output is ASCII-only and truncated to 60 chars.
+
+    Single-word proper nouns and the first capitalized word of a sentence
+    are not stripped; the latter would over-fire on every query that
+    starts with "What", "Where", etc. The privacy/utility tradeoff is
+    noted in classifier_examples.py.
+    """
+    if not query:
+        return ""
+    scrubbed = _EMAIL_RE.sub("[EMAIL]", query)
+    scrubbed = _PROPER_NOUN_RE.sub("[PROPER]", scrubbed)
+    scrubbed = _DIGIT_RUN_RE.sub("[NUM]", scrubbed)
+    scrubbed = scrubbed.encode("ascii", "ignore").decode("ascii")
+    return scrubbed[:60]
+
+
 def _log(stage: str, label: str, confidence: float | None, query: str) -> None:
     """Emit the structured classification log line.
 
+    Gated behind EMBER_CLASSIFIER_TELEMETRY (separate from EMBER_DEBUG)
+    so the ADR-034 training-data pipeline can run independently of full
+    diagnostic logging. Returns silently when telemetry is unset.
+
+    Query is scrubbed via _scrub_for_telemetry before logging — proper
+    nouns, digit runs, and emails are replaced with placeholders. The
+    raw query never enters stdout from this call.
+
     ASCII-only to avoid Windows cp1252 corruption (CLAUDE.md rule 7).
-    Query is truncated to 200 chars per ADR-034 logging spec.
     """
+    if not get_ember_classifier_telemetry():
+        return
     logger.info(
         "[INTENT_CLASSIFY] stage=%s label=%s confidence=%s query=%s",
         stage,
         label,
         "none" if confidence is None else f"{confidence:.3f}",
-        query[:200],
+        _scrub_for_telemetry(query),
     )

--- a/tests/test_diagnostic_privacy.py
+++ b/tests/test_diagnostic_privacy.py
@@ -1,0 +1,274 @@
+"""
+tests/test_diagnostic_privacy.py
+
+Diagnostic-surface privacy gating tests.
+
+The Ember-2 vault privacy rule requires that query, response, and
+vault-adjacent content never enter stdout by default. This file asserts:
+
+  * EMBER_DEBUG gates the [PAYLOAD] block in openai_adapter,
+    the [CLASSIFY] normalized-query log in policies, and the
+    [INTENT_CLASSIFY] warning lines in intent_classifier.
+  * EMBER_CLASSIFIER_TELEMETRY (separate flag) gates the per-call
+    [INTENT_CLASSIFY] stage=... query=... structured log used by the
+    ADR-034 SetFit training pipeline.
+  * The _scrub_for_telemetry helper preserves intent-discriminative
+    structure while removing multi-word Title Case proper nouns,
+    4+ digit runs, and email addresses; output is ASCII-only and
+    truncated to 60 chars.
+  * Gates evaluate at call time, not at import time, so toggling
+    EMBER_DEBUG / EMBER_CLASSIFIER_TELEMETRY without a process restart
+    takes effect on the next call.
+
+All test fixtures are synthetic. No vault content appears in this file.
+ASCII only.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.context.policies import classify_query
+from src.core.config import get_ember_classifier_telemetry, get_ember_debug
+from src.llm.intent_classifier import _scrub_for_telemetry, classify_intent
+
+
+# ---------------------------------------------------------------------------
+# Config reader behavior
+# ---------------------------------------------------------------------------
+
+
+def test_get_ember_debug_default_false(monkeypatch):
+    monkeypatch.delenv("EMBER_DEBUG", raising=False)
+    assert get_ember_debug() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
+def test_get_ember_debug_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("EMBER_DEBUG", value)
+    assert get_ember_debug() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "False"])
+def test_get_ember_debug_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("EMBER_DEBUG", value)
+    assert get_ember_debug() is False
+
+
+def test_get_ember_classifier_telemetry_default_false(monkeypatch):
+    monkeypatch.delenv("EMBER_CLASSIFIER_TELEMETRY", raising=False)
+    assert get_ember_classifier_telemetry() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes"])
+def test_get_ember_classifier_telemetry_truthy(monkeypatch, value):
+    monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", value)
+    assert get_ember_classifier_telemetry() is True
+
+
+# ---------------------------------------------------------------------------
+# Scrub helper
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_empty_string():
+    assert _scrub_for_telemetry("") == ""
+
+
+def test_scrub_preserves_question_structure():
+    result = _scrub_for_telemetry("what are my current projects this week")
+    assert "what" in result
+    assert "my current projects" in result
+
+
+def test_scrub_strips_multiword_title_case():
+    result = _scrub_for_telemetry("what is the weather in New York City today")
+    assert "[PROPER]" in result
+    assert "New York City" not in result
+
+
+def test_scrub_preserves_single_word_capitalized_tokens():
+    # Documented behavior per the plan: single-word Title Case tokens
+    # are not stripped. Avoids over-firing on sentence-initial capitals.
+    result = _scrub_for_telemetry("weather in Richmond today")
+    assert "Richmond" in result
+
+
+def test_scrub_strips_digit_runs():
+    result = _scrub_for_telemetry("current population is 7800000 people")
+    assert "[NUM]" in result
+    assert "7800000" not in result
+
+
+def test_scrub_preserves_short_digit_runs():
+    # 3 digits or fewer are not stripped (years, small counts).
+    result = _scrub_for_telemetry("year 999 happened")
+    assert "999" in result
+
+
+def test_scrub_strips_emails():
+    result = _scrub_for_telemetry("forward to user@example.com please")
+    assert "[EMAIL]" in result
+    assert "user@example.com" not in result
+
+
+def test_scrub_truncates_to_60_chars():
+    long_q = (
+        "what is the current state of the housing market in the western "
+        "united states today and what does the latest data say"
+    )
+    result = _scrub_for_telemetry(long_q)
+    assert len(result) <= 60
+
+
+def test_scrub_drops_non_ascii():
+    result = _scrub_for_telemetry("what is the weather today éclat")
+    # Non-ASCII bytes are stripped. é in eclat must not survive.
+    assert "é" not in result
+    # ASCII letters around the non-ASCII char survive
+    assert "what is the weather today" in result
+
+
+# ---------------------------------------------------------------------------
+# Gate: [CLASSIFY] normalized query log in policies.py
+# ---------------------------------------------------------------------------
+
+
+def test_classify_log_silent_when_ember_debug_unset(monkeypatch, caplog):
+    monkeypatch.delenv("EMBER_DEBUG", raising=False)
+    caplog.set_level(logging.WARNING, logger="ember.policies")
+    classify_query("what is the weather today")
+    classify_records = [
+        r for r in caplog.records
+        if "[CLASSIFY] normalized query" in r.getMessage()
+    ]
+    assert classify_records == []
+
+
+def test_classify_log_emits_when_ember_debug_set(monkeypatch, caplog):
+    monkeypatch.setenv("EMBER_DEBUG", "true")
+    caplog.set_level(logging.WARNING, logger="ember.policies")
+    classify_query("what is the weather today")
+    classify_records = [
+        r for r in caplog.records
+        if "[CLASSIFY] normalized query" in r.getMessage()
+    ]
+    assert len(classify_records) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Gate: [INTENT_CLASSIFY] structured telemetry log
+# ---------------------------------------------------------------------------
+
+
+def test_intent_telemetry_silent_when_unset(monkeypatch, caplog):
+    monkeypatch.delenv("EMBER_CLASSIFIER_TELEMETRY", raising=False)
+    caplog.set_level(logging.INFO, logger="ember.intent_classifier")
+    # "thank you" is a Stage 1 conversational ack so no Ollama call is needed.
+    classify_intent("thank you")
+    telemetry_records = [
+        r for r in caplog.records
+        if "[INTENT_CLASSIFY] stage=" in r.getMessage()
+    ]
+    assert telemetry_records == []
+
+
+def test_intent_telemetry_emits_when_set(monkeypatch, caplog):
+    monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
+    caplog.set_level(logging.INFO, logger="ember.intent_classifier")
+    classify_intent("thank you")
+    telemetry_records = [
+        r for r in caplog.records
+        if "[INTENT_CLASSIFY] stage=" in r.getMessage()
+    ]
+    assert len(telemetry_records) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Gate: _log_payload_diagnostics helper in openai_adapter.py
+# ---------------------------------------------------------------------------
+
+
+def _fake_payload() -> dict:
+    return {
+        "messages": [
+            {"role": "user", "content": "synthetic test payload one"},
+            {"role": "system", "content": "synthetic system payload"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "synthetic part two"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                ],
+            },
+        ]
+    }
+
+
+def test_payload_diagnostics_silent_when_unset(monkeypatch, caplog):
+    monkeypatch.delenv("EMBER_DEBUG", raising=False)
+    caplog.set_level(logging.WARNING, logger="ember.openai_adapter")
+    from src.api.openai_adapter import _log_payload_diagnostics
+    _log_payload_diagnostics(_fake_payload())
+    payload_records = [
+        r for r in caplog.records if "[PAYLOAD]" in r.getMessage()
+    ]
+    assert payload_records == []
+
+
+def test_payload_diagnostics_emits_when_set(monkeypatch, caplog):
+    monkeypatch.setenv("EMBER_DEBUG", "true")
+    caplog.set_level(logging.WARNING, logger="ember.openai_adapter")
+    from src.api.openai_adapter import _log_payload_diagnostics
+    _log_payload_diagnostics(_fake_payload())
+    payload_records = [
+        r for r in caplog.records if "[PAYLOAD]" in r.getMessage()
+    ]
+    assert len(payload_records) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Call-time evaluation (no cached gate at import)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_gate_evaluated_at_call_time(monkeypatch, caplog):
+    monkeypatch.delenv("EMBER_DEBUG", raising=False)
+    caplog.set_level(logging.WARNING, logger="ember.policies")
+
+    classify_query("first call should be silent")
+    silent_count = len([
+        r for r in caplog.records
+        if "[CLASSIFY] normalized query" in r.getMessage()
+    ])
+
+    monkeypatch.setenv("EMBER_DEBUG", "true")
+    classify_query("second call should emit")
+    set_count = len([
+        r for r in caplog.records
+        if "[CLASSIFY] normalized query" in r.getMessage()
+    ])
+
+    assert set_count > silent_count
+
+
+def test_telemetry_gate_evaluated_at_call_time(monkeypatch, caplog):
+    monkeypatch.delenv("EMBER_CLASSIFIER_TELEMETRY", raising=False)
+    caplog.set_level(logging.INFO, logger="ember.intent_classifier")
+
+    classify_intent("thank you")
+    silent_count = len([
+        r for r in caplog.records
+        if "[INTENT_CLASSIFY] stage=" in r.getMessage()
+    ])
+
+    monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
+    classify_intent("thank you")
+    set_count = len([
+        r for r in caplog.records
+        if "[INTENT_CLASSIFY] stage=" in r.getMessage()
+    ])
+
+    assert set_count > silent_count

--- a/tests/test_intent_classifier.py
+++ b/tests/test_intent_classifier.py
@@ -251,7 +251,11 @@ class TestClassifyIntentPublicAPI:
     def test_empty_query_falls_back_to_safe_default(self):
         assert classify_intent("") == "vault_answerable"
 
-    def test_stage1_log_line_emitted(self, caplog):
+    def test_stage1_log_line_emitted(self, caplog, monkeypatch):
+        # Telemetry log is gated behind EMBER_CLASSIFIER_TELEMETRY so the
+        # SetFit training pipeline can opt in without exposing query content
+        # by default. Enable the gate here to observe the log structure.
+        monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
         with caplog.at_level("INFO", logger="ember.intent_classifier"):
             classify_intent("what's the weather today")
         matches = [r for r in caplog.records if "[INTENT_CLASSIFY]" in r.message]
@@ -443,6 +447,7 @@ class TestClassifyIntentStage2Flow:
             ]
         )
         monkeypatch.setattr(intent_classifier, "embed_text", lambda q: [1.0, 0.0])
+        monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
         # Use a query that escapes Stage 1 so Stage 2 actually runs.
         query = "tell me what's going on with the project"
         with caplog.at_level("INFO", logger="ember.intent_classifier"):
@@ -472,6 +477,7 @@ class TestClassifyIntentStage2Flow:
             "_stage3_classify_with_timeout",
             lambda q: ("needs_internet", False),
         )
+        monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
         query = "genuinely ambiguous external question with no keyword signals"
         with caplog.at_level("INFO", logger="ember.intent_classifier"):
             label = classify_intent(query)
@@ -595,6 +601,7 @@ class TestClassifyIntentStage3Flow:
             "_stage3_classify_with_timeout",
             lambda q: ("vault_answerable", True),
         )
+        monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
         query = "intentionally hard to classify without signal"
         with caplog.at_level("INFO", logger="ember.intent_classifier"):
             label = classify_intent(query)
@@ -617,6 +624,7 @@ class TestClassifyIntentStage3Flow:
             "_stage3_classify_with_timeout",
             lambda q: ("needs_internet", False),
         )
+        monkeypatch.setenv("EMBER_CLASSIFIER_TELEMETRY", "true")
         query = "something that only the LLM can resolve cleanly"
         with caplog.at_level("INFO", logger="ember.intent_classifier"):
             label = classify_intent(query)


### PR DESCRIPTION
## Summary

Per-call audit of diagnostic surfaces that touched query, response, or vault-adjacent content. Each call site is gated individually behind an env var; production logger config is untouched.

**Gated behind `EMBER_DEBUG` (default false):**
- `[PAYLOAD]` block in `src/api/openai_adapter.py` — extracted into `_log_payload_diagnostics()` helper with a defensive in-helper gate
- `[CLASSIFY] normalized query` in `src/context/policies.py:139`
- `[INTENT_CLASSIFY]` Stage 2 / Stage 3 warning lines in `src/llm/intent_classifier.py` whose exception payloads may echo the query

**Gated behind separate `EMBER_CLASSIFIER_TELEMETRY` (default false):**
- `[INTENT_CLASSIFY] stage=... query=...` per-call log feeding the ADR-034 SetFit training pipeline
- Query is scrubbed via new `_scrub_for_telemetry()`: multi-word Title Case to `[PROPER]`, 4+ digit runs to `[NUM]`, emails to `[EMAIL]`; ASCII-only; truncated to 60 chars
- Single-word proper nouns and surface phrasing preserved so intent-discriminative structure survives

Both gates evaluate at call time, so toggling without an API restart takes effect on the next call.

This is the standalone hotfix from the v0.18.0 UAT findings plan (item 1). Workstream A/B/C have not started — pausing for review before item 10 (B-CTX-001/B-TOK-001 verification gate) and the B1 Stage 2 confidence measurement.

## Test plan

- [x] Full pytest: 2060 passed, 50 deselected
- [x] New `tests/test_diagnostic_privacy.py`: 33 tests covering config readers, scrub helper edge cases, gate enforcement at each call site, and call-time evaluation
- [x] `tests/test_intent_classifier.py`: 5 tests that assert the telemetry log line is emitted now set `EMBER_CLASSIFIER_TELEMETRY=true` to observe the same structural behavior under the new gate
- [ ] Live verification: start the API with no flags set, send a chat completion, confirm no query/response text in stdout
- [ ] Live verification: start the API with `EMBER_DEBUG=true`, send a chat completion, confirm diagnostic content returns

## Files

- `src/core/config.py` — `get_ember_debug()`, `get_ember_classifier_telemetry()`
- `src/api/openai_adapter.py` — refactored PAYLOAD block, gated
- `src/context/policies.py` — gated CLASSIFY query log
- `src/llm/intent_classifier.py` — gated 5 warning sites + telemetry gate + scrub helper
- `src/llm/classifier_examples.py` — comment updated to note scrubbed telemetry
- `tests/test_diagnostic_privacy.py` — new
- `tests/test_intent_classifier.py` — 5 tests updated for new gate