### PR TITLE
fix(config): reconcile CLOUD_MODELS catalog with reachable model ids

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -246,7 +246,7 @@ def set_ember_model_override(model: str) -> None:
 # Keys are provider names matching keyring service "ember-2-{provider}".
 CLOUD_MODELS: dict[str, list[str]] = {
     "anthropic": [
-        "claude-sonnet-4-20250514",
+        "claude-sonnet-4-5-20250929",
         "claude-haiku-4-5-20251001",
     ],
     "openai": [

--- a/tests/test_cloud_providers.py
+++ b/tests/test_cloud_providers.py
@@ -16,8 +16,8 @@ class TestModelDispatch:
     """Model name prefix determines which provider is used."""
 
     def test_claude_model_is_cloud(self):
-        adapter = LLMAdapter(model="claude-sonnet-4-20250514")
-        assert adapter._is_cloud_model("claude-sonnet-4-20250514")
+        adapter = LLMAdapter(model="claude-sonnet-4-5-20250929")
+        assert adapter._is_cloud_model("claude-sonnet-4-5-20250929")
 
     def test_claude_haiku_is_cloud(self):
         adapter = LLMAdapter(model="claude-haiku-4-5-20251001")
@@ -32,7 +32,7 @@ class TestModelDispatch:
         assert not adapter._is_cloud_model("llama3.1:8b")
 
     def test_chat_dispatches_to_anthropic_for_claude(self):
-        adapter = LLMAdapter(model="claude-sonnet-4-20250514")
+        adapter = LLMAdapter(model="claude-sonnet-4-5-20250929")
         with patch.object(adapter, '_chat_anthropic', return_value="Hello from Claude") as mock:
             result = adapter._chat("system", "hello")
             mock.assert_called_once()
@@ -46,7 +46,7 @@ class TestModelDispatch:
             assert result == "Hello from Qwen"
 
     def test_stream_dispatches_to_anthropic_for_claude(self):
-        adapter = LLMAdapter(model="claude-sonnet-4-20250514")
+        adapter = LLMAdapter(model="claude-sonnet-4-5-20250929")
         with patch.object(adapter, '_chat_anthropic_stream', return_value=iter(["Hello"])) as mock:
             chunks = list(adapter._chat_stream("system", "hello"))
             mock.assert_called_once()
@@ -96,7 +96,7 @@ class TestProviderApiKey:
             assert result == "sk-env-test"
 
     def test_anthropic_chat_raises_without_key(self):
-        adapter = LLMAdapter(model="claude-sonnet-4-20250514")
+        adapter = LLMAdapter(model="claude-sonnet-4-5-20250929")
         with patch.object(LLMAdapter, '_get_provider_api_key', return_value=None):
             with pytest.raises(ValueError, match="No Anthropic API key"):
                 adapter._chat_anthropic("system", "hello")
@@ -108,7 +108,7 @@ class TestCloudModelsConfig:
     def test_anthropic_models_listed(self):
         models = get_cloud_models()
         assert "anthropic" in models
-        assert "claude-sonnet-4-20250514" in models["anthropic"]
+        assert "claude-sonnet-4-5-20250929" in models["anthropic"]
 
     def test_get_cloud_models_returns_dict(self):
         result = get_cloud_models()


### PR DESCRIPTION
The `CLOUD_MODELS` anthropic catalog listed `claude-sonnet-4-20250514`, which returns **404** for keys that aren't provisioned for that dated id (confirmed: a key that 404s on it works fine on `claude-sonnet-4-5-20250929`). Since the catalog feeds the UI model picker, a user could select the stale id and every cloud chat turn would 404.

## Change
- `src/core/config.py`: `CLOUD_MODELS["anthropic"]` Sonnet entry `claude-sonnet-4-20250514` -> `claude-sonnet-4-5-20250929`. The Haiku entry (`claude-haiku-4-5-20251001`) is already the current dated Haiku 4.5 id and is unchanged.
- `tests/test_cloud_providers.py`: updated to the new id (it asserts catalog membership and uses the id for dispatch tests).

## Consumer audit (requested before changing)
Grepped the codebase for `CLOUD_MODELS` / `get_cloud_models` consumers:
- **Only one production consumer:** `get_cloud_models()` -> `GET /model` (`src/api/main.py:1591`), which returns the catalog as `cloud` for the UI model selector. This is the real 404 path the change fixes.
- No other production code reads the catalog.

## Same 404 class elsewhere (NOT the catalog - flagged, not fixed here)
These hardcode the stale Sonnet id independently of `CLOUD_MODELS`; they are eval infrastructure, not production, and will 404 for the same keys:
- `tools/eval_conversations.py:160` - `CLAUDE_MODEL` (Tier-4 cloud judge)
- `tools/eval_local_models.py:264` - a display-label string
- `tests/eval/test_context_coherence.py:74` - `JUDGE_MODEL`

Recommend a follow-up to make those env-configurable (as the response-quality eval judges already are in PR #113), or at minimum bump them to the reachable id. Left out of this PR to keep it to the catalog reconciliation.
