### PR TITLE
test(eval): raise B-CTX-001 per-turn timeout to 300s

### DIFF
--- a/tests/eval/test_context_coherence.py
+++ b/tests/eval/test_context_coherence.py
@@ -82,7 +82,13 @@ JUDGE_SYSTEM = (
 )
 
 # Default per-turn timeout. Generous to accommodate qwen3:8b at peak load.
-PER_TURN_TIMEOUT_S = 180.0
+# Raised from 180.0 to 300.0 after two consecutive timeouts at the 180s
+# cap on this hardware. Late-conversation turns at context_length=32768
+# can exceed 180s on qwen3:8b warm; the test measures coherence, not
+# latency, so a higher cap is correct here. See
+# docs/audits/b1_stage2_confidence_v018.md for the broader throughput
+# pattern this is part of.
+PER_TURN_TIMEOUT_S = 300.0
 
 LOG_DIR = REPO_ROOT / "logs" / "eval_conversations"
 


### PR DESCRIPTION
## Summary

Two consecutive runs of \`test_b_ctx_001_in_session_coherence\` hit \`httpx.ReadTimeout\` at the 180s per-turn cap on a late-conversation turn (overall elapsed ~17-19 minutes across 10 turns). Raising to 300s.

The cap exists to prevent indefinite hangs, not to assert latency — the test measures coherence across \`context_length=32768\`. On \`qwen3:8b\` warm, per-turn average lands near 100s but grief-themed late turns (with constitutional review + full retrieval) exceed 180s on this hardware. The new cap preserves the hang-prevention intent without masking what the test measures.

Same family of throughput observation as the v0.18.0 B1 Stage 2 audit. See \`docs/audits/b1_stage2_confidence_v018.md\`.

## Test plan

- [ ] After merge, run \`pytest tests/eval/test_context_coherence.py::test_b_ctx_001_in_session_coherence -m eval -v\` once and confirm pass
- [ ] Capture verdict + sub-checks into release notes as the item 10 gate result