### PR TITLE
fix(safety): third B6 engagement-closing pattern for list/table/agenda variant

### DIFF
--- a/src/llm/coaching_filter.py
+++ b/src/llm/coaching_filter.py
@@ -79,6 +79,11 @@ _COACHING_CLOSINGS: tuple[re.Pattern, ...] = _compile_patterns((
     # 200-char window in _detect_patterns().
     r"what(?:'s| is) the (?:issue|problem|thing|challenge)(?: you(?:'re| are))?(?: trying)? to (?:resolve|solve|address|figure out|work through|tackle)",
     r"is there (?:something|anything)(?: specific| in particular)? (?:you(?:'d| would) like to|that you(?:'d| would) want to)(?: (?:explore|discuss|share|focus on|talk about|dig into))",
+    # B6 expansion (2026-05-14): "what's actually on/not on the list"
+    # variant surfaced during PR #81 smoke. Covers list / table /
+    # agenda nouns with optional "that feels/seems like it should be"
+    # tail. Same tail-anchor scope as the other B6 patterns.
+    r"what(?:'s| is) actually (?:on|not on) the (?:list|table|agenda)(?: that)?(?: feels| seems)?(?: like it should be)?",
 ))
 
 # B7 (v0.18.0 UAT 2026-05-11): self-referential content-free responses

--- a/tests/test_coaching_filter.py
+++ b/tests/test_coaching_filter.py
@@ -564,6 +564,30 @@ class TestB6EngagementClosingPatterns:
             f"non-engagement closing: {offending}"
         )
 
+    def test_whats_actually_on_the_list_variant_caught_in_tail(self):
+        """B6 expansion (2026-05-14 PR #81 smoke): the 'what's actually
+        on the list that feels like it should be' variant was observed
+        three times in a single short smoke session. Same class as the
+        original B6 patterns but different noun + verb vocabulary."""
+        from src.llm.coaching_filter import _detect_patterns
+        text = (
+            "Stuck usually means something about the decision isn't "
+            "settled yet. Not a bad place to be if you can name what's "
+            "unresolved. What's actually on the list that feels like "
+            "it should be?"
+        )
+        matches = _detect_patterns(text, is_emotional=True)
+        closing_matches = [
+            m for m in matches if m["pattern"] == "coaching_closing"
+        ]
+        assert any(
+            "actually on the list" in m["match"].lower()
+            for m in closing_matches
+        ), (
+            f"B6 'what's actually on the list' variant not caught. "
+            f"closing_matches={closing_matches}"
+        )
+
 
 class TestB7CircularDodgePatterns:
     """B7: self-referential content-free responses that recurse on


### PR DESCRIPTION
## Summary

Smoke verification of PR #81 surfaced an engagement-closing variant the original B6 patterns did not cover. The variant appeared **three times in a single short smoke session** on 2026-05-14:

> *"What's actually on the list that feels like it should be?"*
> *"What's actually not on the list that feels like it should be?"*

Same class as the original B6 patterns (engagement-style closing question offering no substantive answer), different noun + verb vocabulary. The original B6 targeted *"what is the issue / problem / thing / challenge ... to resolve"* and *"is there something specific you would like to explore"*. This variant uses *list / table / agenda* with a *that feels / seems like it should be* tail.

## Change

`src/llm/coaching_filter.py` — append to `_COACHING_CLOSINGS`:

```python
r"what(?:'s| is) actually (?:on|not on) the (?:list|table|agenda)(?: that)?(?: feels| seems)?(?: like it should be)?",
```

Required `actually` keeps the false-positive surface tight — bare `"what's on the list"` doesn't match. 200-char tail window remains the scoping mechanism; no new mechanism introduced.

`tests/test_coaching_filter.py` — one new test in `TestB6EngagementClosingPatterns` asserting the smoke-observed form is caught as a `coaching_closing` match.

## Regex coverage

| Surface form | Matches? |
|---|---|
| `"What's actually on the list that feels like it should be?"` | yes |
| `"What's actually not on the list that feels like it should be?"` | yes |
| `"What's actually on the agenda?"` | yes (bare ending) |
| `"What is actually on the table that seems like it should be there?"` | yes |
| `"What's on the list?"` (no `actually`) | no — `actually` required |
| `"What's actually wrong with this?"` | no — neither `on`/`not on` nor the noun set |

## Test plan

- [x] Tier 1 (`pytest tests/ -q`): **2144 passed**, 50 deselected, 2 xfailed (documented residuals). +1 over the post-#81-merge baseline. No regressions.
- [x] New test `test_whats_actually_on_the_list_variant_caught_in_tail` passes.
- [x] Existing `TestB6EngagementClosingPatterns` (3 prior tests) unchanged.
- [x] Manual smoke (post-merge, deferred): on next live session that produces this closing variant, verify `logs/coaching_filter/{timestamp}.json` shows the new pattern matched.

## Notes

- Follow-up to PR #81 — discovered during PR #81 smoke verification.
- `B-NARR-001` in `KNOWN_ISSUES.md` continues to cover the broader miss class (novel surface forms will not generalize); this PR is one additional point of coverage, not a structural change.
- Auto-merge **not** enabled.