### PR TITLE
fix(state): make pending_confirmation resolution append-only via derived resolved-set (A2)

### DIFF
--- a/docs/adr/ADR-038-append-only-pending-resolution.md
+++ b/docs/adr/ADR-038-append-only-pending-resolution.md
@@ -1,0 +1,48 @@
+# ADR-038: Append-Only Derived Resolution for pending_confirmation
+
+**Status:** Accepted
+**Date:** 2026-06-12
+**Target:** v0.18.1
+
+## Context
+
+The state layer is append-only by CLAUDE.md non-negotiable Rule 3: records are never overwritten in place; every change writes a new artifact. `StateService.mark_resolved()` violated this. It scanned the state directory, found the file whose `id` matched, and rewrote it in place via `f.write_text(...)` to set `metadata.resolved = True`. Its docstring acknowledged the violation ("same pattern as soft-delete").
+
+`mark_resolved` was used for exactly one category, `pending_confirmation` (the ask-first "want me to search?" flow), via `_resolve_original_pending` in `src/api/openai_adapter.py`. Resolving the original pending is load-bearing: without it, `_check_pending_confirmation` re-finds the same pending on every subsequent turn and the confirmation prompt loops forever.
+
+A naive "just write a new resolution record instead" does not work on its own, because nothing in the read path honored such a record:
+
+- The two consumers (`_check_pending_confirmation` and the `_write_pending_confirmation` duplicate-write guard) decided "is this pending active?" by reading each record's own `metadata.resolved` flag. Under append-only the original keeps `resolved=False`, so both would treat a resolved pending as active again -- reopening the infinite loop and suppressing legitimate re-offers.
+- `StateResolver.get_current_state()` surfaced `pending_confirmation` as a "current state" item (single-record, staleness-exempt) and also skipped only by the per-record `resolved` flag. Under append-only it would begin leaking resolved (even stale) pendings into the prompt.
+
+A related latent gap was discovered during this work and filed separately as **B-STATE-001** in `docs/KNOWN_ISSUES.md`: `resolve_open_loops_by_topic` already writes append-only resolution records carrying `metadata.original_id`, but `original_id` is read nowhere, so the original open_loop is not actually suppressed by the resolver. That gap is **out of scope** here; A2 is scoped to `pending_confirmation` only.
+
+## Decision
+
+Resolution for `pending_confirmation` becomes **append-only and derived**.
+
+1. **Append-only resolution.** `StateService.resolve_record(record_id, *, resolution=None)` appends a new resolution tombstone record of the same category carrying `metadata.resolved = True` and `metadata.original_id = record_id`. The original record file is never modified. The call is idempotent: if the record is already resolved it writes no duplicate tombstone. `mark_resolved` is removed.
+
+2. **Derived resolved-set.** `StateService.resolved_ids(records)` is the single canonical definition of "what is resolved": the union of (a) ids of records that carry their own `metadata.resolved = True` (back-compat for records already mutated in place by the old code path) and (b) every `metadata.original_id` value present (the tombstones). A record is active iff `record.id not in resolved_ids(records)`. Both `openai_adapter` consumers use this helper instead of reading the raw flag.
+
+3. **Resolver carve-out.** `StateResolver.get_current_state()` excludes `pending_confirmation` from surfaced items entirely (like `timer`). It is internal ask-first control flow consumed directly by the chat endpoint and never belongs in the prompt. This both fixes a real prompt-hygiene issue and removes the append-only leak surface, so the resolver's general resolution logic for real state categories is left untouched.
+
+Scope is `pending_confirmation` only. `open_loop` and `resolve_open_loops_by_topic` are unchanged; B-STATE-001 remains open.
+
+## Consequences
+
+- **No in-place mutation of canonical state records.** Rule 3 holds for pending resolution. Crash-safety improves: an append never tears an existing file.
+- **Back-compat without migration.** Vaults that already contain in-place-resolved pendings (from the old `mark_resolved`) are still treated as resolved via the flag branch of `resolved_ids`. No rebuild required.
+- **Append-only accumulation.** Each resolution now writes a tombstone, so `pending_confirmation` records accumulate at roughly 2x the prior rate and are never compacted. `read_all()` already scans every state file per turn, so this is a marginal cost on an already-O(all-state-files) read. Acceptable for a single-user vault; a compaction/archival pass is a possible future enhancement, not part of this change.
+- **One definition of "resolved."** Both consumers and the idempotency guard share `resolved_ids`, removing the per-site flag-reading that caused the original drift.
+- **B-STATE-001 is not addressed.** The shared `resolved_ids` helper is deliberately NOT wired into the resolver's `open_loop` path, so the open_loop `original_id` gap persists exactly as filed. Closing it (or removing `original_id` and relying on `ConversationBuffer`) is a separate future workstream.
+- **A future full event-sourced resolution** (deriving resolution for all categories via `resolved_ids` in the resolver) remains available; this ADR is the first, contained step toward it.
+
+## References
+
+- `docs/adr/ADR-011-multi-record-state-categories.md` -- state resolution rules this amends for `pending_confirmation`.
+- `docs/KNOWN_ISSUES.md` -- B-STATE-001 (open_loop suppression gap, out of scope here).
+- `src/state/state_service.py` -- `resolved_ids`, `resolve_record` (replaces `mark_resolved`).
+- `src/state/state_resolver.py` -- `pending_confirmation` exclusion in `get_current_state`.
+- `src/api/openai_adapter.py` -- `_resolve_original_pending`, `_check_pending_confirmation`, `_write_pending_confirmation` derived-resolution sites.
+- CLAUDE.md -- Core Architectural Rule 3 (append-only memory).

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -283,15 +283,16 @@ def _background_deviation_detection(
         logger.warning("[DEVIATION] Background detection failed (non-fatal): %s", exc)
 
 
-def _resolve_original_pending(pending) -> None:
-    """Mark the original pending_confirmation vault file as resolved.
+def _resolve_original_pending(pending, reason: str = "user_response") -> None:
+    """Resolve the original pending_confirmation record append-only (ADR-038).
 
-    Without this, the original record stays metadata.resolved=False and
-    _check_pending_confirmation re-finds it on every subsequent turn,
+    Writes a resolution tombstone via StateService.resolve_record rather than
+    mutating the original file in place. Without resolution the original would
+    be re-found by _check_pending_confirmation on every subsequent turn,
     creating an infinite confirmation loop.
     """
-    if state_service.mark_resolved(pending.id):
-        logger.info("[CONFIRM] Marked original pending %s as resolved", pending.id)
+    if state_service.resolve_record(pending.id, resolution=reason):
+        logger.info("[CONFIRM] Resolved original pending %s append-only", pending.id)
 
 
 def _check_pending_confirmation(
@@ -307,10 +308,10 @@ def _check_pending_confirmation(
                 dict with confirmed=False if declined,
                 None if no pending confirmation exists.
       records : the pending_confirmation records read during this call,
-                with any record this call resolved (via mark_resolved)
-                filtered out. The request handler can pass this list to
-                _write_pending_confirmation later in the same request to
-                skip the duplicate-write guard's redundant vault scan.
+                with any record this call resolved (via resolve_record,
+                append-only) filtered out. The request handler can pass this
+                list to _write_pending_confirmation later in the same request
+                to skip the duplicate-write guard's redundant vault scan.
     """
     try:
         resolver = state_service._state_resolver if hasattr(state_service, '_state_resolver') else None
@@ -322,13 +323,18 @@ def _check_pending_confirmation(
         if not records:
             return None, []
 
-        # Latest pending confirmation that is not resolved AND belongs to
-        # this session. Cross-session pendings are stale - resolve them
-        # silently so they don't accumulate.
+        # Resolution is derived (ADR-038): a record is resolved if it carries
+        # the legacy in-place resolved flag OR an append-only tombstone exists
+        # for it. Records are never mutated in place.
+        _resolved = state_service.resolved_ids(records)
+
+        # Latest ACTIVE pending confirmation that belongs to this session.
+        # Cross-session pendings are stale - resolve them silently so they
+        # don't fire on an unrelated conversation.
         pending = None
-        resolved_ids: set[str] = set()
+        _resolved_this_call: set[str] = set()
         for r in records:
-            if (r.metadata or {}).get("resolved"):
+            if r.id in _resolved:
                 continue
             r_session = (r.metadata or {}).get("session_id", "")
             if r_session == session_id:
@@ -336,27 +342,26 @@ def _check_pending_confirmation(
                 break
             else:
                 # Stale cross-session pending - resolve it silently
-                _resolve_original_pending(r)
-                resolved_ids.add(r.id)
+                _resolve_original_pending(r, reason="stale")
+                _resolved_this_call.add(r.id)
 
         if not pending:
-            # No matching pending in this session, but stale cross-session
-            # records may have been resolved - filter them from the returned list.
-            filtered = [r for r in records if r.id not in resolved_ids]
+            # No active pending in this session, but stale cross-session
+            # records may have been resolved - filter them from the list.
+            filtered = [r for r in records if r.id not in _resolved_this_call]
             return None, filtered
 
         action = (pending.metadata or {}).get("action", "unknown")
         action_query = (pending.metadata or {}).get("query", "")
         offer_text = pending.text
 
-        # Mark the ORIGINAL pending record as resolved FIRST - before
-        # the LLM interpretation. This prevents the infinite loop where
-        # the original record stays unresolved and gets re-found on every
-        # subsequent turn. The append-only rule is preserved by updating
-        # metadata (same pattern as soft-delete and resolved_priority fix).
+        # Resolve the ORIGINAL pending FIRST - before interpretation - so it
+        # is never re-found on a subsequent turn (the infinite-loop guard).
+        # Append-only: resolve_record writes a tombstone, it does not mutate
+        # the original file (ADR-038).
         _resolve_original_pending(pending)
-        resolved_ids.add(pending.id)
-        filtered = [r for r in records if r.id not in resolved_ids]
+        _resolved_this_call.add(pending.id)
+        filtered = [r for r in records if r.id not in _resolved_this_call]
 
         # Deterministic keyword match for YES/NO - replaces the LLM call
         # that added ~500ms latency and could misinterpret at 8B scale.
@@ -434,11 +439,16 @@ def _write_pending_confirmation(
             existing = existing_pending
         else:
             existing = state_service.read_by_category("pending_confirmation")
+        # Resolution is derived (ADR-038): only an ACTIVE (unresolved) pending
+        # for the same session+query should suppress a new offer. Tombstoned
+        # or legacy-flag-resolved records must not block re-offering.
+        _resolved = state_service.resolved_ids(existing)
         for er in existing:
+            if er.id in _resolved:
+                continue
             em = er.metadata or {}
             if (
-                not em.get("resolved")
-                and em.get("session_id") == session_id
+                em.get("session_id") == session_id
                 and em.get("query") == user_message
             ):
                 logger.info("[ASK_FIRST] Duplicate suppressed for session %s", session_id)

--- a/src/state/state_resolver.py
+++ b/src/state/state_resolver.py
@@ -189,9 +189,16 @@ class StateResolver:
         # Timer records have their own resolution semantics (latest-per-
         # timer_id with status filtering) and are excluded from both the
         # single-category and multi-category buckets here.
+        # pending_confirmation is internal ask-first control flow consumed
+        # directly by the chat endpoint (_check_pending_confirmation). It is
+        # never surfaced as "current state" in the prompt. Excluding it here
+        # also prevents append-only resolved pendings (whose original keeps
+        # metadata.resolved=False) from leaking into context (ADR-038).
         single_records = [
             r for r in records
-            if r.type not in MULTI_RECORD_CATEGORIES and r.type != "timer"
+            if r.type not in MULTI_RECORD_CATEGORIES
+            and r.type != "timer"
+            and r.type != "pending_confirmation"
         ]
         multi_records = [r for r in records if r.type in MULTI_RECORD_CATEGORIES]
 

--- a/src/state/state_service.py
+++ b/src/state/state_service.py
@@ -19,6 +19,7 @@ Design rules (per CLAUDE.md):
 from __future__ import annotations
 
 import json
+import logging
 import warnings
 from dataclasses import asdict
 from datetime import datetime
@@ -26,6 +27,8 @@ from pathlib import Path
 
 from src.core.config import get_private_vault_path
 from src.state.models import VALID_STATE_CATEGORIES, StateRecord
+
+logger = logging.getLogger("ember.state_service")
 
 
 # Subdirectory within the vault where state records live.
@@ -325,35 +328,69 @@ class StateService:
 
         return resolved_count
 
-    def mark_resolved(self, record_id: str) -> bool:
-        """Set metadata.resolved=True on the vault file matching *record_id*.
+    @staticmethod
+    def resolved_ids(records: list[StateRecord]) -> set[str]:
+        """Compute the set of record ids considered resolved (ADR-038).
 
-        In-place metadata update — same pattern as soft-delete. Returns True
-        if a matching unresolved record was found and updated, False otherwise.
+        Resolution is derived from append-only data, never from an in-place
+        edit. A record id is resolved if either:
+
+          - some record carries metadata.original_id equal to that id (an
+            append-only resolution tombstone written by resolve_record), or
+          - the record itself carries metadata.resolved == True (back-compat
+            with records resolved in place by the pre-ADR-038 code path).
+
+        Callers compute "is this record still active?" as
+        `record.id not in resolved_ids(records)`.
         """
-        import json as _json
+        resolved: set[str] = set()
+        for r in records:
+            meta = r.metadata or {}
+            if meta.get("resolved"):
+                resolved.add(r.id)
+            original_id = meta.get("original_id")
+            if original_id:
+                resolved.add(original_id)
+        return resolved
 
-        state_dir = self._get_state_dir()
-        if not state_dir.is_dir():
+    def resolve_record(self, record_id: str, *, resolution: str | None = None) -> bool:
+        """Resolve a state record append-only by appending a resolution tombstone.
+
+        Finds the record whose id == record_id and, if it is not already
+        resolved (per resolved_ids), writes a NEW record of the same category
+        carrying metadata.original_id == record_id and metadata.resolved == True.
+        The original record file is never modified (CLAUDE.md Rule 3, ADR-038).
+
+        Returns True when a tombstone was written, False when no matching
+        record exists or it was already resolved. Idempotent: a second call
+        for an already-resolved id is a no-op and writes no duplicate tombstone.
+        """
+        records = self.read_all()
+        target = next((r for r in records if r.id == record_id), None)
+        if target is None:
+            return False
+        if record_id in self.resolved_ids(records):
             return False
 
-        for f in state_dir.glob("*.json"):
-            try:
-                data = _json.loads(f.read_text(encoding="utf-8"))
-                if data.get("id") == record_id:
-                    meta = data.get("metadata") or {}
-                    if meta.get("resolved"):
-                        return False
-                    meta["resolved"] = True
-                    data["metadata"] = meta
-                    f.write_text(
-                        _json.dumps(data, ensure_ascii=False, indent=2),
-                        encoding="utf-8",
-                    )
-                    return True
-            except Exception:
-                continue
-        return False
+        meta: dict = {"resolved": True, "original_id": record_id}
+        if resolution:
+            meta["resolution"] = resolution
+        session_id = (target.metadata or {}).get("session_id")
+        if session_id:
+            meta["session_id"] = session_id
+
+        tombstone = self.make_record(
+            state_type=target.type,
+            text=f"[resolved] {target.text}",
+            source="state_resolver",
+            metadata=meta,
+        )
+        self.write(tombstone)
+        logger.info(
+            "[STATE] resolve_record: appended tombstone for %s (type=%s resolution=%s)",
+            record_id, target.type, resolution,
+        )
+        return True
 
     @staticmethod
     def make_record(

--- a/tests/test_ask_first_confirmation.py
+++ b/tests/test_ask_first_confirmation.py
@@ -175,49 +175,54 @@ class TestCheckPendingConfirmation:
         assert result["action"] == "web_search"
 
     # -------------------------------------------------------------------
-    # 6. Writes a resolution record regardless of outcome
+    # 6. Resolution is append-only and derived (ADR-038)
     # -------------------------------------------------------------------
 
-    def test_marks_original_resolved_on_yes(self, svc, vault):
-        """Confirming marks the ORIGINAL pending record as resolved."""
-        self._seed_pending(svc, query="weather forecast")
+    def test_resolves_pending_append_only_on_yes(self, svc, vault):
+        """Confirming resolves the pending append-only: the original file is
+        unchanged, a tombstone is written, the derived resolved-set marks the
+        original, and the pending is not re-found on the next turn."""
+        rec = self._seed_pending(svc, query="weather forecast")
+        original_path = svc._get_state_dir() / svc._filename_for(rec)
+        original_bytes = original_path.read_bytes()
 
-        mock_response = {"message": {"content": "YES"}}
-
-        with (
-            patch("src.api.openai_adapter.state_service", svc),
-            patch("ollama.chat", return_value=mock_response),
-        ):
+        with patch("src.api.openai_adapter.state_service", svc):
             from src.api.openai_adapter import _check_pending_confirmation
 
             result, _ = _check_pending_confirmation("sess_test_010", "Yes please")
 
-        assert result is not None
-        assert result["confirmed"] is True
-        # The original record should now be marked resolved on disk
-        records = svc.read_by_category("pending_confirmation")
-        unresolved = [r for r in records if not (r.metadata or {}).get("resolved")]
-        assert len(unresolved) == 0
+            assert result is not None
+            assert result["confirmed"] is True
+            # Append-only: the original record file is byte-for-byte unchanged.
+            assert original_path.read_bytes() == original_bytes
+            # A tombstone resolves the original via the derived resolved-set.
+            records = svc.read_by_category("pending_confirmation")
+            assert rec.id in StateService.resolved_ids(records)
+            assert any(
+                (r.metadata or {}).get("original_id") == rec.id for r in records
+            )
+            # Derived suppression: the resolved pending is not re-found.
+            again, _ = _check_pending_confirmation("sess_test_010", "anything else")
+            assert again is None
 
-    def test_marks_original_resolved_on_no(self, svc, vault):
-        """Declining also marks the ORIGINAL pending record as resolved."""
-        self._seed_pending(svc, query="weather forecast")
+    def test_resolves_pending_append_only_on_no(self, svc, vault):
+        """Declining also resolves the pending append-only (same contract)."""
+        rec = self._seed_pending(svc, query="weather forecast")
+        original_path = svc._get_state_dir() / svc._filename_for(rec)
+        original_bytes = original_path.read_bytes()
 
-        mock_response = {"message": {"content": "NO"}}
-
-        with (
-            patch("src.api.openai_adapter.state_service", svc),
-            patch("ollama.chat", return_value=mock_response),
-        ):
+        with patch("src.api.openai_adapter.state_service", svc):
             from src.api.openai_adapter import _check_pending_confirmation
 
             result, _ = _check_pending_confirmation("sess_test_010", "No thanks")
 
-        assert result is not None
-        assert result["confirmed"] is False
-        records = svc.read_by_category("pending_confirmation")
-        unresolved = [r for r in records if not (r.metadata or {}).get("resolved")]
-        assert len(unresolved) == 0
+            assert result is not None
+            assert result["confirmed"] is False
+            assert original_path.read_bytes() == original_bytes
+            records = svc.read_by_category("pending_confirmation")
+            assert rec.id in StateService.resolved_ids(records)
+            again, _ = _check_pending_confirmation("sess_test_010", "ok then")
+            assert again is None
 
 
 # ---------------------------------------------------------------------------
@@ -256,57 +261,85 @@ class TestExtractorExclusion:
 
 
 # ---------------------------------------------------------------------------
-# 9. pending_confirmation exempt from staleness filtering
+# 9. pending_confirmation is internal control flow, never surfaced (ADR-038)
 # ---------------------------------------------------------------------------
 
-class TestStalenessExemption:
+class TestPendingConfirmationNotSurfaced:
 
-    def test_staleness_exempt_set_includes_pending_confirmation(self, vault):
-        """StateResolver's _STALENESS_EXEMPT set includes pending_confirmation.
-
-        We verify this by writing a very old pending_confirmation record to
-        the vault and confirming it still appears in resolved state items.
-        A non-exempt category with the same timestamp would be filtered out.
+    def test_pending_confirmation_excluded_from_current_state(self, vault):
+        """pending_confirmation is ask-first control flow consumed directly by
+        the chat endpoint; the resolver never surfaces it as current state
+        (ADR-038). This is what lets pending resolution be append-only without
+        leaking resolved-but-flag-False pendings into the prompt. A normal
+        category still resolves, proving the exclusion is specific.
         """
         from src.state.state_resolver import StateResolver
-        from src.state.models import StateRecord
 
         service = StateService(vault_path=vault)
 
-        # Write a very old pending_confirmation record — should survive
-        # staleness for exempt categories but not for normal ones.
-        old_pc = StateRecord(
-            id="2020-01-01T00-00-00",
-            timestamp="2020-01-01T00-00-00",
-            type="pending_confirmation",
+        # An unresolved, recent pending would have surfaced under the old
+        # contract; it must not surface now.
+        pc = StateService.make_record(
+            state_type="pending_confirmation",
             text="Want me to search for that?",
             source="ask_first_detector",
             metadata={"action": "web_search", "resolved": False},
         )
-        service.write(old_pc)
+        service.write(pc)
 
-        # Also write an equally old non-exempt record for contrast.
-        old_focus = StateRecord(
-            id="2020-01-01T00-00-01",
-            timestamp="2020-01-01T00-00-01",
-            type="current_focus",
-            text="Old focus item",
+        # A normal recent state record still resolves, for contrast.
+        focus = StateService.make_record(
+            state_type="current_focus",
+            text="Active focus item",
             source="test",
         )
-        service.write(old_focus)
+        service.write(focus)
 
-        resolver = StateResolver(service=service)
+        items = StateResolver(service=service).get_current_state()
 
-        with patch(
-            "src.core.config.get_state_staleness_days", return_value=7
-        ):
-            items = resolver.get_current_state()
+        assert all(i.category != "pending_confirmation" for i in items)
+        assert any(i.category == "current_focus" for i in items)
 
-        # The old pending_confirmation should survive staleness filtering
-        pc_items = [i for i in items if i.category == "pending_confirmation"]
-        assert len(pc_items) == 1
-        assert "search" in pc_items[0].text.lower()
 
-        # The old current_focus should be filtered out by staleness
-        focus_items = [i for i in items if i.category == "current_focus"]
-        assert len(focus_items) == 0
+# ---------------------------------------------------------------------------
+# 10. Regression: resolved pending does not re-trigger (infinite-loop guard)
+# ---------------------------------------------------------------------------
+
+class TestNoInfiniteConfirmationLoop:
+
+    def _seed(self, svc, query="weather"):
+        rec = StateService.make_record(
+            state_type="pending_confirmation",
+            text="Want me to search for that?",
+            source="ask_first_detector",
+            metadata={
+                "action": "web_search", "query": query,
+                "session_id": "sess_loop", "resolved": False,
+            },
+        )
+        svc.write(rec)
+        return rec
+
+    def test_resolved_pending_does_not_retrigger(self, svc, vault):
+        """After a pending is resolved append-only, subsequent turns in the
+        same session never re-find it, so the confirmation prompt cannot loop
+        (the regression the in-place mark_resolved used to guard against).
+        Exactly one resolution tombstone is written - no per-turn accumulation.
+        """
+        rec = self._seed(svc)
+
+        with patch("src.api.openai_adapter.state_service", svc):
+            from src.api.openai_adapter import _check_pending_confirmation
+
+            first, _ = _check_pending_confirmation("sess_loop", "yes")
+            assert first is not None and first["confirmed"] is True
+
+            for msg in ("tell me a joke", "what's the time", "hello"):
+                again, _ = _check_pending_confirmation("sess_loop", msg)
+                assert again is None
+
+        records = svc.read_by_category("pending_confirmation")
+        tombstones = [
+            r for r in records if (r.metadata or {}).get("original_id") == rec.id
+        ]
+        assert len(tombstones) == 1

--- a/tests/test_state_layer.py
+++ b/tests/test_state_layer.py
@@ -414,3 +414,97 @@ def test_resolved_open_loop_excluded(tmp_path: Path) -> None:
     open_loops = [i for i in items if i.category == "open_loop"]
     assert len(open_loops) == 1
     assert open_loops[0].text == "Active loop."
+
+
+# ---------------------------------------------------------------------------
+# A2: append-only derived resolution (ADR-038)
+# ---------------------------------------------------------------------------
+
+class TestResolveRecordAppendOnly:
+    """resolve_record() resolves a record without mutating it in place, and
+    resolved_ids() derives the resolved set from the append-only tombstones
+    (plus the legacy in-place resolved flag for back-compat)."""
+
+    def _pending(self, service: StateService, session_id: str = "sess_a2") -> StateRecord:
+        rec = StateService.make_record(
+            state_type="pending_confirmation",
+            text="Want me to search for the weather?",
+            source="ask_first_detector",
+            metadata={"action": "web_search", "session_id": session_id, "resolved": False},
+        )
+        service.write(rec)
+        return rec
+
+    def test_resolve_record_is_append_only(self, tmp_path):
+        service = make_service(tmp_path)
+        rec = self._pending(service)
+        original_path = service._get_state_dir() / service._filename_for(rec)
+        original_bytes = original_path.read_bytes()
+
+        result = service.resolve_record(rec.id)
+
+        assert result is True
+        # The original record file is byte-for-byte unchanged: no in-place mutation.
+        assert original_path.read_bytes() == original_bytes
+        # A tombstone was appended pointing back at the original.
+        all_records = service.read_all()
+        tombstones = [
+            r for r in all_records if (r.metadata or {}).get("original_id") == rec.id
+        ]
+        assert len(tombstones) == 1
+        assert tombstones[0].metadata.get("resolved") is True
+        # The derived resolved set marks the original id as resolved.
+        assert rec.id in service.resolved_ids(all_records)
+
+    def test_resolve_record_is_idempotent(self, tmp_path):
+        service = make_service(tmp_path)
+        rec = self._pending(service)
+
+        assert service.resolve_record(rec.id) is True
+        # Second call: already resolved -> no-op, no duplicate tombstone.
+        assert service.resolve_record(rec.id) is False
+
+        tombstones = [
+            r for r in service.read_all()
+            if (r.metadata or {}).get("original_id") == rec.id
+        ]
+        assert len(tombstones) == 1
+
+    def test_resolve_record_unknown_id_returns_false(self, tmp_path):
+        service = make_service(tmp_path)
+        assert service.resolve_record("2099-01-01T00-00-00") is False
+
+    def test_resolved_ids_honors_legacy_in_place_flag(self, tmp_path):
+        # Back-compat: a record resolved in place by the pre-ADR-038 code path
+        # (metadata.resolved=True on the record itself) must still be treated
+        # as resolved by the derived set.
+        service = make_service(tmp_path)
+        rec = StateService.make_record(
+            state_type="pending_confirmation",
+            text="Old in-place resolved pending",
+            source="test",
+            metadata={"resolved": True},
+        )
+        service.write(rec)
+        assert rec.id in StateService.resolved_ids(service.read_all())
+
+
+class TestResolverExcludesPendingConfirmation:
+    """pending_confirmation is internal ask-first control flow, consumed
+    directly by the chat endpoint. It must never surface as 'current state'
+    in the prompt (ADR-038). This also prevents append-only resolved pendings
+    (original keeps resolved=False) from leaking into context."""
+
+    def test_active_pending_not_surfaced(self, tmp_path):
+        service = make_service(tmp_path)
+        rec = StateService.make_record(
+            state_type="pending_confirmation",
+            text="Want me to search for that?",
+            source="ask_first_detector",
+            metadata={"action": "web_search", "resolved": False},
+        )
+        rec.timestamp = _recent_ts(0)
+        service.write(rec)
+
+        items = StateResolver(service=service).get_current_state()
+        assert all(i.category != "pending_confirmation" for i in items)


### PR DESCRIPTION
## A2 - Append-only derived resolution for pending_confirmation

Second item from the architecture review. `StateService.mark_resolved()` rewrote vault files **in place** to set `metadata.resolved=True`, violating CLAUDE.md Rule 3 (append-only). It was used only for `pending_confirmation` (the ask-first flow), where resolving the original is load-bearing against an infinite confirmation loop.

### Change
- **`resolve_record(record_id)`** appends a resolution tombstone (`metadata.original_id`, `resolved=True`); the original file is never modified. Idempotent. `mark_resolved` removed.
- **`resolved_ids(records)`** is the single canonical "what is resolved" helper: union of tombstone `original_id`s and the legacy in-place `resolved` flag (back-compat, no migration).
- Both `openai_adapter` consumers (`_check_pending_confirmation`, `_write_pending_confirmation` dup-guard) compute active-ness via `resolved_ids` instead of the raw per-record flag, preserving the infinite-loop guard under append-only.
- **`StateResolver` excludes `pending_confirmation`** from current-state output (internal ask-first control flow; also removes the append-only leak surface where resolved-but-flag-False pendings would reach the prompt).

### Scope
`pending_confirmation` only. `open_loop` / `resolve_open_loops_by_topic` unchanged - the `original_id`-never-read gap is filed separately as **B-STATE-001** in KNOWN_ISSUES. See **ADR-038**.

### Tests / verification
- Full suite: **2163 passed, 0 failures**.
- New tests: append-only proof (original file byte-unchanged, tombstone written, derived suppression, no re-trigger), idempotency, legacy-flag back-compat, resolver exclusion, and a 2-turn infinite-loop regression test.
- Live in-process 2-turn simulation confirmed no re-trigger across 3 later turns, exactly one tombstone, and fix-point logs firing (Bug Standard #5/#6).

### Grill findings that shaped this
- The review premise was partly wrong: `original_id` was dead metadata; the two resolution mechanisms served different categories; "leave the resolver as-is" was unsafe (would leak resolved pendings into the prompt). All resolved in the grill before implementation.
