### PR TITLE
fix(intent): raise Stage 3 timeout to 1500ms

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -164,11 +164,18 @@ def get_retrieval_min_raw_score() -> float:
 def get_intent_classifier_timeout_ms() -> int:
     """Hard timeout for Stage 3 of the ADR-034 intent classifier.
 
-    Per ADR-034, Stage 3 calls qwen3:8b in non-thinking mode; 800ms is
-    a conservative cap on target hardware. On timeout the classifier
-    falls back to vault_answerable (the behavioral-contract-safe default).
+    Per ADR-034, Stage 3 calls qwen3:8b in non-thinking mode. The default
+    cap is 1500ms on target hardware: the B1 audit (docs/audits/b1_stage2_
+    confidence_v018.md) measured 5/5 Stage 3 timeouts at 830-857ms under
+    the prior 800ms cap, meaning the safe-default fired in place of any
+    real Stage 3 decision. Raising to 1500ms lets the prompt content
+    influence outcome on ambiguous queries while preserving the bounded
+    worst-case latency contribution.
+
+    On timeout the classifier still falls back to vault_answerable (the
+    behavioral-contract-safe default).
     """
-    return int(os.getenv("INTENT_CLASSIFIER_TIMEOUT_MS", "800"))
+    return int(os.getenv("INTENT_CLASSIFIER_TIMEOUT_MS", "1500"))
 
 
 def get_ember_debug() -> bool:

--- a/src/llm/intent_classifier.py
+++ b/src/llm/intent_classifier.py
@@ -10,10 +10,10 @@ Classifies each user query as either:
 Architecture (ADR-034):
   Stage 1  Structural rules with compound first-person guard   ~2ms
   Stage 2  Embedding similarity against labeled examples       ~30-50ms
-  Stage 3  qwen3:8b non-thinking with JSON grammar, 800ms cap  ~300-800ms
+  Stage 3  qwen3:8b non-thinking with JSON grammar, 1500ms cap ~300-1500ms
 
 Stage 3 runs qwen3:8b in a background thread with a hard timeout read
-from INTENT_CLASSIFIER_TIMEOUT_MS (default 800ms). On timeout, the
+from INTENT_CLASSIFIER_TIMEOUT_MS (default 1500ms). On timeout, the
 classifier returns the safe default (vault_answerable) per the ADR-034
 behavioral contract.
 
@@ -256,7 +256,7 @@ def _stage2_classify(query: str) -> tuple[str | None, float | None]:
 # a stuck Ollama call would cascade-timeout every subsequent Stage 3 query
 # because later submissions would queue behind it. Per-call executors let
 # concurrent classify_intent calls attempt Stage 3 in parallel; the creation
-# overhead (~2-5ms) is noise next to the 800ms budget.
+# overhead (~2-5ms) is noise next to the 1500ms budget.
 
 _STAGE3_SYSTEM_PROMPT: str = (
     "You are a binary intent classifier. Decide whether the user's query "

--- a/tests/test_intent_classifier.py
+++ b/tests/test_intent_classifier.py
@@ -583,6 +583,28 @@ class TestStage3Timeout:
         assert timed_out is True
 
 
+class TestStage3TimeoutDefault:
+    """The default Stage 3 timeout cap (B1 audit gating).
+
+    The B1 audit (docs/audits/b1_stage2_confidence_v018.md) measured 5/5
+    Stage 3 timeouts at 830-857ms under the prior 800ms default cap on
+    qwen3:8b warm latency. The default was raised to 1500ms so Stage 3
+    can actually complete on target hardware and the prompt content
+    influences the outcome rather than the safe-default firing on every
+    ambiguous query.
+
+    This test pins the default at 1500ms to prevent silent regression.
+    Operators may still override via INTENT_CLASSIFIER_TIMEOUT_MS env var.
+    """
+
+    def test_default_timeout_is_1500ms(self, monkeypatch):
+        # Clear any override so we observe the code default.
+        monkeypatch.delenv("INTENT_CLASSIFIER_TIMEOUT_MS", raising=False)
+        from src.core.config import get_intent_classifier_timeout_ms
+
+        assert get_intent_classifier_timeout_ms() == 1500
+
+
 class TestClassifyIntentStage3Flow:
     """Stage 3 result flows through classify_intent's top-level log line."""
 


### PR DESCRIPTION
## Summary

Raise the Stage 3 intent classifier hard timeout from 800ms to 1500ms in `src/core/config.py`.

The B1 audit (local `docs/audits/b1_stage2_confidence_v018.md`, not tracked in git) measured 5/5 Stage 3 timeouts at 830-857ms under the prior 800ms cap. Under those conditions Stage 3 never returned a real decision on ambiguous queries — the safe-default (`vault_answerable`) fired in place of any prompt-driven outcome. The same timeout incorrectly routed 4 of 5 legitimate `needs_internet` queries to `vault_answerable`, consistent with the broader "needs_internet feels broken on novel queries" report.

This PR is **step 1 of a two-step plan**. Step 2 (a Stage 3 prompt reframe) was gated by re-measurement against the new cap. Re-measurement on the same 5 B1 fixtures showed 0/5 complete at 1500ms (queries landing at ~1506-1515ms), so step 2 defers under the locked decision tree. The 1500ms raise still ships on its own merit: it gives any Stage 3 invocation that completes in the 800-1499ms window a chance to actually decide, and matches the audit's Path 1 recommendation.

## Changes

- `src/core/config.py` — `get_intent_classifier_timeout_ms()` default raised from `"800"` to `"1500"`. Docstring expanded with the rationale and link to the B1 audit.
- `src/llm/intent_classifier.py` — module docstring and inline comment updated from `800ms` → `1500ms` references; no behavioral code change.
- `tests/test_intent_classifier.py` — new `TestStage3TimeoutDefault::test_default_timeout_is_1500ms` pins the default to prevent silent regression. Operators may still override via the `INTENT_CLASSIFIER_TIMEOUT_MS` env var.

No behavioral change to the slow-LLM-times-out path: when Stage 3 exceeds the (now larger) cap, the safe-default still fires.

## Test plan

- [x] Tier 1 (`pytest tests/ -q`): 2085 passed, 2 xfailed (documented B-CTX-001 residuals), 50 deselected. No regressions.
- [x] New unit test (`test_default_timeout_is_1500ms`) fails on prior code (`assert 800 == 1500`), passes on this branch.
- [x] Re-measurement on the 5 B1 fixtures under the raised cap — confirmed step 2 defers.
- [x] Tier 2 retrieval eval will run automatically on commit (post-commit hook).

## Notes

- Auto-merge **not** enabled.
- B1 step 2 (prompt sentence) deferred — see audit doc for re-measurement details. A separate latency study would inform whether to raise further or treat step 2 as permanently unreachable on this hardware.
- Plan reference: this is PR #1 of a 4-PR sequence (B1, JSON-index cleanup, adversarial eval, B2 bare-marker clarification).