### PR TITLE
chore(retrieval): retire JSON index rebuild path for profile/reflection/journal

### DIFF
--- a/scripts/rebuild_indexes.py
+++ b/scripts/rebuild_indexes.py
@@ -43,13 +43,15 @@ from src.retrieval.embedding_model import embed_texts
 BATCH_SIZE = 50
 
 # Memory types that use JSON indexes.
-# B-RET-001: "conversation" removed -- conversation records live in
-# memory.db (SQLite vector store) alongside the other migrated types.
-# The legacy file-based conversation_index.json was never read by any
-# live retrieval path and was only rebuilt by manual runs of this
-# script, producing a stale-by-default index. Stale conversation_index.json
-# files in user vaults are left in place (user data); nothing reads them.
-JSON_INDEX_TYPES = ["profile", "reflection", "journal"]
+# B-RET-001 retired "conversation" first. The follow-up cleanup retired
+# profile, reflection, and journal: src/memory/write_memory.py and
+# src/retrieval/semantic_search.py both route those types through
+# SQLITE_MEMORY_TYPES, and no live retrieval path reads the per-type
+# JSON indexes. The list is intentionally empty - any future memory
+# type that uses a JSON index would be added here, but none currently
+# do. Stale {type}_index.json files in user vaults are left in place
+# (user data); nothing live reads them.
+JSON_INDEX_TYPES = []
 
 
 def rebuild_json_index(vault: Path, memory_type: str) -> int:

--- a/src/retrieval/sqlite_vector_store.py
+++ b/src/retrieval/sqlite_vector_store.py
@@ -247,6 +247,25 @@ class SqliteVectorStore:
         row = self._conn.execute("SELECT COUNT(*) FROM vectors").fetchone()
         return row[0]
 
+    def delete_by_ids(self, ids: list[str]) -> int:
+        """Delete rows by primary key. Returns the count of rows removed.
+
+        Used by maintenance tools (tools/suppress_reflections.py) that
+        need to remove specific records from the vector index while the
+        canonical JSON records remain on disk with their suppression
+        flag. The canonical record is the source of truth; the vector
+        store is rebuildable from canonical records.
+        """
+        if not ids:
+            return 0
+        placeholders = ",".join("?" for _ in ids)
+        cursor = self._conn.execute(
+            f"DELETE FROM vectors WHERE id IN ({placeholders})",
+            ids,
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
     def close(self) -> None:
         """Close the SQLite connection."""
         self._conn.close()

--- a/tests/test_b_ret_001_dead_code_retired.py
+++ b/tests/test_b_ret_001_dead_code_retired.py
@@ -77,6 +77,44 @@ def test_rebuild_indexes_excludes_conversation() -> None:
     )
 
 
+def test_rebuild_indexes_excludes_sqlite_backed_types() -> None:
+    """All four SQLite-backed memory types (conversation, profile,
+    reflection, journal) must be absent from JSON_INDEX_TYPES.
+
+    Background: B-RET-001 retired the JSON index path for conversation
+    records once memory.db became the sole backend. The follow-up
+    cleanup extended the same treatment to profile, reflection, and
+    journal: src/memory/write_memory.py and src/retrieval/semantic_search
+    .py both route those types through SQLITE_MEMORY_TYPES, and no live
+    code reads the per-type JSON indexes. Listing any of them in
+    JSON_INDEX_TYPES would have manual rebuilds keep producing
+    stale-by-default files."""
+    import importlib.util
+    import os
+    import re
+    spec = importlib.util.spec_from_file_location(
+        "rebuild_indexes_under_test",
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "scripts",
+            "rebuild_indexes.py",
+        ),
+    )
+    if spec is None or spec.loader is None:
+        pytest.skip("Could not locate scripts/rebuild_indexes.py via spec")
+    with open(spec.origin, encoding="utf-8") as f:
+        src = f.read()
+    match = re.search(r"JSON_INDEX_TYPES\s*=\s*\[([^\]]*)\]", src)
+    assert match is not None, "JSON_INDEX_TYPES list not found in script"
+    body = match.group(1)
+    for sqlite_type in ("conversation", "profile", "reflection", "journal"):
+        assert f'"{sqlite_type}"' not in body and f"'{sqlite_type}'" not in body, (
+            f"JSON_INDEX_TYPES must not contain '{sqlite_type}' - it is "
+            f"SQLite-backed and the JSON index is orphaned."
+        )
+
+
 def test_no_stray_imports_of_search_conversation() -> None:
     """No source file in src/ should still IMPORT the deleted module.
 

--- a/tests/test_suppress_reflections.py
+++ b/tests/test_suppress_reflections.py
@@ -1,0 +1,209 @@
+"""
+tests/test_suppress_reflections.py
+
+Tests for tools/suppress_reflections.py.
+
+After the JSON_INDEX_TYPES cleanup, profile/reflection/journal records
+are no longer indexed in JSON files - memory.db (SQLite) is the sole
+backend. The suppression tool was migrated to operate on memory.db
+directly: junk records are hard-deleted from the SQLite vector store
+while their canonical JSON records remain in place with
+metadata.quality = "suppressed".
+
+Test verifies the contract:
+  - Junk record is REMOVED from memory.db (not just filtered).
+  - Canonical JSON record is FLAGGED but preserved (append-only rule).
+  - Non-junk records are untouched in both stores.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.retrieval.sqlite_vector_store import SqliteVectorStore
+
+
+# Synthetic embedding dimension - small for fast tests; SqliteVectorStore
+# does not validate dimension.
+_FAKE_EMBED_DIM = 8
+_FAKE_EMBEDDING = [0.1] * _FAKE_EMBED_DIM
+
+
+def _build_vault(tmp_path: Path) -> Path:
+    """Create a minimal test vault with reflection dir and embeddings dir."""
+    vault = tmp_path / "vault"
+    (vault / "memory" / "reflection").mkdir(parents=True)
+    (vault / "embeddings").mkdir(parents=True)
+    return vault
+
+
+def _write_canonical(reflection_dir: Path, record: dict) -> Path:
+    """Write a canonical reflection JSON record to disk."""
+    path = reflection_dir / f"{record['id']}.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+def _seed_memory_db(db_path: Path, records: list[dict]) -> None:
+    """Insert records into memory.db so the tool has rows to delete."""
+    store = SqliteVectorStore(db_path)
+    try:
+        for record in records:
+            store.insert({
+                "id": record["id"],
+                "text": record["text"],
+                "embedding": _FAKE_EMBEDDING,
+                "memory_type": "reflection",
+                "created_at": record["timestamp"],
+                "metadata": {},
+            })
+    finally:
+        store.close()
+
+
+def test_suppress_removes_junk_from_memory_db_and_flags_canonical(
+    tmp_path, monkeypatch,
+):
+    """End-to-end: suppress reads canonical, flags junk in JSON, and
+    hard-deletes the corresponding row from memory.db."""
+    vault = _build_vault(tmp_path)
+    reflection_dir = vault / "memory" / "reflection"
+    db_path = vault / "embeddings" / "memory.db"
+
+    # Junk text matches the "i'm here to help" JUNK_MARKER in
+    # tools/audit_reflections.is_junk_reflection. Padded over 100 chars
+    # to clear the minimum-length filter.
+    junk_record = {
+        "id": "2026-05-13T10-00-00",
+        "timestamp": "2026-05-13T10-00-00",
+        "type": "reflection",
+        "text": (
+            "I'm here to help with whatever you would like to discuss. "
+            "Let me clarify what I can do for you in this session."
+        ),
+        "source": "reflection_engine",
+        "tags": [],
+        "metadata": {},
+    }
+
+    # Good text: long enough, no junk markers, not dominated by I-sentences.
+    good_record = {
+        "id": "2026-05-13T11-00-00",
+        "timestamp": "2026-05-13T11-00-00",
+        "type": "reflection",
+        "text": (
+            "Across the last three weeks the user shifted attention from "
+            "infrastructure work to interface design, with a steady cadence "
+            "of evening sessions and longer focus windows on weekends."
+        ),
+        "source": "reflection_engine",
+        "tags": [],
+        "metadata": {},
+    }
+
+    _write_canonical(reflection_dir, junk_record)
+    _write_canonical(reflection_dir, good_record)
+    _seed_memory_db(db_path, [junk_record, good_record])
+
+    # Sanity precondition.
+    pre = SqliteVectorStore(db_path)
+    try:
+        assert pre.count() == 2
+    finally:
+        pre.close()
+
+    # Point the tool at our temp vault. The tool imports
+    # get_private_vault_path with `from x import y`, so we patch the
+    # symbol in the tool's namespace.
+    import tools.suppress_reflections as suppress_mod
+
+    monkeypatch.setattr(suppress_mod, "get_private_vault_path", lambda: vault)
+
+    total, suppressed, _ = suppress_mod.suppress_reflections()
+
+    assert total == 2
+    assert suppressed == 1
+
+    # memory.db must reflect the hard-delete.
+    after = SqliteVectorStore(db_path)
+    try:
+        assert after.count() == 1, (
+            "Junk reflection should have been hard-deleted from memory.db"
+        )
+        rows = list(after._conn.execute("SELECT id FROM vectors"))
+        remaining_ids = [r[0] for r in rows]
+        assert remaining_ids == [good_record["id"]]
+    finally:
+        after.close()
+
+    # Canonical junk record stays on disk, now flagged. Append-only.
+    junk_after = json.loads(
+        (reflection_dir / f"{junk_record['id']}.json").read_text(encoding="utf-8")
+    )
+    assert junk_after["metadata"]["quality"] == "suppressed"
+    assert "suppressed_reason" in junk_after["metadata"]
+
+    # Canonical good record unchanged.
+    good_after = json.loads(
+        (reflection_dir / f"{good_record['id']}.json").read_text(encoding="utf-8")
+    )
+    assert good_after.get("metadata", {}).get("quality") != "suppressed"
+
+
+def test_suppress_does_not_touch_stale_reflection_index_json(
+    tmp_path, monkeypatch,
+):
+    """After migration the tool must leave any stale
+    vault/embeddings/reflection_index.json alone. Matches the B-RET-001
+    precedent on conversation_index.json: stale JSON indexes in user
+    vaults are user data; the tool's responsibility is memory.db only."""
+    vault = _build_vault(tmp_path)
+    reflection_dir = vault / "memory" / "reflection"
+    db_path = vault / "embeddings" / "memory.db"
+    json_index_path = vault / "embeddings" / "reflection_index.json"
+
+    junk_record = {
+        "id": "2026-05-13T10-00-00",
+        "timestamp": "2026-05-13T10-00-00",
+        "type": "reflection",
+        "text": (
+            "I'm here to help. How can I assist you today with your goals "
+            "and what would you like to discuss in this session please?"
+        ),
+        "source": "reflection_engine",
+        "tags": [],
+        "metadata": {},
+    }
+    _write_canonical(reflection_dir, junk_record)
+    _seed_memory_db(db_path, [junk_record])
+
+    # Pre-seed a stale JSON index containing an entry for the junk record.
+    # The pre-migration tool would have filtered this out and rewritten
+    # the file; the post-migration tool must NOT touch it.
+    stale_index_payload = [
+        {
+            "id": junk_record["id"],
+            "file_path": str(reflection_dir / f"{junk_record['id']}.json"),
+            "text_preview": junk_record["text"][:80],
+            "embedding": _FAKE_EMBEDDING,
+        },
+    ]
+    json_index_path.write_text(
+        json.dumps(stale_index_payload, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    original_bytes = json_index_path.read_bytes()
+
+    import tools.suppress_reflections as suppress_mod
+
+    monkeypatch.setattr(suppress_mod, "get_private_vault_path", lambda: vault)
+
+    suppress_mod.suppress_reflections()
+
+    assert json_index_path.exists(), (
+        "Tool must not delete a pre-existing JSON index file - user data."
+    )
+    assert json_index_path.read_bytes() == original_bytes, (
+        "Tool must leave the stale JSON index byte-for-byte unchanged."
+    )

--- a/tools/suppress_reflections.py
+++ b/tools/suppress_reflections.py
@@ -2,18 +2,30 @@
 tools/suppress_reflections.py
 
 Suppress junk reflection records by marking them in-place.
-Does NOT delete records — append-only principle.
+Canonical JSON records are NOT deleted - append-only principle.
 
 Adds metadata.quality = "suppressed" and metadata.suppressed_reason
-to each flagged record's JSON file. Also updates the reflection vector
-index to exclude suppressed records.
+to each flagged record's canonical JSON file. Also hard-deletes the
+corresponding row from memory.db (the SQLite vector index) so the
+record is invisible to semantic search.
+
+Reflection records are SQLite-backed (memory.db). The legacy JSON index
+path (vault/embeddings/reflection_index.json) is dead for reflections,
+and any stale file in a user vault is left untouched - same B-RET-001
+precedent applied to conversation_index.json.
+
+Known tool-debt: running scripts/rebuild_indexes.py against canonical
+records will re-insert suppressed rows into memory.db because the insert
+path does not currently read metadata.quality. Re-run this tool after
+any manual rebuild. A schema-level "suppressed" propagation would close
+this gap but is out of scope.
 
 Usage:
     python tools/audit_reflections.py          # audit first
     python tools/suppress_reflections.py       # then suppress
 
-This is a one-time cleanup tool for junk that accumulated before
-the reflection skip filters were tightened.
+This is a one-time cleanup tool for junk that accumulated before the
+reflection skip filters were tightened.
 """
 
 from __future__ import annotations
@@ -28,12 +40,15 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.core.config import get_private_vault_path
+from src.retrieval.sqlite_vector_store import SqliteVectorStore
 from tools.audit_reflections import is_junk_reflection
 
 
 def suppress_reflections() -> tuple[int, int, str]:
     """
-    Mark junk reflections as suppressed in their JSON files.
+    Mark junk reflections as suppressed in their canonical JSON records
+    and hard-delete them from memory.db.
+
     Returns (total, suppressed_count, summary_text).
     """
     vault = get_private_vault_path()
@@ -45,9 +60,10 @@ def suppress_reflections() -> tuple[int, int, str]:
     lines: list[str] = []
     total = 0
     suppressed = 0
+    suppressed_ids: list[str] = []
 
     timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-    lines.append(f"Reflection Suppression — {timestamp}")
+    lines.append(f"Reflection Suppression - {timestamp}")
     lines.append(f"{'=' * 50}")
 
     for json_file in sorted(reflection_dir.glob("*.json")):
@@ -70,7 +86,7 @@ def suppress_reflections() -> tuple[int, int, str]:
 
         junk, reason = is_junk_reflection(text)
         if junk:
-            # Mark as suppressed in the record itself
+            # Flag the canonical record. Append-only: file stays in place.
             metadata["quality"] = "suppressed"
             metadata["suppressed_reason"] = reason
             metadata["suppressed_at"] = timestamp
@@ -80,62 +96,47 @@ def suppress_reflections() -> tuple[int, int, str]:
                 encoding="utf-8",
             )
 
+            record_id = record.get("id")
+            if record_id:
+                suppressed_ids.append(record_id)
+
             suppressed += 1
-            lines.append(f"  SUPPRESSED: {json_file.name} — {reason}")
+            lines.append(f"  SUPPRESSED: {json_file.name} - {reason}")
 
     lines.append(f"\nTotal reflections: {total}")
     lines.append(f"Suppressed: {suppressed}")
     lines.append(f"Remaining: {total - suppressed}")
 
-    # Update the reflection vector index to exclude suppressed records
-    index_suppressed = _update_reflection_index(vault, reflection_dir)
-    lines.append(f"Index entries removed: {index_suppressed}")
+    # Hard-delete suppressed rows from memory.db. Canonical JSON records
+    # remain on disk; only the vector index entries are removed so the
+    # records are invisible to semantic_search.
+    deleted = _delete_from_memory_db(vault, suppressed_ids)
+    lines.append(f"memory.db rows deleted: {deleted}")
 
     summary = "\n".join(lines)
     return total, suppressed, summary
 
 
-def _update_reflection_index(vault: Path, reflection_dir: Path) -> int:
-    """Remove suppressed records from the reflection vector index."""
-    index_path = vault / "embeddings" / "reflection_index.json"
-    if not index_path.exists():
+def _delete_from_memory_db(vault: Path, ids: list[str]) -> int:
+    """Hard-delete the listed record ids from memory.db.
+
+    Returns the count of rows actually removed. Returns 0 if memory.db
+    does not exist (fresh vault, never indexed). Leaves any stale
+    reflection_index.json in user vaults untouched - same B-RET-001
+    precedent applied to conversation_index.json.
+    """
+    if not ids:
         return 0
 
+    db_path = vault / "embeddings" / "memory.db"
+    if not db_path.exists():
+        return 0
+
+    store = SqliteVectorStore(db_path)
     try:
-        index_data = json.loads(index_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return 0
-
-    if not isinstance(index_data, list):
-        return 0
-
-    # Build set of suppressed file paths
-    suppressed_paths = set()
-    for json_file in reflection_dir.glob("*.json"):
-        try:
-            record = json.loads(json_file.read_text(encoding="utf-8"))
-            metadata = record.get("metadata", {})
-            if isinstance(metadata, dict) and metadata.get("quality") == "suppressed":
-                suppressed_paths.add(str(json_file))
-        except (json.JSONDecodeError, OSError):
-            continue
-
-    # Filter index
-    original_count = len(index_data)
-    filtered = [
-        item for item in index_data
-        if item.get("file_path") not in suppressed_paths
-    ]
-
-    removed = original_count - len(filtered)
-
-    if removed > 0:
-        index_path.write_text(
-            json.dumps(filtered, ensure_ascii=False),
-            encoding="utf-8",
-        )
-
-    return removed
+        return store.delete_by_ids(ids)
+    finally:
+        store.close()
 
 
 def main():


### PR DESCRIPTION
## Summary

Extends the B-RET-001 cleanup pattern to the remaining three SQLite-backed memory types. After this PR `JSON_INDEX_TYPES` is empty; no live or tool writer remains on the per-type JSON index path.

Two-commit sequence on this branch:

1. **`chore(tools): migrate suppress_reflections to memory.db hard-delete`** - the only remaining tool-level writer to `reflection_index.json` was `tools/suppress_reflections.py`. It now operates on `memory.db` directly via a new `SqliteVectorStore.delete_by_ids()` helper. Canonical JSON records still get `metadata.quality = "suppressed"` (append-only preserved).
2. **`chore(retrieval): remove profile/reflection/journal from JSON_INDEX_TYPES`** - removes the three types from `scripts/rebuild_indexes.py:52`; the list is now empty. Extends `tests/test_b_ret_001_dead_code_retired.py` with a regression assertion covering all four SQLite-backed types.

## Why this is safe

Audit findings (all confirmed in code, not by claim):

- **Runtime writers:** zero for all three types. `src/memory/write_memory.py:17` SQLITE_MEMORY_TYPES routes profile/reflection/journal to `memory.db` on write; the JSON-index branch is unreachable.
- **Runtime readers:** zero for all three types. `src/retrieval/semantic_search.py:15` SQLITE_MEMORY_TYPES routes them to `memory.db` on read.
- **Tool writers:** one (`tools/suppress_reflections.py`) - migrated in commit 1 of this branch.
- **Tool readers:** `tools/audit_reflections.py` reads canonical records from `vault/memory/reflection/`, never the index. `scripts/audit_memory.py:294` loads indexes for diagnostic display only.

## Stale user-vault files

`profile_index.json`, `reflection_index.json`, `journal_index.json` already in user vaults are left untouched - same precedent as B-RET-001's handling of `conversation_index.json`. Nothing live reads them. The next manual `rebuild_indexes.py` run produces nothing for these types (empty `JSON_INDEX_TYPES` list).

## Known tool-debt (documented, not addressed here)

If an operator runs `scripts/rebuild_indexes.py` against canonical records, the SQLite insert path does NOT currently propagate `metadata.quality = "suppressed"`. Re-running `tools/suppress_reflections.py` after a rebuild restores the suppression. Documented in `tools/suppress_reflections.py` module docstring. A schema-level propagation would close this gap but is out of scope.

## Test plan

- [x] Tier 1 (`pytest tests/ -q`): 2087 passed, 2 xfailed (documented B-CTX-001 residuals), 50 deselected. No regressions.
- [x] New unit tests `tests/test_suppress_reflections.py` cover the migration end-to-end (junk record removed from `memory.db`, canonical record preserved with suppression flag, stale JSON index untouched byte-for-byte).
- [x] New regression test `test_rebuild_indexes_excludes_sqlite_backed_types` mirrors the existing conversation-only assertion across all four SQLite-backed types.
- [x] Tier 2 retrieval eval will run via post-commit hook.

## Notes

- Auto-merge **not** enabled.
- Independent of PR #76 (B1 timeout raise) - no file overlap. Either may merge first.
- Plan reference: this is PR #2 of a 4-PR sequence (B1, JSON-index cleanup, adversarial eval, B2 bare-marker clarification).