### PR TITLE
refactor(api): complete chat_completions decomposition (GenerationContext + enrichment pipeline) (#93 PR c)

### DIFF
--- a/docs/adr/ADR-042-generation-context-and-enrichment-pipeline.md
+++ b/docs/adr/ADR-042-generation-context-and-enrichment-pipeline.md
@@ -1,0 +1,125 @@
+# ADR-042: GenerationContext and the Two-Phase Enrichment Pipeline
+
+**Status:** Accepted
+**Date:** 2026-07-20
+**Target:** v0.18.1
+**Related:** ADR-041 (PreGeneration terminal router), ADR-040 (SSE wire contract), issue #93 (decompose `chat_completions`)
+
+## Context
+
+Issue #93 decomposes `chat_completions` in three sequenced PRs. PR (a) froze the
+SSE wire contract (ADR-040); PR (b) extracted the pre-enrichment terminal router
+(ADR-041). This ADR is **PR (c)**, the final step: introduce the per-request
+context object the earlier PRs deferred, migrate the clarification short-circuit
+onto it, and extract the request-enrichment work out of the endpoint body.
+
+After PR (b), the middle of `chat_completions` was still a long run of inline
+work: resolve `is_test` / vault flags / `project_id`, ensure the session, then a
+bare-marker clarification short-circuit, then message-mutating prep
+(pending-confirmation, task creation, timer detection) that rewrites the user
+message at several sites before generation. All of it depends on
+enrichment-resolved values and shares mutable locals.
+
+## Decision
+
+### Two carriers: a frozen context and a mutable working state
+
+- **`GenerationContext`** (frozen) carries the enrichment-resolved identity /
+  routing values that are computed once and never change: `session_id`,
+  `project_id`, `project_name`, `is_test`, `vault_enabled`, `skip_vault`,
+  `completion_id`, `stream`, the memoized query `policy`, and `raw_user_message`
+  (the clean pre-prefix snapshot).
+- **`GenerationWork`** (mutable) carries the evolving user message (rewritten with
+  system prefixes by the prep builders) and the values those builders derive
+  (`confirmation_web_items`, `confirmation_confirmed`, `confirmation_search_failed`,
+  `pending_records`; `raw_message` stays the clean snapshot).
+
+Why split rather than one object: PR (b)'s frozen `RouterContext` gave a
+*structural* no-mutation guarantee that made interceptor inputs tamper-proof. A
+prep pipeline is, by nature, a mutation flow. Freezing the values that are truly
+constant (and that the clarification terminal reads) preserves that guarantee
+where it matters, while a separate mutable carrier is honest about the message
+rewriting that genuinely happens. Both live in `src/api/pregeneration.py`
+alongside `RouterContext`; the module stays free of domain logic and of any
+runtime import from `openai_adapter`.
+
+### Two-phase enrichment, clarification in between
+
+The endpoint body becomes:
+
+```
+normalize (messages, ### Task guard, image placeholder, session_id)
+PreGenerationRouter[RouterContext].run   # empty / override / onboarding (PR b)
+build GenerationContext                   # Phase A value builders
+PreGenerationRouter[GenerationContext].run   # clarification (migrated)
+Phase B builders over GenerationWork      # confirmation, task, timer
+generation handler                        # context build, vision, intent, generate
+```
+
+Clarification runs **after** Phase A (it needs the resolved session/project/vault
+values to write its two conversation turns) and **before** the Phase B prep
+builders. That ordering is load-bearing, not cosmetic: in the pre-refactor code
+clarification early-returned before confirmation/task/timer ever ran, so a
+bare-marker turn ("google please") never triggered their side effects (task
+records, timer state, pending-confirmation resolution). Running the prep builders
+first and clarification last would fire those writes and then discard the work --
+a behavior change. Phase A -> clarification -> Phase B preserves the original
+side-effect profile exactly.
+
+### Generic router over context type
+
+`PreGenerationRouter` is made generic over its context type `C`. Two instances
+run: `PreGenerationRouter[RouterContext]` (the PR b terminals) and
+`PreGenerationRouter[GenerationContext]` (clarification). One mechanism, one
+`TerminalReply` type, one `early_return_response` funnel, one `[EARLY-RETURN]`
+log format. Clarification is the only enrichment-*dependent* terminal; it may
+perform side effects (it writes the two turns) but reads only the frozen context
+and never mutates it, so PR (b)'s contract still holds -- terminal, so nothing
+downstream consumes those writes on the same turn.
+
+### Unified completion id; memoized policy (and its limit)
+
+- One `completion_id` is minted per request and carried from the `RouterContext`
+  into the `GenerationContext`, so the pre-router terminals, the clarification
+  terminal, and the final generation response all share one id. The separate
+  `_clarification_id` is gone.
+- `GenerationContext.policy` memoizes the `classify_query` call on the **raw**
+  message. The clarification terminal consumes it instead of re-classifying.
+  **This memoization does not extend to the downstream "early"/"late" policy**:
+  those classify the message *after* the Phase B prep builders have prefixed it
+  with `[System: ...]` notes, which is a different string. Collapsing them onto
+  `GenerationContext.policy` would classify the raw message instead of the
+  prefixed one and change routing. They remain separate classifications by design.
+
+### Scoped deviation: what stays inline
+
+The plan considered extracting the B2 next-turn dispatch and the relational-
+intensity suppression into Phase B builders as well. They stay inline in the
+generation handler: both are retrieval-gating policy (they set the classification
+/ lodestone-suppression that feed context assembly), not message prep, and they
+are entangled with the context-build branch. Extracting them would be an awkward,
+higher-risk move with no clean seam. The cleanly separable, message-mutating prep
+-- pending-confirmation, task, timer -- is what became builders over
+`GenerationWork`.
+
+### Source encoding note
+
+The timer stop/check notes contain an em dash. The builders encode it as the
+`\u2014` escape so the source stays ASCII (CLAUDE.md) while the runtime prompt
+string is byte-identical to the pre-refactor note. A unit test asserts the
+runtime string carries U+2014.
+
+## Consequences
+
+- `chat_completions` reads as a sequence of named phases; the enrichment work is
+  in small, unit-testable builders (`_build_generation_context`,
+  `_apply_confirmation`, `_apply_tasks`, `_apply_timers`) beside their
+  dependencies. No symbols moved, so existing patch-based tests keep working.
+- The two-stage router pattern generalizes cleanly; a future enrichment-dependent
+  terminal drops into `PreGenerationRouter[GenerationContext]`.
+- Behavior is preserved end-to-end: the clarification write/response contract,
+  the confirmation/task/timer side effects and message prefixes, the
+  `_raw_user_message` snapshot semantics, and the A1 stream-vs-JSON invariant are
+  all unchanged. Verified by the existing endpoint integration suite plus new
+  builder-level unit tests.
+- The SSE wire format is untouched; ADR-040 remains its governing authority.

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("ember.openai_adapter")
 from src.api.limiter import limiter
 from src.api.pregeneration import (
     RouterContext,
+    GenerationContext,
     TerminalReply,
     PreGenerationRouter,
 )
@@ -943,6 +944,112 @@ def _ensure_session(session_id: str, first_user_message: str, *, test: bool = Fa
     logger.info("[SESSION] Created session %s: %s", session_id, title)
 
 
+# ---------------------------------------------------------------------------
+# Phase A enrichment value builders (ADR-042, issue #93 PR c).
+#
+# These resolve the per-request identity/routing values into the frozen
+# GenerationContext, AFTER the RouterContext-stage terminals (empty / override /
+# onboarding) have passed and BEFORE the enrichment-dependent clarification
+# terminal and the Phase B message-mutating prep builders run. Order within the
+# assembler mirrors the historical inline order exactly: is_test, then vault
+# toggle, then session ensure, then project resolution.
+# ---------------------------------------------------------------------------
+
+def _resolve_is_test(request) -> bool:
+    """Test-session flag from the X-Test-Session header."""
+    return request.headers.get("X-Test-Session", "").strip().lower() == "true"
+
+
+def _resolve_vault_enabled(body) -> bool:
+    """Effective per-request vault flag.
+
+    The global preferences toggle wins: when vault_toggle_enabled is False the
+    feature is off as a product, so the per-request body flag is ignored and the
+    vault stays enabled (stateless mode is a per-request opt-in, not a global
+    kill switch). Mirrors the original inline logic exactly.
+    """
+    _vault_global_enabled = True
+    try:
+        from src.core.preferences import read as _read_prefs
+        _vault_global_enabled = _read_prefs().get("vault_toggle_enabled", True)
+    except Exception:
+        pass
+    return body.vault_enabled if _vault_global_enabled else True
+
+
+def _resolve_project(session_id: str):
+    """Resolve (project_id, project_name) from the session record.
+
+    project_id is read from the session metadata; project_name is the project
+    record's canonical text field. Both are non-fatal - any error yields None so
+    the request proceeds without project context. Note (behavior-preserving
+    wart): this reads the vault regardless of skip_vault, exactly as the original
+    inline block did; no test guard is added here.
+    """
+    project_id = None
+    project_name = None
+    try:
+        session_rec = get_session(session_id)
+        if session_rec:
+            project_id = session_rec.get("metadata", {}).get("project_id")
+    except Exception:
+        pass  # Non-fatal - proceed without project context
+    if project_id:
+        try:
+            from src.memory.project import get_project
+            project_rec = get_project(project_id)
+            if project_rec:
+                # Project name is canonically stored in record["text"]
+                # (see src/memory/project.py:create_project).
+                project_name = project_rec.get("text") or None
+        except Exception:
+            project_name = None  # Non-fatal - proceed without project name
+    return project_id, project_name
+
+
+def _build_generation_context(
+    request,
+    body,
+    *,
+    session_id: str,
+    latest_user_message: str,
+    completion_id: str,
+) -> GenerationContext:
+    """Run the Phase A builders and assemble the frozen GenerationContext.
+
+    completion_id is carried in from the request's RouterContext so one id spans
+    the pre-router terminals, the clarification terminal, and the final
+    generation response. raw_user_message snapshots the normalized message at the
+    Phase A->B boundary (before any prep prefix injection). policy memoizes the
+    single classify_query call the clarification terminal and the downstream
+    routing all consume.
+    """
+    is_test = _resolve_is_test(request)
+    vault_enabled = _resolve_vault_enabled(body)
+    # Vault is skipped if either the test flag is set OR vault is disabled.
+    skip_vault = is_test or not vault_enabled
+
+    _ensure_session(session_id, latest_user_message, test=skip_vault)
+
+    project_id, project_name = _resolve_project(session_id)
+
+    from src.context.policies import classify_query
+    policy = classify_query(latest_user_message)
+
+    return GenerationContext(
+        session_id=session_id,
+        project_id=project_id,
+        project_name=project_name,
+        is_test=is_test,
+        vault_enabled=vault_enabled,
+        skip_vault=skip_vault,
+        completion_id=completion_id,
+        stream=bool(body.stream),
+        policy=policy,
+        raw_user_message=latest_user_message,
+    )
+
+
 @router.post("/v1/chat/completions", response_model=ChatCompletionsResponse)
 @limiter.limit("30/minute")
 async def chat_completions(request: Request, body: ChatCompletionsRequest):
@@ -1029,51 +1136,25 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
         if ";base64," in url_val:
             image_data.append(url_val.split(";base64,", 1)[1])
 
-    # --- TEST SESSION FLAG ---
-    is_test = request.headers.get("X-Test-Session", "").strip().lower() == "true"
-
-    # --- VAULT TOGGLE ---
-    # When vault_enabled=False, skip all vault reads and writes.
-    # The model runs in stateless mode: no memory retrieval, no state,
-    # no lodestone, no reflections. Constitutional review still runs.
-    # Check global toggle first - if the feature is disabled globally,
-    # vault_enabled is always True regardless of per-request setting.
-    _vault_global_enabled = True
-    try:
-        from src.core.preferences import read as _read_prefs
-        _vault_global_enabled = _read_prefs().get("vault_toggle_enabled", True)
-    except Exception:
-        pass
-    vault_enabled = body.vault_enabled if _vault_global_enabled else True
-    # Combine: vault is disabled if either test flag OR vault_enabled=False
-    _skip_vault = is_test or not vault_enabled
-
-    # --- ENSURE SESSION EXISTS ---
-    _ensure_session(session_id, latest_user_message, test=_skip_vault)
-
-    # --- RESOLVE PROJECT CONTEXT ---
-    # Look up the session's project_id so retrieval can boost project-relevant memories.
-    # Also resolve the project_name so the prompt builder can surface it to the model
-    # as an explicit <active_project> context section (BUG-002).
-    project_id = None
-    project_name: str | None = None
-    try:
-        session_rec = get_session(session_id)
-        if session_rec:
-            project_id = session_rec.get("metadata", {}).get("project_id")
-    except Exception:
-        pass  # Non-fatal - proceed without project context
-
-    if project_id:
-        try:
-            from src.memory.project import get_project
-            project_rec = get_project(project_id)
-            if project_rec:
-                # Project name is canonically stored in record["text"]
-                # (see src/memory/project.py:create_project).
-                project_name = project_rec.get("text") or None
-        except Exception:
-            project_name = None  # Non-fatal - proceed without project name
+    # --- PHASE A: build the enrichment-resolved GenerationContext (ADR-042) ---
+    # Resolve is_test / vault toggle / skip_vault / project, ensure the session,
+    # and memoize the query policy into one frozen context. completion_id is
+    # carried forward from the router so a single id spans every early-return and
+    # the final response. The downstream generation handler still reads the
+    # individual locals below; they are now sourced from the frozen context so
+    # behavior is unchanged while the values live in one place.
+    gen_ctx = _build_generation_context(
+        request,
+        body,
+        session_id=session_id,
+        latest_user_message=latest_user_message,
+        completion_id=_router_completion_id,
+    )
+    is_test = gen_ctx.is_test
+    vault_enabled = gen_ctx.vault_enabled
+    _skip_vault = gen_ctx.skip_vault
+    project_id = gen_ctx.project_id
+    project_name = gen_ctx.project_name
 
     # --- BARE-MARKER CLARIFICATION SHORT-CIRCUIT (B2) ---
     # When the user invokes an explicit web marker ("google please",

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -570,14 +570,78 @@ def _intercept_onboarding(ctx: RouterContext) -> Optional[TerminalReply]:
     return None
 
 
-# Ordered terminal chain. Declared order IS precedence and mirrors the
+def _intercept_clarification(ctx: GenerationContext) -> Optional[TerminalReply]:
+    """Claim bare-marker queries ("google please", "look it up") that carry an
+    explicit web marker but no search content, before any classifier/search
+    dispatch (B2).
+
+    Enrichment-DEPENDENT terminal (ADR-042): unlike empty/override/onboarding it
+    reads enrichment-resolved values off the frozen GenerationContext. It uses
+    the memoized policy (no re-classification) and, unless the vault is skipped,
+    writes both conversation turns keyed by the resolved session/project so the
+    NEXT turn's dispatch can detect awaiting_search_content on the assistant
+    record. Terminal, so nothing downstream consumes those writes this turn. It
+    reads only the frozen context and never mutates it. The scripted reply shares
+    the request's unified completion_id via the single early_return_response
+    funnel at the call site.
+    """
+    if not ctx.policy.emit_clarification:
+        return None
+
+    from src.context.policies import SCRIPTED_CLARIFICATION_RESPONSE
+
+    logger.warning("[CLARIFY] emit clarification, bypass classifier+search")
+
+    # Write both turns so the next-turn handler can detect awaiting_search_content
+    # on the assistant record. Skipped in test/stateless mode (skip_vault).
+    if not ctx.skip_vault:
+        _user_clar_meta = {
+            "role": "user",
+            "content_kind": "user_content",
+            "session_id": ctx.session_id,
+        }
+        _assistant_clar_meta = {
+            "role": "assistant",
+            "content_kind": "answer",
+            "session_id": ctx.session_id,
+            "source": "clarification",
+            "awaiting_search_content": True,
+        }
+        if ctx.project_id:
+            _user_clar_meta["project_id"] = ctx.project_id
+            _assistant_clar_meta["project_id"] = ctx.project_id
+        write_memory(
+            text=ctx.raw_user_message,
+            memory_type="conversation",
+            source="chat",
+            tags=["conversation"],
+            metadata=_user_clar_meta,
+        )
+        write_memory(
+            text=SCRIPTED_CLARIFICATION_RESPONSE,
+            memory_type="conversation",
+            source="chat",
+            tags=["conversation", "clarification"],
+            metadata=_assistant_clar_meta,
+        )
+
+    return TerminalReply(SCRIPTED_CLARIFICATION_RESPONSE, label="clarification")
+
+
+# Pre-enrichment terminal chain. Declared order IS precedence and mirrors the
 # historical top-to-bottom short-circuit order: empty, then override, then
-# onboarding. The clarification short-circuit is intentionally NOT here - it
-# writes adapter-level conversation turns keyed by session/project, so it is
-# not enrichment-independent and stays inline until PR c (ADR-041).
+# onboarding. These are enrichment-INDEPENDENT (RouterContext only).
 _pre_generation_router = PreGenerationRouter(
     [_intercept_empty, _intercept_override, _intercept_onboarding]
 )
+
+# Post-enrichment terminal chain (ADR-042 PR c). Runs over the frozen
+# GenerationContext after the Phase A value builders resolve session/project/
+# vault and before the Phase B prep builders. Clarification is the only
+# enrichment-dependent terminal; it kept its historical position (before
+# confirmation/task/timer) so a bare-marker turn short-circuits before any of
+# their side effects run.
+_enriched_generation_router = PreGenerationRouter([_intercept_clarification])
 
 
 class OpenAIMessage(BaseModel):
@@ -1156,62 +1220,21 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     project_id = gen_ctx.project_id
     project_name = gen_ctx.project_name
 
-    # --- BARE-MARKER CLARIFICATION SHORT-CIRCUIT (B2) ---
-    # When the user invokes an explicit web marker ("google please",
-    # "look it up", "search the web for me") but provides no actual
-    # search content, route to a hardcoded clarification response
-    # rather than dispatching a useless bare query to SearXNG.
-    #
-    # Bypasses constitutional review. The clarification text is a
-    # hardcoded trusted string identical in trust class to
-    # SCRIPTED_ASK_FIRST_RESPONSE substitution.
-    from src.context.policies import (
-        SCRIPTED_CLARIFICATION_RESPONSE,
-        classify_query as _classify_for_clarification,
-    )
-    _clarification_check_policy = _classify_for_clarification(latest_user_message)
-    if _clarification_check_policy.emit_clarification:
-        logger.warning("[CLARIFY] emit clarification, bypass classifier+search")
-        _clarification_id = f"chatcmpl-{uuid.uuid4().hex}"
-
-        # Write both turns so the next-turn handler can detect
-        # awaiting_search_content on the assistant record.
-        if not (is_test or not vault_enabled):
-            _user_clar_meta = {
-                "role": "user",
-                "content_kind": "user_content",
-                "session_id": session_id,
-            }
-            _assistant_clar_meta = {
-                "role": "assistant",
-                "content_kind": "answer",
-                "session_id": session_id,
-                "source": "clarification",
-                "awaiting_search_content": True,
-            }
-            if project_id:
-                _user_clar_meta["project_id"] = project_id
-                _assistant_clar_meta["project_id"] = project_id
-            write_memory(
-                text=latest_user_message,
-                memory_type="conversation",
-                source="chat",
-                tags=["conversation"],
-                metadata=_user_clar_meta,
-            )
-            write_memory(
-                text=SCRIPTED_CLARIFICATION_RESPONSE,
-                memory_type="conversation",
-                source="chat",
-                tags=["conversation", "clarification"],
-                metadata=_assistant_clar_meta,
-            )
-
+    # --- ENRICHED TERMINAL ROUTER: clarification (B2, ADR-042 PR c) ---
+    # The bare-marker clarification short-circuit ("google please" with no search
+    # content) now runs as an enrichment-dependent terminal interceptor over the
+    # frozen GenerationContext. It runs AFTER Phase A value resolution and BEFORE
+    # the Phase B prep builders (confirmation/task/timer), preserving its
+    # historical position so a bare-marker turn short-circuits before any of
+    # their side effects run. Same single early_return_response funnel and the
+    # unified completion_id, so the A1 stream-vs-JSON invariant holds.
+    _enriched_reply = _enriched_generation_router.run(gen_ctx)
+    if _enriched_reply is not None:
         return early_return_response(
-            SCRIPTED_CLARIFICATION_RESPONSE,
-            _clarification_id,
-            stream=bool(body.stream),
-            label="clarification",
+            _enriched_reply.text,
+            gen_ctx.completion_id,
+            stream=gen_ctx.stream,
+            label=_enriched_reply.label,
         )
 
     # --- RESOLVE INTER-SESSION TIME GAP (BUG-003) ---

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -16,6 +16,7 @@ from src.api.limiter import limiter
 from src.api.pregeneration import (
     RouterContext,
     GenerationContext,
+    GenerationWork,
     TerminalReply,
     PreGenerationRouter,
 )
@@ -1114,6 +1115,161 @@ def _build_generation_context(
     )
 
 
+# ---------------------------------------------------------------------------
+# Phase B generation-prep builders (ADR-042, issue #93 PR c).
+#
+# These run AFTER the enriched clarification terminal passes and BEFORE the
+# generation handler. Each operates on the mutable GenerationWork: work.message
+# is the evolving query (rewritten with system prefixes for the model), while
+# work.raw_message stays the clean pre-prefix snapshot _write_pending_confirmation
+# needs. Logic, order, and side effects mirror the previous inline blocks exactly.
+# Runtime-identical to the originals; only the structure changed.
+# ---------------------------------------------------------------------------
+
+def _apply_confirmation(gen_ctx: GenerationContext, work: GenerationWork) -> None:
+    """Pending-confirmation check (pre-generation).
+
+    If Ember previously asked "want me to search for that?" and the user is now
+    responding, interpret the response via LLM and route accordingly. A confirmed
+    web_search runs the deferred search on the ORIGINAL stored query and
+    overwrites both work.message and work.raw_message with it (so the stored
+    search query stays clean). Sets the confirmation-derived values the generation
+    handler consumes. Gated on is_test.
+    """
+    if not gen_ctx.is_test:
+        _confirmation_result, work.pending_records = _check_pending_confirmation(
+            gen_ctx.session_id, work.message
+        )
+    else:
+        _confirmation_result, work.pending_records = None, []
+    if _confirmation_result is not None:
+        if _confirmation_result["confirmed"] and _confirmation_result["action"] == "web_search":
+            work.confirmation_confirmed = True
+            _original_query = _confirmation_result["query"]
+            work.message = _original_query
+            work.raw_message = _original_query
+            try:
+                from src.tools.web_search import web_search
+                work.confirmation_web_items = web_search(_original_query)
+                logger.info("[CONFIRM] Executing deferred web search for: %s",
+                            _original_query[:80])
+            except Exception as exc:
+                logger.warning("[CONFIRM] Deferred web search failed: %s", exc)
+                work.confirmation_search_failed = True
+        elif not _confirmation_result["confirmed"]:
+            pass
+
+
+def _apply_tasks(gen_ctx: GenerationContext, work: GenerationWork) -> None:
+    """Task creation (pre-generation).
+
+    Path 1: explicit task request ("create a task for X"). Path 2: pending offer
+    confirmation ("yes" after Ember offered a task). Prefixes work.message with a
+    system note so Ember confirms naturally. Gated on is_test. Vault writes via
+    create_task_record.
+    """
+    from src.tasks.task_handler import (
+        detect_explicit_task_request,
+        check_pending_confirmation,
+        create_task as create_task_record,
+    )
+
+    explicit_task_titles = detect_explicit_task_request(work.message) if not gen_ctx.is_test else []
+    if explicit_task_titles:
+        created_titles = []
+        failed_titles = []
+        for task_title in explicit_task_titles:
+            result = create_task_record(
+                title=task_title,
+                source="user_input",
+                session_id=gen_ctx.session_id,
+                project_id=gen_ctx.project_id,
+            )
+            if result.created:
+                created_titles.append(task_title)
+            else:
+                logger.warning("[TASK] Write failed for '%s': %s", task_title, result.error)
+                failed_titles.append(task_title)
+
+        # Inject system context so Ember confirms naturally
+        if created_titles:
+            titles_str = ", ".join(f'"{t}"' for t in created_titles)
+            work.message = f"[System: tasks created - {titles_str}] {work.message}"
+
+    pending_result = check_pending_confirmation(
+        session_id=gen_ctx.session_id,
+        user_message=work.message,
+        project_id=gen_ctx.project_id,
+    ) if not gen_ctx.is_test else None
+    if pending_result is not None:
+        if pending_result.created and pending_result.task_titles:
+            titles_str = ", ".join(f'"{t}"' for t in pending_result.task_titles)
+            work.message = f'[System: tasks created - {titles_str}] {work.message}'
+        elif not pending_result.created:
+            work.message = f'[System: user declined task creation] {work.message}'
+
+
+def _apply_timers(gen_ctx: GenerationContext, work: GenerationWork) -> None:
+    """Timer detection (pre-generation) - BUG-004.
+
+    Three intent paths, each fully non-fatal: start (write a running timer),
+    stop (write a stopped record for the most recent active timer), check (inject
+    elapsed-time status). Prefixes work.message with the immediate confirmation
+    note. Skipped when skip_vault (timer writes are vault writes). The em dash in
+    the stop/check notes is written as \\u2014 so the source stays ASCII while the
+    runtime prompt text is byte-identical to the original.
+    """
+    if not gen_ctx.skip_vault:
+        try:
+            from src.state.timer_service import (
+                detect_check_timer,
+                detect_start_timer,
+                detect_stop_timer,
+                format_elapsed,
+                get_active_timers,
+                start_timer,
+                stop_timer,
+            )
+
+            timer_label = detect_start_timer(work.message)
+            if timer_label:
+                try:
+                    start_timer(label=timer_label, session_id=gen_ctx.session_id)
+                    work.message = (
+                        f'[System: timer started for "{timer_label}"] {work.message}'
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("[TIMER] Failed to start timer: %s", exc)
+            elif detect_stop_timer(work.message) or detect_check_timer(work.message):
+                try:
+                    active = get_active_timers()
+                    wants_stop = detect_stop_timer(work.message)
+                    if active:
+                        statuses = []
+                        for t in active:
+                            started_at = (t.metadata or {}).get("started_at", "")
+                            statuses.append(f'"{t.text}" {format_elapsed(started_at)}')
+                        statuses_str = "; ".join(statuses)
+                        if wants_stop:
+                            most_recent = active[0]
+                            stop_timer(timer_id=most_recent.metadata["timer_id"])
+                            work.message = (
+                                f"[System: timer stopped \u2014 was {statuses_str}] {work.message}"
+                            )
+                        else:
+                            work.message = (
+                                f"[System: active timers \u2014 {statuses_str}] {work.message}"
+                            )
+                    else:
+                        note = "no active timer to stop" if wants_stop else "no active timers"
+                        work.message = f"[System: {note}] {work.message}"
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("[TIMER] Failed to query/stop timers: %s", exc)
+        except Exception as exc:  # noqa: BLE001
+            # Defensive: timer module load failures should never break a chat request.
+            logger.warning("[TIMER] Detection block failed: %s", exc)
+
+
 @router.post("/v1/chat/completions", response_model=ChatCompletionsResponse)
 @limiter.limit("30/minute")
 async def chat_completions(request: Request, body: ChatCompletionsRequest):
@@ -1244,145 +1400,24 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # the section is omitted from the prompt entirely.
     last_session_label = _resolve_last_session_label(session_id)
 
-    # Capture the raw user message before any system prefix injection
-    # modifies it. Used by _write_pending_confirmation so the stored
-    # query is clean for deferred web search execution. Without this,
-    # the search query arrives at SearXNG as "[System: no relevant
-    # vault content...] What is the population of Tokyo?" - garbage.
-    _raw_user_message = latest_user_message
-
-    # --- PENDING CONFIRMATION CHECK (pre-generation) ---
-    # If Ember previously asked "want me to search for that?" and the user
-    # is now responding, interpret the response via LLM (no keyword matching)
-    # and route accordingly. Confirmation triggers web search on the original
-    # query; decline clears the state and proceeds normally.
-    _confirmation_web_items: list[dict] = []
-    _confirmation_search_failed = False
-    _confirmation_confirmed = False
-    if not is_test:
-        _confirmation_result, _pending_records = _check_pending_confirmation(
-            session_id, latest_user_message
-        )
-    else:
-        _confirmation_result, _pending_records = None, []
-    if _confirmation_result is not None:
-        if _confirmation_result["confirmed"] and _confirmation_result["action"] == "web_search":
-            _confirmation_confirmed = True
-            _original_query = _confirmation_result["query"]
-            latest_user_message = _original_query
-            _raw_user_message = _original_query
-            try:
-                from src.tools.web_search import web_search
-                _confirmation_web_items = web_search(_original_query)
-                logger.info("[CONFIRM] Executing deferred web search for: %s",
-                            _original_query[:80])
-            except Exception as exc:
-                logger.warning("[CONFIRM] Deferred web search failed: %s", exc)
-                _confirmation_search_failed = True
-        elif not _confirmation_result["confirmed"]:
-            pass
-
-    # --- TASK CREATION (pre-generation) ---
-    # Path 1: Explicit task request ("create a task for X")
-    # Path 2: Pending offer confirmation ("yes" after Ember offered a task)
-    from src.tasks.task_handler import (
-        detect_explicit_task_request,
-        check_pending_confirmation,
-        create_task as create_task_record,
-    )
-
-    explicit_task_titles = detect_explicit_task_request(latest_user_message) if not is_test else []
-    if explicit_task_titles:
-        created_titles = []
-        failed_titles = []
-        for task_title in explicit_task_titles:
-            result = create_task_record(
-                title=task_title,
-                source="user_input",
-                session_id=session_id,
-                project_id=project_id,
-            )
-            if result.created:
-                created_titles.append(task_title)
-            else:
-                logger.warning("[TASK] Write failed for '%s': %s", task_title, result.error)
-                failed_titles.append(task_title)
-
-        # Inject system context so Ember confirms naturally
-        if created_titles:
-            titles_str = ", ".join(f'"{t}"' for t in created_titles)
-            latest_user_message = f"[System: tasks created - {titles_str}] {latest_user_message}"
-
-    pending_result = check_pending_confirmation(
-        session_id=session_id,
-        user_message=latest_user_message,
-        project_id=project_id,
-    ) if not is_test else None
-    if pending_result is not None:
-        if pending_result.created and pending_result.task_titles:
-            titles_str = ", ".join(f'"{t}"' for t in pending_result.task_titles)
-            latest_user_message = f'[System: tasks created - {titles_str}] {latest_user_message}'
-        elif not pending_result.created:
-            latest_user_message = f'[System: user declined task creation] {latest_user_message}'
-
-    # --- TIMER DETECTION (pre-generation) - BUG-004 ---
-    # Three intent paths, each fully non-fatal:
-    #   1. start: detected label -> write a running timer record
-    #   2. stop:  any active timers -> write a stopped record for the most recent
-    #   3. check: any active timers -> inject elapsed-time status
-    # Active timers are also surfaced via StateResolver into the context packet,
-    # so the system note here is the immediate confirmation; the resolver
-    # provides the longer-lived awareness.
-    # Skip for test sessions - timer writes are vault writes.
-    if not _skip_vault:
-        try:
-            from src.state.timer_service import (
-                detect_check_timer,
-                detect_start_timer,
-                detect_stop_timer,
-                format_elapsed,
-                get_active_timers,
-                start_timer,
-                stop_timer,
-            )
-
-            timer_label = detect_start_timer(latest_user_message)
-            if timer_label:
-                try:
-                    start_timer(label=timer_label, session_id=session_id)
-                    latest_user_message = (
-                        f'[System: timer started for "{timer_label}"] {latest_user_message}'
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("[TIMER] Failed to start timer: %s", exc)
-            elif detect_stop_timer(latest_user_message) or detect_check_timer(latest_user_message):
-                try:
-                    active = get_active_timers()
-                    wants_stop = detect_stop_timer(latest_user_message)
-                    if active:
-                        statuses = []
-                        for t in active:
-                            started_at = (t.metadata or {}).get("started_at", "")
-                            statuses.append(f'"{t.text}" {format_elapsed(started_at)}')
-                        statuses_str = "; ".join(statuses)
-                        if wants_stop:
-                            most_recent = active[0]
-                            stop_timer(timer_id=most_recent.metadata["timer_id"])
-                            latest_user_message = (
-                                f"[System: timer stopped — was {statuses_str}] {latest_user_message}"
-                            )
-                        else:
-                            latest_user_message = (
-                                f"[System: active timers — {statuses_str}] {latest_user_message}"
-                            )
-                    else:
-                        note = "no active timer to stop" if wants_stop else "no active timers"
-                        latest_user_message = f"[System: {note}] {latest_user_message}"
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("[TIMER] Failed to query/stop timers: %s", exc)
-        except Exception as exc:  # noqa: BLE001
-            # Defensive: timer module load failures should never break a chat request.
-            logger.warning("[TIMER] Detection block failed: %s", exc)
+    # --- PHASE B: generation-prep builders (ADR-042 PR c) ---
+    # Confirmation, task, and timer prep run over a mutable GenerationWork whose
+    # message is the evolving query (rewritten with system prefixes for the
+    # model) and whose raw_message stays the clean pre-prefix snapshot that
+    # _write_pending_confirmation needs for the deferred web-search query. Order
+    # and side effects are identical to the previous inline blocks. (B2 next-turn
+    # dispatch and relational suppression remain inline below - they are
+    # retrieval-gating policy, not message prep; see ADR-042.)
+    work = GenerationWork(message=latest_user_message)
+    _apply_confirmation(gen_ctx, work)
+    _apply_tasks(gen_ctx, work)
+    _apply_timers(gen_ctx, work)
+    latest_user_message = work.message
+    _raw_user_message = work.raw_message
+    _confirmation_web_items = work.confirmation_web_items
+    _confirmation_confirmed = work.confirmation_confirmed
+    _confirmation_search_failed = work.confirmation_search_failed
+    _pending_records = work.pending_records
 
     # --- RELATIONAL INTENSITY AMPLIFICATION GATE ---
     # Pre-generation check: if the user's message contains markers that

--- a/src/api/pregeneration.py
+++ b/src/api/pregeneration.py
@@ -1,56 +1,114 @@
 """
 src/api/pregeneration.py
 
-Terminal pre-generation routing mechanism for /v1/chat/completions (ADR-041,
-issue #93 PR b).
+Terminal pre-generation routing mechanism for /v1/chat/completions
+(ADR-041 PR b; ADR-042 PR c).
 
-This module is the generic dispatch machinery only - it carries no domain
-knowledge and imports nothing from openai_adapter, so it can never form an
-import cycle with it. The concrete interceptors (empty / override / onboarding)
-live in openai_adapter alongside their dependencies; this module just holds the
-context type, the terminal-reply type, and the ordered-chain runner.
+This module holds the generic dispatch machinery plus the per-request context
+types it dispatches over. It carries no domain LOGIC and imports nothing from
+openai_adapter at runtime, so it can never form an import cycle with it. The
+concrete interceptors (empty / override / onboarding, and the enrichment-
+dependent clarification) live in openai_adapter alongside their dependencies;
+this module holds only the context types, the terminal-reply type, and the
+ordered-chain runner.
 
-Contract - "enrichment-independent terminal interceptor" (ADR-041):
-  An interceptor is a callable (RouterContext) -> TerminalReply | None. It may
-  only read the RouterContext; it must not mutate it or any value the
-  enrichment pipeline or generation handler later reads. Any side effects must
-  be fully encapsulated behind a service that needs no enrichment-resolved
-  inputs (this is why onboarding qualifies but the clarification short-circuit,
-  which writes adapter-level conversation turns keyed by session/project, does
-  not - the latter is deferred to PR c).
+Two router stages exist (ADR-042):
+  1. Pre-enrichment: PreGenerationRouter[RouterContext] runs the enrichment-
+     INDEPENDENT terminals (empty / override / onboarding) before any session /
+     project / vault resolution.
+  2. Post-enrichment: PreGenerationRouter[GenerationContext] runs the
+     enrichment-DEPENDENT terminals (clarification) after the Phase A value
+     builders have resolved session_id / project_id / is_test / vault_enabled,
+     and before the Phase B message-mutating prep builders run.
 
-The RouterContext and TerminalReply dataclasses are frozen so the "must not
-mutate the context" half of the contract is enforced structurally rather than
-by convention.
+Contract - terminal interceptor:
+  An interceptor is a callable (C) -> TerminalReply | None over its context
+  type C. It may only READ the context; it must not mutate it. Side effects are
+  allowed only when they need no value the later pipeline reads back on the same
+  turn (onboarding writes onboarding state; clarification writes conversation
+  turns keyed by the already-resolved session/project - both terminal, so
+  nothing downstream consumes their output on that turn).
 
-Deviation from issue #93's stated signature (documented in ADR-041): the issue
-described interceptors as (ctx) -> Optional[Response]. We instead return
-TerminalReply DATA and let the single caller translate it into a response via
-early_return_response. That gives the A1 stream-vs-JSON invariant exactly one
-funnel (one early_return_response call site, not three) and keeps this module
-free of any dependency on the response builders.
+The context dataclasses (RouterContext, GenerationContext) are frozen so the
+"must not mutate the context" half of the contract is enforced structurally.
+GenerationWork - the mutable per-request carrier for the evolving message and
+prep-derived values - is deliberately NOT frozen: it is the Phase B builders'
+working state, never an interceptor input.
+
+Deviation from issue #93's stated signature (documented in ADR-041):
+interceptors return TerminalReply DATA, not a Response. The single caller
+translates it via early_return_response, giving the A1 stream-vs-JSON invariant
+exactly one funnel and keeping this module free of any response-builder import.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Generic, Optional, Sequence, TypeVar
+
+if TYPE_CHECKING:
+    # Typing-only import: the memoized query policy carried on GenerationContext.
+    # Imported under TYPE_CHECKING so this module stays runtime-import-light and
+    # domain-logic-free.
+    from src.context.policies import ContextPolicy
 
 
 @dataclass(frozen=True)
 class RouterContext:
-    """Read-only inputs a terminal interceptor is allowed to see.
+    """Read-only inputs an enrichment-INDEPENDENT terminal interceptor may see.
 
-    Deliberately minimal - NOT the full GenerationContext (that arrives in
-    PR c). It carries only what the empty / override / onboarding decisions
-    need plus the completion id minted once per request so every terminal
-    reply and its log line share one id.
+    Deliberately minimal: only what empty / override / onboarding need, plus the
+    completion id minted once per request so every terminal reply and its log
+    line share one id. GenerationContext (below) is the post-enrichment superset.
     """
 
     latest_user_message: str
     stream: bool
     image_parts: list
     completion_id: str
+
+
+@dataclass(frozen=True)
+class GenerationContext:
+    """Read-only, enrichment-resolved per-request identity/routing values.
+
+    Built by the Phase A value builders once the RouterContext-stage terminals
+    have passed. Frozen: these values are resolved once and never change, so an
+    enrichment-dependent interceptor (clarification) reading them cannot have its
+    inputs mutated out from under it by the later Phase B prep builders.
+
+    completion_id and stream are carried forward from the request's RouterContext
+    so a single id spans the pre-router terminals, the clarification terminal,
+    and the final generation response. raw_user_message is the clean pre-prefix
+    snapshot of the user message taken at the Phase A->B boundary (the value
+    _write_pending_confirmation stores as the web-search query); the mutating
+    message itself lives on GenerationWork, not here.
+    """
+
+    session_id: str
+    project_id: Optional[str]
+    project_name: Optional[str]
+    is_test: bool
+    vault_enabled: bool
+    skip_vault: bool
+    completion_id: str
+    stream: bool
+    policy: "ContextPolicy"
+    raw_user_message: str
+
+
+@dataclass
+class GenerationWork:
+    """Mutable per-request working state for the Phase B generation-prep builders.
+
+    Holds the evolving user message - rewritten at several prep sites
+    (confirmation override, task / timer system-prefixes, thin-vault offer) - and
+    the values those builders derive for the generation handler. NOT frozen and
+    NOT an interceptor input: only the Phase B builders and the generation
+    handler touch it.
+    """
+
+    message: str
 
 
 @dataclass(frozen=True)
@@ -66,24 +124,29 @@ class TerminalReply:
     label: str
 
 
-# An interceptor inspects the context and either claims the request (returns a
+# Context type an interceptor dispatches over (RouterContext or GenerationContext).
+C = TypeVar("C")
+
+# An interceptor inspects its context and either claims the request (returns a
 # TerminalReply) or passes (returns None).
-Interceptor = Callable[[RouterContext], Optional[TerminalReply]]
+Interceptor = Callable[[C], Optional[TerminalReply]]
 
 
-class PreGenerationRouter:
-    """Ordered chain of terminal interceptors; the first to claim wins.
+class PreGenerationRouter(Generic[C]):
+    """Ordered chain of terminal interceptors over a context type C; first claim wins.
 
-    run() walks the interceptors in declared order and returns the first
-    non-None TerminalReply, short-circuiting the rest. Declared order IS the
-    precedence, so it must mirror the historical top-to-bottom order of the
-    short-circuits it replaces.
+    Generic over C so one mechanism serves both the pre-enrichment RouterContext
+    stage and the post-enrichment GenerationContext stage (ADR-042). run() walks
+    the interceptors in declared order and returns the first non-None
+    TerminalReply, short-circuiting the rest. Declared order IS the precedence,
+    so it must mirror the historical top-to-bottom order of the short-circuits it
+    replaces.
     """
 
-    def __init__(self, interceptors: Sequence[Interceptor]):
+    def __init__(self, interceptors: Sequence[Interceptor[C]]):
         self._interceptors = tuple(interceptors)
 
-    def run(self, ctx: RouterContext) -> Optional[TerminalReply]:
+    def run(self, ctx: C) -> Optional[TerminalReply]:
         for interceptor in self._interceptors:
             reply = interceptor(ctx)
             if reply is not None:

--- a/src/api/pregeneration.py
+++ b/src/api/pregeneration.py
@@ -43,7 +43,7 @@ exactly one funnel and keeping this module free of any response-builder import.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Generic, Optional, Sequence, TypeVar
 
 if TYPE_CHECKING:
@@ -102,13 +102,29 @@ class GenerationWork:
     """Mutable per-request working state for the Phase B generation-prep builders.
 
     Holds the evolving user message - rewritten at several prep sites
-    (confirmation override, task / timer system-prefixes, thin-vault offer) - and
-    the values those builders derive for the generation handler. NOT frozen and
-    NOT an interceptor input: only the Phase B builders and the generation
-    handler touch it.
+    (confirmation override, task / timer system-prefixes) - and the values those
+    builders derive for the generation handler. NOT frozen and NOT an interceptor
+    input: only the Phase B builders and the generation handler touch it.
+
+    raw_message is the clean pre-prefix snapshot of the query (defaults to the
+    message at construction). The confirmation builder overwrites BOTH message
+    and raw_message with the original deferred query on a confirmed web search;
+    the task and timer builders prefix only message, leaving raw_message clean
+    for _write_pending_confirmation. confirmation_* / pending_records carry the
+    confirmation builder's outputs to the generation handler.
     """
 
     message: str
+    raw_message: str = ""
+    confirmation_web_items: list = field(default_factory=list)
+    confirmation_confirmed: bool = False
+    confirmation_search_failed: bool = False
+    pending_records: list = field(default_factory=list)
+
+    def __post_init__(self):
+        # Snapshot the clean message when a caller does not pass raw_message.
+        if not self.raw_message:
+            self.raw_message = self.message
 
 
 @dataclass(frozen=True)

--- a/tests/test_generation_context.py
+++ b/tests/test_generation_context.py
@@ -12,8 +12,15 @@ interceptor and the generation handler consume.
 """
 
 from unittest.mock import patch
+from types import SimpleNamespace
 
-from src.api.openai_adapter import _build_generation_context
+from src.api.openai_adapter import (
+    _build_generation_context,
+    _apply_confirmation,
+    _apply_tasks,
+    _apply_timers,
+)
+from src.api.pregeneration import GenerationContext, GenerationWork
 
 
 class _FakeReq:
@@ -82,3 +89,87 @@ def test_build_generation_context_vault_disabled_sets_skip():
     assert ctx.is_test is False
     assert ctx.vault_enabled is False      # per-request opt-out honored
     assert ctx.skip_vault is True          # vault disabled forces skip
+
+
+# ---------------------------------------------------------------------------
+# Phase B prep builders over GenerationWork (verbatim extractions).
+# ---------------------------------------------------------------------------
+
+def _gctx(is_test=False, skip_vault=False, session_id="sess_test_b", project_id=None):
+    return GenerationContext(
+        session_id=session_id, project_id=project_id, project_name=None,
+        is_test=is_test, vault_enabled=True, skip_vault=skip_vault,
+        completion_id="chatcmpl-b", stream=False, policy=None, raw_user_message="",
+    )
+
+
+def test_apply_confirmation_confirmed_web_search_overwrites_message():
+    ctx = _gctx()
+    work = GenerationWork(message="yes")
+    result = {"confirmed": True, "action": "web_search", "query": "population of tokyo"}
+    with patch("src.api.openai_adapter._check_pending_confirmation",
+               return_value=(result, ["rec"])), \
+         patch("src.tools.web_search.web_search", return_value=[{"title": "x"}]):
+        _apply_confirmation(ctx, work)
+    # Both the working message AND the clean snapshot become the original query.
+    assert work.message == "population of tokyo"
+    assert work.raw_message == "population of tokyo"
+    assert work.confirmation_confirmed is True
+    assert work.confirmation_web_items == [{"title": "x"}]
+    assert work.pending_records == ["rec"]
+
+
+def test_apply_confirmation_is_test_is_noop():
+    ctx = _gctx(is_test=True)
+    work = GenerationWork(message="yes")
+    with patch("src.api.openai_adapter._check_pending_confirmation") as chk:
+        _apply_confirmation(ctx, work)
+    chk.assert_not_called()
+    assert work.confirmation_confirmed is False
+    assert work.pending_records == []
+
+
+def test_apply_tasks_explicit_request_prefixes_message():
+    ctx = _gctx()
+    work = GenerationWork(message="make a task to call mom")
+    created = SimpleNamespace(created=True, error=None)
+    with patch("src.tasks.task_handler.detect_explicit_task_request",
+               return_value=["call mom"]), \
+         patch("src.tasks.task_handler.create_task", return_value=created), \
+         patch("src.tasks.task_handler.check_pending_confirmation", return_value=None):
+        _apply_tasks(ctx, work)
+    assert work.message.startswith('[System: tasks created - "call mom"]')
+
+
+def test_apply_timers_skip_vault_is_noop():
+    ctx = _gctx(skip_vault=True)
+    work = GenerationWork(message="start a timer for tea")
+    _apply_timers(ctx, work)
+    assert work.message == "start a timer for tea"
+
+
+def test_apply_timers_start_prefixes_message():
+    ctx = _gctx(skip_vault=False)
+    work = GenerationWork(message="start a timer for tea")
+    with patch("src.state.timer_service.detect_start_timer", return_value="tea"), \
+         patch("src.state.timer_service.start_timer"):
+        _apply_timers(ctx, work)
+    assert work.message.startswith('[System: timer started for "tea"]')
+
+
+def test_apply_timers_stop_note_uses_real_em_dash_at_runtime():
+    # The builder emits U+2014 at runtime; the note text must stay
+    # contain the actual em dash (U+2014), byte-identical to the pre-refactor note.
+    ctx = _gctx(skip_vault=False)
+    work = GenerationWork(message="stop the timer")
+    active = [SimpleNamespace(text="tea", metadata={"started_at": "", "timer_id": "t1"})]
+    with patch("src.state.timer_service.detect_start_timer", return_value=None), \
+         patch("src.state.timer_service.detect_stop_timer", return_value=True), \
+         patch("src.state.timer_service.detect_check_timer", return_value=False), \
+         patch("src.state.timer_service.get_active_timers", return_value=active), \
+         patch("src.state.timer_service.format_elapsed", return_value="1m"), \
+         patch("src.state.timer_service.stop_timer"):
+        _apply_timers(ctx, work)
+    dash = chr(0x2014)
+    assert dash in work.message
+    assert work.message.startswith(f"[System: timer stopped {dash} was ")

--- a/tests/test_generation_context.py
+++ b/tests/test_generation_context.py
@@ -1,0 +1,84 @@
+"""
+tests/test_generation_context.py
+
+Tests for the Phase A enrichment value builders that assemble the frozen
+GenerationContext (ADR-042, issue #93 PR c).
+
+These exercise _build_generation_context directly: given a request/body and the
+normalization outputs (session_id, latest_user_message, completion_id), it must
+resolve is_test / vault_enabled / skip_vault / project, ensure the session, and
+memoize the query policy - the enrichment-resolved values the clarification
+interceptor and the generation handler consume.
+"""
+
+from unittest.mock import patch
+
+from src.api.openai_adapter import _build_generation_context
+
+
+class _FakeReq:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+class _FakeBody:
+    def __init__(self, vault_enabled=True, stream=False):
+        self.vault_enabled = vault_enabled
+        self.stream = stream
+
+
+def test_build_generation_context_resolves_test_and_skip_vault():
+    req = _FakeReq({"X-Test-Session": "true"})
+    body = _FakeBody(vault_enabled=True, stream=True)
+    with patch("src.api.openai_adapter._ensure_session") as ens, \
+         patch("src.api.openai_adapter.get_session", return_value=None):
+        ctx = _build_generation_context(
+            req, body,
+            session_id="sess_test_001",
+            latest_user_message="hello world",
+            completion_id="chatcmpl-abc",
+        )
+    assert ctx.is_test is True
+    assert ctx.skip_vault is True          # is_test forces skip
+    assert ctx.session_id == "sess_test_001"
+    assert ctx.completion_id == "chatcmpl-abc"
+    assert ctx.stream is True
+    assert ctx.raw_user_message == "hello world"
+    assert ctx.policy is not None          # memoized classify_query result
+    # Session ensure ran once, gated on skip_vault.
+    ens.assert_called_once_with("sess_test_001", "hello world", test=True)
+
+
+def test_build_generation_context_resolves_project():
+    req = _FakeReq({})
+    body = _FakeBody()
+    sess_rec = {"metadata": {"project_id": "proj_1"}}
+    proj_rec = {"text": "Quarterly Planning"}
+    with patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.api.openai_adapter.get_session", return_value=sess_rec), \
+         patch("src.memory.project.get_project", return_value=proj_rec):
+        ctx = _build_generation_context(
+            req, body,
+            session_id="sess_test_002",
+            latest_user_message="hi",
+            completion_id="chatcmpl-p",
+        )
+    assert ctx.project_id == "proj_1"
+    assert ctx.project_name == "Quarterly Planning"
+
+
+def test_build_generation_context_vault_disabled_sets_skip():
+    req = _FakeReq({})
+    body = _FakeBody(vault_enabled=False, stream=False)
+    with patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.api.openai_adapter.get_session", return_value=None), \
+         patch("src.core.preferences.read", return_value={"vault_toggle_enabled": True}):
+        ctx = _build_generation_context(
+            req, body,
+            session_id="sess_test_003",
+            latest_user_message="hi",
+            completion_id="chatcmpl-v",
+        )
+    assert ctx.is_test is False
+    assert ctx.vault_enabled is False      # per-request opt-out honored
+    assert ctx.skip_vault is True          # vault disabled forces skip

--- a/tests/test_pregeneration_router.py
+++ b/tests/test_pregeneration_router.py
@@ -257,3 +257,63 @@ def test_generation_work_is_mutable():
     work = GenerationWork(message="hello")
     work.message = "hello [system-prefixed]"
     assert work.message == "hello [system-prefixed]"
+
+
+# ---------------------------------------------------------------------------
+# Enrichment-dependent terminal: clarification (PR c migration).
+# Reads only the frozen GenerationContext; writes the two conversation turns as
+# a terminal side effect unless the vault is skipped.
+# ---------------------------------------------------------------------------
+from types import SimpleNamespace
+
+from src.api.openai_adapter import _intercept_clarification
+from src.context.policies import SCRIPTED_CLARIFICATION_RESPONSE
+
+
+def _policy(emit=True):
+    return SimpleNamespace(emit_clarification=emit)
+
+
+def test_clarification_interceptor_fires_and_writes_two_turns():
+    ctx = _gen_ctx(session_id="sess_test_c", project_id=None, skip_vault=False,
+                   policy=_policy(True), raw_user_message="google please")
+    with patch("src.api.openai_adapter.write_memory") as w:
+        reply = _intercept_clarification(ctx)
+    assert reply is not None
+    assert reply.label == "clarification"
+    assert reply.text == SCRIPTED_CLARIFICATION_RESPONSE
+    assert w.call_count == 2
+    user_call, assistant_call = w.call_args_list
+    # User turn carries the clean raw message; assistant turn carries the flags
+    # the next-turn dispatch reads.
+    assert user_call.kwargs["text"] == "google please"
+    assert user_call.kwargs["metadata"]["role"] == "user"
+    assert user_call.kwargs["metadata"]["session_id"] == "sess_test_c"
+    assert assistant_call.kwargs["text"] == SCRIPTED_CLARIFICATION_RESPONSE
+    assert assistant_call.kwargs["metadata"]["source"] == "clarification"
+    assert assistant_call.kwargs["metadata"]["awaiting_search_content"] is True
+
+
+def test_clarification_interceptor_passes_when_not_emit():
+    ctx = _gen_ctx(policy=_policy(False))
+    with patch("src.api.openai_adapter.write_memory") as w:
+        assert _intercept_clarification(ctx) is None
+    w.assert_not_called()
+
+
+def test_clarification_interceptor_skips_writes_when_skip_vault():
+    # Terminal reply still returned, but no vault writes in test/stateless mode.
+    ctx = _gen_ctx(skip_vault=True, policy=_policy(True), raw_user_message="google please")
+    with patch("src.api.openai_adapter.write_memory") as w:
+        reply = _intercept_clarification(ctx)
+    assert reply is not None and reply.label == "clarification"
+    w.assert_not_called()
+
+
+def test_clarification_interceptor_threads_project_id():
+    ctx = _gen_ctx(session_id="s", project_id="proj_9", skip_vault=False,
+                   policy=_policy(True), raw_user_message="look it up")
+    with patch("src.api.openai_adapter.write_memory") as w:
+        _intercept_clarification(ctx)
+    for call in w.call_args_list:
+        assert call.kwargs["metadata"]["project_id"] == "proj_9"

--- a/tests/test_pregeneration_router.py
+++ b/tests/test_pregeneration_router.py
@@ -259,6 +259,17 @@ def test_generation_work_is_mutable():
     assert work.message == "hello [system-prefixed]"
 
 
+def test_generation_work_defaults_and_prep_fields():
+    # raw_message snapshots the message at construction (the clean pre-prefix
+    # query); the confirmation-derived fields start empty.
+    work = GenerationWork(message="hello")
+    assert work.raw_message == "hello"
+    assert work.confirmation_web_items == []
+    assert work.confirmation_confirmed is False
+    assert work.confirmation_search_failed is False
+    assert work.pending_records == []
+
+
 # ---------------------------------------------------------------------------
 # Enrichment-dependent terminal: clarification (PR c migration).
 # Reads only the frozen GenerationContext; writes the two conversation turns as

--- a/tests/test_pregeneration_router.py
+++ b/tests/test_pregeneration_router.py
@@ -201,3 +201,59 @@ def test_fired_router_skips_context_build_and_generation(caplog):
         mock_gen.assert_not_called()
         # The funnel executed via the override interceptor at runtime.
         assert "[EARLY-RETURN] label=override stream=True" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# PR c (ADR-042): the router is generic over context type. The same mechanism
+# runs enrichment-DEPENDENT terminals over a GenerationContext, and the frozen
+# core / mutable working carrier split is structural.
+# ---------------------------------------------------------------------------
+from src.api.pregeneration import GenerationContext, GenerationWork
+
+
+def _gen_ctx(session_id="sess_test_001", project_id=None, project_name=None,
+             is_test=False, vault_enabled=True, skip_vault=False,
+             completion_id="chatcmpl-test", stream=False, policy=None,
+             raw_user_message="hello"):
+    return GenerationContext(
+        session_id=session_id,
+        project_id=project_id,
+        project_name=project_name,
+        is_test=is_test,
+        vault_enabled=vault_enabled,
+        skip_vault=skip_vault,
+        completion_id=completion_id,
+        stream=stream,
+        policy=policy,
+        raw_user_message=raw_user_message,
+    )
+
+
+def test_router_dispatches_over_generation_context():
+    # The same router mechanism runs an enrichment-dependent interceptor over a
+    # GenerationContext, not just a RouterContext (PR c generalization).
+    seen = {}
+
+    def clarification(ctx):
+        seen["session_id"] = ctx.session_id
+        return TerminalReply("scripted", label="clarification")
+
+    reply = PreGenerationRouter([clarification]).run(_gen_ctx(session_id="sess_abc"))
+    assert reply == TerminalReply("scripted", label="clarification")
+    assert seen["session_id"] == "sess_abc"
+
+
+def test_generation_context_is_frozen():
+    # Identity/routing values are resolved once and structurally immutable, so a
+    # migrated interceptor's inputs cannot be mutated out from under it.
+    ctx = _gen_ctx()
+    with pytest.raises(Exception):
+        ctx.session_id = "mutated"
+
+
+def test_generation_work_is_mutable():
+    # The evolving message + prep-derived values live in a mutable carrier that
+    # is never an interceptor input.
+    work = GenerationWork(message="hello")
+    work.message = "hello [system-prefixed]"
+    assert work.message == "hello [system-prefixed]"


### PR DESCRIPTION
Completes issue #93 (the third and final PR, after PR a / ADR-040 and PR b / ADR-041). Decomposes the remaining inline body of `chat_completions` into a two-phase enrichment pipeline with a per-request context object, and migrates the clarification short-circuit onto it.

## What changed

Five reviewable commits:

1. **Generalize `PreGenerationRouter` over context type** + add frozen `GenerationContext` and mutable `GenerationWork` dataclasses (`pregeneration.py`). Typing/scaffolding only.
2. **Phase A value builders** assemble the frozen `GenerationContext` (`is_test`, vault toggle, `skip_vault`, project, session-ensure, memoized policy). One `completion_id` minted and carried forward.
3. **Migrate clarification** to an enrichment-dependent terminal interceptor over `PreGenerationRouter[GenerationContext]`. Drops the redundant re-classification and the separate `_clarification_id`.
4. **Phase B prep builders** (`_apply_confirmation` / `_apply_tasks` / `_apply_timers`) over `GenerationWork` -- the confirmation/task/timer message-mutating prep.
5. **ADR-042** documenting the design.

Endpoint now reads: normalize, `PreGenerationRouter[RouterContext]` (empty/override/onboarding), build `GenerationContext`, `PreGenerationRouter[GenerationContext]` (clarification), Phase B builders, generation handler.

## Design decisions (see ADR-042)

- **Frozen `GenerationContext` + mutable `GenerationWork`.** Freezes the values that never change (and that the clarification terminal reads); a separate mutable carrier holds the message that prep rewrites.
- **Ordering: Phase A, then clarification, then Phase B.** Load-bearing: preserves the pre-refactor behavior where a bare-marker turn short-circuits BEFORE any confirmation/task/timer side effect runs. "Clarify last" was rejected as a behavior change.
- **Generic router, two stages.** One mechanism, one `TerminalReply`, one `early_return_response` funnel (A1 invariant).
- **Memoization limit (correctness):** only the raw-message classify is memoized (clarification). The early/late policy still classifies the prefix-mutated message by design; collapsing them would change routing.
- **Scoped deviation:** B2 next-turn dispatch and relational suppression stay inline (retrieval-gating policy, not message prep).
- **Em dash preserved** as a `-` source escape: runtime prompt text byte-identical, source stays ASCII.

## Behavior preservation

No functional change intended. Clarification write/response contract, confirmation/task/timer side effects and message prefixes, the `_raw_user_message` snapshot semantics, and the A1 stream-vs-JSON invariant are all unchanged.

## Tests

- New: generic-router dispatch, frozen/mutable dataclass guards, `_build_generation_context` resolution, clarification interceptor (writes + skip-vault + project threading), Phase B builders (incl. a runtime U+2014 assertion).
- Existing endpoint integration tests (clarification short-circuit/next-turn, ask-first, confirmation, streaming/A1) pass unchanged -- the behavior-preservation guard.
- Full suite: **2221 passed**, 70 deselected, 2 xpassed. Backend-only; SSE wire format and UI untouched.
