### PR TITLE
fix(eval-tools): env-configurable Sonnet judge id across eval tools/tests

### DIFF
--- a/tests/eval/test_context_coherence.py
+++ b/tests/eval/test_context_coherence.py
@@ -71,7 +71,9 @@ VAULT_SWAP_ENDPOINT = f"{API_BASE}/v1/developer/vault/swap"
 PREFS_ENDPOINT = f"{API_BASE}/v1/preferences"
 
 # Judge model. Sonnet is the same model used by tools/eval_conversations.py.
-JUDGE_MODEL = "claude-sonnet-4-20250514"
+# Env-configurable (same override var) so a model transition or a key without
+# access to a dated id is a config change, not a code edit.
+JUDGE_MODEL = os.getenv("EMBER_EVAL_JUDGE_SONNET_MODEL", "claude-sonnet-4-5-20250929")
 JUDGE_TEMPERATURE = 0.0  # determinism for reproducible verdicts
 JUDGE_SYSTEM = (
     "You are evaluating an AI system called Ember for conversational "

--- a/tools/eval_conversations.py
+++ b/tools/eval_conversations.py
@@ -4,8 +4,9 @@ tools/eval_conversations.py
 Conversation quality evaluation harness for Ember-2.
 
 Sends test messages to the local Ember API, collects responses, then
-sends each response to Claude (claude-sonnet-4-20250514) for behavioral
-evaluation. Outputs pass/warn/fail per test case with evaluator notes.
+sends each response to a Claude judge (Sonnet; model id configurable via
+EMBER_EVAL_JUDGE_SONNET_MODEL) for behavioral evaluation. Outputs
+pass/warn/fail per test case with evaluator notes.
 
 Ember's responses are sent to Claude for evaluation but are NOT logged
 to disk or stdout — they may contain vault-grounded content. Only scores,
@@ -157,7 +158,11 @@ TEST_CASES = [
 # ---------------------------------------------------------------------------
 
 EMBER_API_URL = "http://localhost:8000/v1/chat/completions"
-CLAUDE_MODEL = "claude-sonnet-4-20250514"
+# Judge model, env-configurable so a model transition (or a key without access
+# to a given dated id) is a config change, not a code edit. Default is the id
+# reachable by broadly-provisioned keys; the older claude-sonnet-4-20250514 404s
+# for some keys. Same override var as the response-quality eval judges.
+CLAUDE_MODEL = os.getenv("EMBER_EVAL_JUDGE_SONNET_MODEL", "claude-sonnet-4-5-20250929")
 
 EVALUATOR_SYSTEM = (
     "You are evaluating an AI system called Ember for behavioral quality. "

--- a/tools/eval_local_models.py
+++ b/tools/eval_local_models.py
@@ -42,6 +42,7 @@ from tools.eval_conversations import (
     send_to_ember,
     evaluate_with_claude,
     get_ember_api_key,
+    CLAUDE_MODEL,
 )
 from tools.eval_helpers import swap_to_test_vault, restore_vault
 
@@ -261,7 +262,7 @@ def main():
     lines: list[str] = []
 
     lines.append(f"Local Model Comparison Eval — {timestamp}")
-    lines.append(f"Evaluator: claude-sonnet-4-20250514")
+    lines.append(f"Evaluator: {CLAUDE_MODEL}")
     lines.append(f"{'=' * 70}")
     lines.append("")
 


### PR DESCRIPTION
Follow-up to #114. The catalog PR fixed `CLOUD_MODELS`, but three eval-infra sites hardcoded the same stale Sonnet id (`claude-sonnet-4-20250514`) independently, and would 404 for the same keys. This makes them env-configurable with the reachable default, matching the pattern used by the response-quality eval judges (#113).

## Change
Each now reads `os.getenv("EMBER_EVAL_JUDGE_SONNET_MODEL", "claude-sonnet-4-5-20250929")` (same override var everywhere - one env var controls the Sonnet judge across the eval suite):
- `tools/eval_conversations.py` - `CLAUDE_MODEL` (Tier-4 cloud judge) + docstring updated.
- `tests/eval/test_context_coherence.py` - `JUDGE_MODEL`.
- `tools/eval_local_models.py` - imports `CLAUDE_MODEL` and uses it in the run-header label, so the label always reflects the actual evaluator instead of a hardcoded (and previously wrong) string.

## Verification
- Stale id gone from the three sites (one explanatory comment intentionally retains it to document what 404s).
- Confirmed default resolves to `claude-sonnet-4-5-20250929` and `EMBER_EVAL_JUDGE_SONNET_MODEL` overrides it.
- No Tier-1/CI coverage change: `tools/` are scripts (not collected) and `test_context_coherence.py` is `-m eval` gated - consistent with how these already run (locally, with Ollama + a live API + a judge key).
