### PR TITLE
fix(intent): route bare-marker queries to clarification policy (B2)

### DIFF
--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("ember.openai_adapter")
 from src.api.limiter import limiter
 from src.core.config import get_ember_debug
 from src.memory.service import MemoryService
+from src.memory.read_memory import read_memories
 from src.memory.write_memory import write_memory
 from src.memory.session import create_session, session_exists, get_session, list_sessions
 from src.context.service import ContextService
@@ -987,6 +988,113 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
         except Exception:
             project_name = None  # Non-fatal — proceed without project name
 
+    # --- BARE-MARKER CLARIFICATION SHORT-CIRCUIT (B2) ---
+    # When the user invokes an explicit web marker ("google please",
+    # "look it up", "search the web for me") but provides no actual
+    # search content, route to a hardcoded clarification response
+    # rather than dispatching a useless bare query to SearXNG.
+    #
+    # Bypasses constitutional review. The clarification text is a
+    # hardcoded trusted string identical in trust class to
+    # SCRIPTED_ASK_FIRST_RESPONSE substitution.
+    from src.context.policies import (
+        SCRIPTED_CLARIFICATION_RESPONSE,
+        classify_query as _classify_for_clarification,
+    )
+    _clarification_check_policy = _classify_for_clarification(latest_user_message)
+    if _clarification_check_policy.emit_clarification:
+        logger.warning("[CLARIFY] emit clarification, bypass classifier+search")
+        _clarification_id = f"chatcmpl-{uuid.uuid4().hex}"
+
+        # Write both turns so the next-turn handler can detect
+        # awaiting_search_content on the assistant record.
+        if not (is_test or not vault_enabled):
+            _user_clar_meta = {
+                "role": "user",
+                "content_kind": "user_content",
+                "session_id": session_id,
+            }
+            _assistant_clar_meta = {
+                "role": "assistant",
+                "content_kind": "answer",
+                "session_id": session_id,
+                "source": "clarification",
+                "awaiting_search_content": True,
+            }
+            if project_id:
+                _user_clar_meta["project_id"] = project_id
+                _assistant_clar_meta["project_id"] = project_id
+            write_memory(
+                text=latest_user_message,
+                memory_type="conversation",
+                source="chat",
+                tags=["conversation"],
+                metadata=_user_clar_meta,
+            )
+            write_memory(
+                text=SCRIPTED_CLARIFICATION_RESPONSE,
+                memory_type="conversation",
+                source="chat",
+                tags=["conversation", "clarification"],
+                metadata=_assistant_clar_meta,
+            )
+
+        if body.stream:
+            async def _clarification_sse():
+                import json as _json
+                yield (
+                    "data: "
+                    + _json.dumps({
+                        "id": _clarification_id,
+                        "object": "chat.completion.chunk",
+                        "created": int(time.time()),
+                        "model": "ember-2",
+                        "choices": [{
+                            "index": 0,
+                            "delta": {"content": SCRIPTED_CLARIFICATION_RESPONSE},
+                            "finish_reason": None,
+                        }],
+                    })
+                    + "\n\n"
+                )
+                yield (
+                    "data: "
+                    + _json.dumps({
+                        "id": _clarification_id,
+                        "object": "chat.completion.chunk",
+                        "created": int(time.time()),
+                        "model": "ember-2",
+                        "choices": [{
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                        }],
+                    })
+                    + "\n\n"
+                )
+                yield "data: [DONE]\n\n"
+            return StreamingResponse(
+                _clarification_sse(),
+                media_type="text/event-stream",
+            )
+
+        return ChatCompletionsResponse(
+            id=_clarification_id,
+            object="chat.completion",
+            created=int(time.time()),
+            model="ember-2",
+            choices=[
+                ChatCompletionsChoice(
+                    index=0,
+                    message=ChatCompletionsResponseMessage(
+                        role="assistant",
+                        content=SCRIPTED_CLARIFICATION_RESPONSE,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+        )
+
     # --- RESOLVE INTER-SESSION TIME GAP (BUG-003) ---
     # Compute a human label for "how long since the previous session was active"
     # so the prompt builder can surface it as an explicit context section. The
@@ -1199,7 +1307,38 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
         # "look it up" etc. The user's own words ARE the confirmation —
         # ask-first gate must not block this.
         from src.context.policies import classify_query as _classify_early
+        from src.context.policies import _web_search_policy as _force_web_search_policy
         _early_policy = _classify_early(latest_user_message)
+
+        # B2 next-turn dispatch: if the immediately prior assistant turn
+        # was a clarification ("What would you like me to search for?"),
+        # treat this user message as the search content. Bypass the
+        # classifier (which would inspect the bare follow-up in isolation
+        # and may mis-route) and dispatch directly to web_search.
+        try:
+            _recent_conv = read_memories(memory_type="conversation", limit=5)
+            for _r in _recent_conv:
+                _meta = _r.get("metadata", {}) if isinstance(_r, dict) else {}
+                if not isinstance(_meta, dict):
+                    continue
+                if _meta.get("session_id") != session_id:
+                    continue
+                if _meta.get("role") != "assistant":
+                    continue
+                # First (most recent) assistant turn in this session.
+                if _meta.get("awaiting_search_content") is True:
+                    logger.info(
+                        "[CLARIFY] Next-turn dispatch: prior assistant turn "
+                        "carried awaiting_search_content; bypassing classifier "
+                        "and routing user message to web_search"
+                    )
+                    _early_policy = _force_web_search_policy(explicit=True)
+                break
+        except Exception as exc:
+            logger.warning(
+                "[CLARIFY] Next-turn check failed (non-fatal): %s", exc,
+            )
+
         _explicit_search = getattr(_early_policy, "explicit_search_request", False)
         # Gate bypass: skip_web_search is False when autonomous is on OR
         # the user explicitly requested a search. Confirmation-confirmed

--- a/src/context/policies.py
+++ b/src/context/policies.py
@@ -85,6 +85,11 @@ class ContextPolicy:
     # up", "search the web"). Explicit requests bypass ask-first — the user's
     # own words ARE the confirmation.
     explicit_search_request: bool = False
+    # B2 fix: True when an explicit web marker matched but the query carries
+    # no search content. openai_adapter.py short-circuits the request and
+    # emits SCRIPTED_CLARIFICATION_RESPONSE instead of dispatching a useless
+    # bare query to SearXNG.
+    emit_clarification: bool = False
     # ADR-018: Intent-aware memory type gating.
     # eligible_memory_types: which types are candidates. None = all eligible.
     # suppress_memory_types: types excluded from candidates.
@@ -114,6 +119,69 @@ _EXPLICIT_WEB_MARKERS: tuple[str, ...] = (
 )
 
 
+# Conservative starter set. Natural language filler is not enumerable.
+# Add items here when a real dispatch-empty case is observed in production logs.
+# Do not pre-emptively expand; each addition is a maintenance surface.
+META_PHRASES: frozenset[str] = frozenset({
+    "please",
+    "now",
+    "thanks",
+    "thank you",
+    "for me",
+    "for it",
+    "for that",
+    "would you",
+    "could you",
+})
+
+
+# Hardcoded response emitted when an explicit web marker matches but
+# the query carries no actual search content (B2 fix). Same trust
+# class as SCRIPTED_ASK_FIRST_RESPONSE in src/llm/ask_first_validator.py.
+SCRIPTED_CLARIFICATION_RESPONSE: str = "What would you like me to search for?"
+
+
+_RESIDUAL_PUNCTUATION_RE = re.compile(r"[,.!?;:]+")
+
+
+def _is_bare_marker_query(q: str, marker: str) -> bool:
+    """Return True if `q` contains `marker` but no actual search content.
+
+    Strips the first occurrence of the marker substring, normalizes the
+    residual (punctuation, whitespace), and walks tokens left-to-right
+    consuming the longest META_PHRASES prefix at each step. Returns
+    True if either the residual is empty or all tokens get consumed by
+    a META_PHRASES match.
+
+    Caller is expected to pass a lowercase, apostrophe-normalized `q`
+    (matches the existing classify_query() pipeline at line 136).
+    """
+    residual = q.replace(marker, "", 1)
+    residual = _RESIDUAL_PUNCTUATION_RE.sub(" ", residual)
+    residual = " ".join(residual.split())
+    if not residual:
+        return True
+    tokens = residual.split(" ")
+    # Greedy multi-word match: at each position, try the longest
+    # META_PHRASES entry first. If no entry matches starting at the
+    # current position, the residual contains content - not bare.
+    max_phrase_len = max(
+        len(phrase.split(" ")) for phrase in META_PHRASES
+    )
+    i = 0
+    while i < len(tokens):
+        matched = False
+        for length in range(min(max_phrase_len, len(tokens) - i), 0, -1):
+            candidate = " ".join(tokens[i:i + length])
+            if candidate in META_PHRASES:
+                i += length
+                matched = True
+                break
+        if not matched:
+            return False
+    return True
+
+
 def _web_search_policy(explicit: bool) -> ContextPolicy:
     """Construct the shared web_search policy shape.
 
@@ -132,6 +200,21 @@ def _web_search_policy(explicit: bool) -> ContextPolicy:
     )
 
 
+def _clarification_policy() -> ContextPolicy:
+    """Construct the clarification policy (B2 fix).
+
+    Returned when an explicit web marker matches but the query carries
+    no search content. openai_adapter.py short-circuits the request and
+    emits SCRIPTED_CLARIFICATION_RESPONSE rather than dispatching a
+    bare query to SearXNG.
+    """
+    return ContextPolicy(
+        name="clarification",
+        use_web_search=False,
+        emit_clarification=True,
+    )
+
+
 def classify_query(user_message: str) -> ContextPolicy:
     q = user_message.lower()
     # Normalize curly apostrophes to straight so markers like "what's" match
@@ -144,7 +227,17 @@ def classify_query(user_message: str) -> ContextPolicy:
 
     # Stage 0: explicit web-search request. User-stated instruction, not
     # intent inference — bypass ask-first and skip the intent classifier.
-    if any(marker in q for marker in _EXPLICIT_WEB_MARKERS):
+    matched_marker = next(
+        (marker for marker in _EXPLICIT_WEB_MARKERS if marker in q), None,
+    )
+    if matched_marker is not None:
+        # B2 fix: a marker without content is dispatch-empty. Route to
+        # the clarification policy so openai_adapter.py emits a
+        # scripted "what would you like me to search for?" instead of
+        # firing SearXNG with a useless bare query.
+        if _is_bare_marker_query(q, matched_marker):
+            logger.warning("[CLASSIFY] intent=clarification trigger=bare_marker")
+            return _clarification_policy()
         logger.warning("[CLASSIFY] intent=web_search trigger=explicit")
         return _web_search_policy(explicit=True)
 

--- a/tests/test_clarification_next_turn.py
+++ b/tests/test_clarification_next_turn.py
@@ -1,0 +1,184 @@
+"""tests/test_clarification_next_turn.py
+
+After a B2 clarification short-circuit, the assistant conversation
+record carries metadata.awaiting_search_content=True. When the user
+sends their follow-up turn, the request handler must:
+
+  1. Detect the prior clarification by reading the most recent
+     assistant conversation record for the session.
+  2. Bypass the intent classifier on this turn.
+  3. Dispatch the user's full new message to web_search() as the
+     search query.
+
+Without this, the follow-up "iPhone 16 release date" would be
+classified in isolation; if the classifier mis-routes (e.g., vault
+because of no temporal anchor), the user gets a vault-empty answer
+after explicitly responding to the clarification prompt.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    with patch("src.api.main.get_ember_api_key", return_value=None):
+        from src.api.main import app
+        yield TestClient(app)
+
+
+def _payload(text: str) -> dict:
+    return {
+        "model": "ember",
+        "stream": False,
+        "messages": [{"role": "user", "content": text}],
+    }
+
+
+def _fake_recent_conversations(session_id: str) -> list[dict]:
+    """Return what read_memories('conversation', limit=N) would return
+    after a clarification short-circuit fired in this session."""
+    return [
+        {
+            "id": "2026-05-13T05-30-00",
+            "timestamp": "2026-05-13T05-30-00",
+            "type": "conversation",
+            "text": "What would you like me to search for?",
+            "source": "chat",
+            "tags": ["conversation", "clarification"],
+            "metadata": {
+                "role": "assistant",
+                "content_kind": "answer",
+                "session_id": session_id,
+                "source": "clarification",
+                "awaiting_search_content": True,
+            },
+        },
+        {
+            "id": "2026-05-13T05-29-59",
+            "timestamp": "2026-05-13T05-29-59",
+            "type": "conversation",
+            "text": "google please",
+            "source": "chat",
+            "tags": ["conversation"],
+            "metadata": {
+                "role": "user",
+                "content_kind": "user_content",
+                "session_id": session_id,
+            },
+        },
+    ]
+
+
+def test_next_turn_after_clarification_dispatches_user_message_to_web_search(client):
+    """When the prior assistant turn is a clarification, the user's
+    next message goes directly to web_search() bypassing the classifier."""
+    session_id = "sess_b2_followup"
+
+    with patch("src.api.openai_adapter.read_memories") as _read_conv, \
+         patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.api.openai_adapter.get_session") as _get_session:
+        _onb.is_active.return_value = False
+        _read_conv.return_value = _fake_recent_conversations(session_id)
+        _get_session.return_value = {"id": session_id, "metadata": {}}
+
+        from src.context.models import ContextPacket
+        # Pretend build_context returned a packet with web results to
+        # confirm the request did go through the dispatch path.
+        empty_packet = ContextPacket(
+            user_message="iPhone 16 release date",
+            web_items=[],
+        )
+        _ctx.build_context.return_value = empty_packet
+        _llm.generate_response.return_value = "iPhone 16 was released..."
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "ember",
+                "stream": False,
+                "messages": [
+                    {"role": "user", "content": "iPhone 16 release date"},
+                ],
+            },
+            headers={"X-Session-Id": session_id},
+        )
+
+        assert resp.status_code == 200
+
+        # build_context must have run with skip_web_search=False so the
+        # dispatch through context_service.web_search executes.
+        assert _ctx.build_context.called
+        call_kwargs = _ctx.build_context.call_args.kwargs
+        assert call_kwargs.get("skip_web_search") is False, (
+            f"After clarification, follow-up turn must dispatch to web_search; "
+            f"got skip_web_search={call_kwargs.get('skip_web_search')!r}"
+        )
+
+
+def test_no_clarification_in_history_does_not_force_web_search(client):
+    """Sanity check: when the prior assistant turn is NOT a clarification,
+    the next-turn handler must not fire. The normal classifier path runs."""
+    session_id = "sess_no_clarification"
+
+    # Recent conversations: a normal assistant turn (no
+    # awaiting_search_content).
+    normal_history = [
+        {
+            "id": "2026-05-13T06-00-00",
+            "timestamp": "2026-05-13T06-00-00",
+            "type": "conversation",
+            "text": "I noticed you mentioned the docs earlier.",
+            "source": "chat",
+            "tags": ["conversation"],
+            "metadata": {
+                "role": "assistant",
+                "content_kind": "answer",
+                "session_id": session_id,
+                # No source=clarification, no awaiting_search_content.
+            },
+        },
+    ]
+
+    with patch("src.api.openai_adapter.read_memories") as _read_conv, \
+         patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.api.openai_adapter.get_session") as _get_session, \
+         patch("src.core.preferences.get", return_value=False):
+        _onb.is_active.return_value = False
+        _read_conv.return_value = normal_history
+        _get_session.return_value = {"id": session_id, "metadata": {}}
+
+        from src.context.models import ContextPacket
+        empty_packet = ContextPacket(user_message="hello there", web_items=[])
+        _ctx.build_context.return_value = empty_packet
+        _llm.generate_response.return_value = "Hi."
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json=_payload("hello there"),
+            headers={"X-Session-Id": session_id},
+        )
+
+        assert resp.status_code == 200
+        # No clarification flag means normal flow: web_autonomous=False
+        # means ask-first is active and skip_web_search=True.
+        call_kwargs = _ctx.build_context.call_args.kwargs
+        assert call_kwargs.get("skip_web_search") is True

--- a/tests/test_clarification_policy.py
+++ b/tests/test_clarification_policy.py
@@ -1,0 +1,71 @@
+"""tests/test_clarification_policy.py
+
+Unit tests for the _is_bare_marker_query helper in src/context/policies.py.
+
+The helper decides whether an explicit web-marker query carries any
+actual search content. A marker match without content (e.g.,
+"google please") routes to a clarification policy instead of
+dispatching a useless bare query to SearXNG.
+
+Contract: given the user query and the matched marker substring,
+return True if the residual after the marker strip is either empty or
+made entirely of META_PHRASES tokens (politeness/filler).
+"""
+
+from __future__ import annotations
+
+from src.context.policies import _is_bare_marker_query
+
+
+def test_marker_followed_by_single_meta_phrase_is_bare():
+    """Tracer bullet: the canonical B2 failure case.
+
+    'google please' was the seed example throughout the design grill.
+    After stripping the 'google' marker the residual is 'please', a
+    META_PHRASES member, so the helper must report this as bare."""
+    assert _is_bare_marker_query("google please", "google") is True
+
+
+def test_marker_followed_by_content_is_not_bare():
+    """A marker with real search content must NOT be flagged bare.
+
+    'google iPhone 16 release' has 'iPhone', '16', 'release' in the
+    residual - none are META_PHRASES tokens, so the helper must let
+    this dispatch normally."""
+    assert _is_bare_marker_query("google iphone 16 release", "google") is False
+
+
+def test_marker_alone_with_no_residual_is_bare():
+    """A query that is exactly the marker (or marker + whitespace) has
+    an empty residual after the strip - clearly nothing to search for."""
+    assert _is_bare_marker_query("google", "google") is True
+    assert _is_bare_marker_query("google ", "google") is True
+
+
+def test_multi_word_meta_phrase_residual_is_bare():
+    """Multi-word META_PHRASES entries like 'for me' must be matched
+    as a single phrase, not split across single-token checks.
+
+    Without greedy multi-word matching, 'for me' would fail because
+    bare 'for' is not in META_PHRASES."""
+    assert _is_bare_marker_query("google for me", "google") is True
+    assert _is_bare_marker_query("look this up for me", "look this up") is True
+
+
+def test_punctuation_does_not_defeat_meta_match():
+    """Punctuation around the residual must not block the META_PHRASES
+    match. 'google please.' and 'google please!' should both be bare."""
+    assert _is_bare_marker_query("google please.", "google") is True
+    assert _is_bare_marker_query("google please!", "google") is True
+    assert _is_bare_marker_query("google, please", "google") is True
+
+
+def test_mixed_meta_and_content_tokens_is_not_bare():
+    """When the residual has at least one non-META token, the query is
+    real - even if the rest is filler.
+
+    'google for me today' has 'today' as content; the helper must let
+    this dispatch normally. Same for 'google please tomorrow'."""
+    assert _is_bare_marker_query("google for me today", "google") is False
+    assert _is_bare_marker_query("google please tomorrow", "google") is False
+    assert _is_bare_marker_query("google news please", "google") is False

--- a/tests/test_clarification_short_circuit.py
+++ b/tests/test_clarification_short_circuit.py
@@ -1,0 +1,125 @@
+"""tests/test_clarification_short_circuit.py
+
+B2 fix: when a bare-marker query like "google please" reaches the
+chat completions endpoint, the request short-circuits at the policy
+layer. The user receives SCRIPTED_CLARIFICATION_RESPONSE directly
+without context build, retrieval, LLM generation, or constitutional
+review.
+
+Both conversation records (user turn + assistant turn) are still
+written so the next-turn handler can detect the awaiting_search_content
+flag on the assistant turn.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.context.policies import SCRIPTED_CLARIFICATION_RESPONSE
+
+
+@pytest.fixture
+def client():
+    with patch("src.api.main.get_ember_api_key", return_value=None):
+        from src.api.main import app
+        yield TestClient(app)
+
+
+def _bare_marker_payload(text: str = "google please") -> dict:
+    return {
+        "model": "ember",
+        "stream": False,
+        "messages": [{"role": "user", "content": text}],
+    }
+
+
+def test_bare_marker_returns_scripted_clarification(client):
+    """The clarification text reaches the client as the assistant's
+    response content."""
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.tools.web_search.web_search") as _web:
+        _onb.is_active.return_value = False
+
+        resp = client.post("/v1/chat/completions", json=_bare_marker_payload())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"]
+        assert content == SCRIPTED_CLARIFICATION_RESPONSE
+
+        # No LLM call, no context build, no web search dispatched.
+        assert _ctx.build_context.call_count == 0
+        assert _llm.generate_response.call_count == 0
+        assert _web.call_count == 0
+
+
+def test_bare_marker_writes_both_conversation_records_with_metadata(client):
+    """User turn and assistant turn must both be written. The assistant
+    record carries metadata.source='clarification' and
+    metadata.awaiting_search_content=True so the next-turn handler can
+    detect the followup."""
+    with patch("src.api.openai_adapter.context_service"), \
+         patch("src.api.openai_adapter.llm_adapter"), \
+         patch("src.api.openai_adapter.write_memory") as _write, \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.tools.web_search.web_search"):
+        _onb.is_active.return_value = False
+
+        resp = client.post("/v1/chat/completions", json=_bare_marker_payload())
+
+        assert resp.status_code == 200
+        assert _write.call_count == 2
+
+        user_call, assistant_call = _write.call_args_list
+        # User turn: raw user message in text, role=user metadata.
+        assert user_call.kwargs["text"] == "google please"
+        assert user_call.kwargs["memory_type"] == "conversation"
+        assert user_call.kwargs["metadata"]["role"] == "user"
+
+        # Assistant turn: clarification text + clarification-source flags.
+        assert assistant_call.kwargs["text"] == SCRIPTED_CLARIFICATION_RESPONSE
+        assert assistant_call.kwargs["memory_type"] == "conversation"
+        meta = assistant_call.kwargs["metadata"]
+        assert meta["role"] == "assistant"
+        assert meta["source"] == "clarification"
+        assert meta["awaiting_search_content"] is True
+
+
+def test_bare_marker_streaming_emits_clarification_sse(client):
+    """When body.stream=True, the response is an SSE stream containing
+    the clarification text and a [DONE] sentinel. No LLM is invoked."""
+    payload = _bare_marker_payload()
+    payload["stream"] = True
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.tools.web_search.web_search"):
+        _onb.is_active.return_value = False
+
+        resp = client.post("/v1/chat/completions", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert SCRIPTED_CLARIFICATION_RESPONSE in body
+        assert "data: [DONE]" in body
+        assert _llm.generate_response.call_count == 0
+        assert _ctx.build_context.call_count == 0

--- a/tests/test_explicit_search.py
+++ b/tests/test_explicit_search.py
@@ -37,17 +37,17 @@ class TestExplicitSearchClassification:
     @pytest.mark.parametrize("query", [
         "search the web for tokyo population",
         "google that",
-        "look it up",
-        "look this up for me",
         "search online for the latest news",
-        # ADR-034 tightening: "can you find" alone is too broad — it was
+        # ADR-034 tightening: "can you find" alone is too broad - it was
         # misclassifying vault lookups like "can you find my current focus"
         # as explicit web requests. The marker now requires "online" to
         # scope it to actual web requests.
         "can you find online the latest inflation data",
-        "can you find it online please",
-        "find this online please",
         "web search for NVIDIA stock price",
+        # B2: queries with explicit markers PLUS actual content stay on
+        # the dispatch path. Bare-marker variants ("look it up", "look
+        # this up for me", "find this online please") moved to
+        # TestBareMarkerRoutesToClarification below.
     ])
     def test_explicit_phrases_set_flag(self, query):
         policy = classify_query(query)
@@ -76,6 +76,45 @@ class TestExplicitSearchClassification:
         policy = classify_query(query)
         assert policy.name != "web_search"
         assert policy.explicit_search_request is False
+
+
+class TestBareMarkerRoutesToClarification:
+    """When the user invokes an explicit search marker but provides no
+    actual search content, the policy routes to clarification instead
+    of dispatching a useless bare query to SearXNG. The B2 fix."""
+
+    @pytest.mark.parametrize("query", [
+        "google please",
+        "google please.",
+        "could you google please",
+        "search the web for me",
+        "look this up please",
+        "look this up for me",
+        "look it up",
+        "find this online please",
+        "google now",
+    ])
+    def test_bare_marker_routes_to_clarification(self, query):
+        policy = classify_query(query)
+        assert policy.name == "clarification", (
+            f"{query!r} expected clarification policy, got "
+            f"name={policy.name!r}, use_web_search={policy.use_web_search}"
+        )
+        assert policy.use_web_search is False
+        assert policy.emit_clarification is True
+
+    @pytest.mark.parametrize("query", [
+        "google iphone 16 release please",
+        "look this up for the latest news",
+        "search the web for tokyo population",
+    ])
+    def test_marker_with_content_still_dispatches(self, query):
+        """A marker with real search content must still dispatch -
+        only dispatch-empty queries clarify."""
+        policy = classify_query(query)
+        assert policy.name == "web_search"
+        assert policy.use_web_search is True
+        assert policy.explicit_search_request is True
 
 
 class TestExplicitSearchBypassesAskFirst:


### PR DESCRIPTION
## Summary

Fixes B2: bare-marker queries like `"google please"` no longer dispatch an empty/useless query to SearXNG. Instead they short-circuit to a hardcoded clarification response, and the next user turn dispatches their content directly to web search.

Two-commit branch:
1. **`feat(policies)`** - the policy-layer mechanism: `_is_bare_marker_query` helper, `META_PHRASES` constant (9-item conservative set), `SCRIPTED_CLARIFICATION_RESPONSE` text, `_clarification_policy()` factory, `emit_clarification` field on `ContextPolicy`, dispatch wiring in `classify_query()`.
2. **`fix(intent)`** - the adapter integration: clarification short-circuit (skip context/retrieval/LLM/review), and next-turn dispatch handler that reads the prior assistant record's `awaiting_search_content` flag and routes the user's content directly to web search.

## Adversarial gate impact

Verified Cat 4 of the adversarial baseline (the deterministic 5/5 category):

| Query | Before | After |
|---|---|---|
| `google please` | web_search (bare query) | clarification |
| `search the web for me` | web_search (bare query) | clarification |
| `look this up please` | web_search (bare query) | clarification |
| `look it up` | web_search (bare query) | clarification |
| `google now` | web_search (bare query) | clarification |

**Cat 4: 0/5 -> 5/5.** Aggregate projects to **19/20** once PR #78 merges and the adversarial eval includes this file.

## Architecture (Architecture A from grill, locked in plan)

- Policy-level direct emit, not LLM-mediated. The clarification text reaches the client without an LLM turn.
- Constitutional review bypass is explicit and named in a code comment. Same trust class as `SCRIPTED_ASK_FIRST_RESPONSE` substitution.
- Both conversation turns persist (`source=clarification`, `awaiting_search_content=True` on the assistant turn) so the next-turn handler can detect the follow-up.
- Next-turn handler is gated narrowly: only the immediately-prior assistant record is checked, only within the same session. No history scan.
- No pivot guard (per Q6 of the grill: simpler, accept one wasted SearXNG call if the user pivots).

## META_PHRASES policy

Ships with the 9-item conservative set from the grill (`please`, `now`, `thanks`, `thank you`, `for me`, `for it`, `for that`, `would you`, `could you`). Comment above the constant pins the expansion discipline:

```python
# Conservative starter set. Natural language filler is not enumerable.
# Add items here when a real dispatch-empty case is observed in production logs.
# Do not pre-emptively expand; each addition is a maintenance surface.
```

## Test plan

- [x] Tier 1 (`pytest tests/ -q`): **2107 passed**, 50 deselected, 2 xfailed (documented B-CTX-001 residuals). No regressions.
- [x] New file `tests/test_clarification_policy.py`: 6 unit tests for `_is_bare_marker_query` covering single-token META, content, empty residual, multi-word phrases, punctuation, mixed META + content.
- [x] Extended `tests/test_explicit_search.py`: `TestBareMarkerRoutesToClarification` with 9 bare-marker cases + 3 with-content cases that must still dispatch.
- [x] New file `tests/test_clarification_short_circuit.py`: 3 FastAPI TestClient integration tests verifying the response text, no LLM/web_search call, both conversation records written with correct metadata, streaming SSE flow.
- [x] New file `tests/test_clarification_next_turn.py`: 2 integration tests verifying the next-turn handler fires on `awaiting_search_content=True` and does NOT fire on normal assistant records.
- [x] Direct Cat 4 verification: all 5 adversarial queries flip from `web_search` to `clarification`.
- [x] Manual smoke test of the live API at merge time (per CLAUDE.md bug-fix item 5: "A bug is not verified fixed until tested live with the actual trigger").

## Behavioral notes

- Three queries in the existing `test_explicit_phrases_set_flag` parametrize list pinned the pre-B2 buggy dispatch behavior: `look it up`, `look this up for me`, `find this online please`. They now correctly route to clarification and have been moved to `TestBareMarkerRoutesToClarification`.
- The plan's "no pivot guard" decision means a user who replies `"nevermind"` after a clarification will get a SearXNG call with `"nevermind"` as the query. This is acceptable for v0.18.0; pivot handling can be a future iteration if observed.

## Notes

- Auto-merge **not** enabled.
- Plan reference: PR #4 of a 4-PR sequence. PR #76 and #77 merged; PR #78 (adversarial baseline) open and not yet merged.
- B1 step 2 (Stage 3 prompt sentence) remains deferred per PR #76 measurement.