### PR TITLE
fix(eval): retry judge calls with backoff so transient failures don't block the baseline

### DIFF
--- a/tests/eval/judge.py
+++ b/tests/eval/judge.py
@@ -18,6 +18,8 @@ import os
 
 import anthropic
 
+from tests.eval.retry_util import retry_call
+
 
 # All detectable failure modes.
 FAILURE_MODES = [
@@ -236,13 +238,13 @@ class ClaudeJudge:
         )
 
         try:
-            message = self.client.messages.create(
+            message = retry_call(lambda: self.client.messages.create(
                 model=self.model,
                 max_tokens=1000,
                 temperature=0,
                 system=_FLAG_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": prompt}],
-            )
+            ))
             return self._parse_flags(message.content[0].text, probed)
         except Exception:
             # Worst case: flag everything probed
@@ -271,13 +273,13 @@ class ClaudeJudge:
         )
 
         try:
-            message = self.client.messages.create(
+            message = retry_call(lambda: self.client.messages.create(
                 model=self.model,
                 max_tokens=1000,
                 temperature=0,
                 system=_SCORING_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": prompt}],
-            )
+            ))
             return self._parse_dimensions(message.content[0].text, dimensions)
         except Exception:
             return (

--- a/tests/eval/quality_judges.py
+++ b/tests/eval/quality_judges.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 import os
 
+from tests.eval.retry_util import retry_call
+
 # Default grader model ids. These are NOT hardcoded at the call site - they are
 # resolved at call time from env vars so a model transition (or a key without
 # access to a given dated id) is a config change, not a code change. The Sonnet
@@ -159,11 +161,11 @@ def score_claims(response: str, retrieved_texts: list[str],
     try:
         import anthropic
         client = anthropic.Anthropic(api_key=_resolve_api_key())
-        msg = client.messages.create(
+        msg = retry_call(lambda: client.messages.create(
             model=model, max_tokens=1000, temperature=0,
             system=_GROUNDING_SYSTEM,
             messages=[{"role": "user", "content": prompt}],
-        )
+        ))
         return parse_claim_verdicts(msg.content[0].text)
     except Exception:
         return [{"claim": GROUNDING_ERROR_CLAIM, "supported": False}]
@@ -187,9 +189,9 @@ def score_turn(user_message: str, response: str,
     model = model or haiku_judge_model()
     import anthropic
     client = anthropic.Anthropic(api_key=_resolve_api_key())
-    msg = client.messages.create(
+    msg = retry_call(lambda: client.messages.create(
         model=model, max_tokens=400, temperature=0,
         system=_DRIFT_SYSTEM,
         messages=[{"role": "user", "content": prompt}],
-    )
+    ))
     return parse_turn_scores(msg.content[0].text, dimensions)

--- a/tests/eval/retry_util.py
+++ b/tests/eval/retry_util.py
@@ -1,0 +1,53 @@
+"""
+tests/eval/retry_util.py
+
+A tiny retry-with-backoff helper for the eval judge calls.
+
+The Sonnet/Haiku judges fire many calls back-to-back per run (register alone is
+~18). Some sporadically fail on transient conditions - rate limits (429),
+network blips - which previously counted as judge_errors and blocked the
+baseline. This retries the call a few times with exponential backoff so a
+transient failure self-heals before the fail-closed sentinel is used.
+
+Deliberately dependency-free (no anthropic import) so it stays Tier-1 / CI-safe
+and can be reused by both tests/eval/judge.py and tests/eval/quality_judges.py.
+`sleep` is injectable so tests run instantly.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+# Total attempts (initial + retries) and the base backoff in seconds. Backoff
+# grows as base * 2**attempt: with base 2.0 that is 2s then 4s between the three
+# attempts - enough headroom for a rate-limit window to clear.
+DEFAULT_ATTEMPTS = 3
+DEFAULT_BASE_DELAY = 2.0
+
+
+def retry_call(
+    fn: Callable,
+    attempts: int = DEFAULT_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    sleep: Callable[[float], None] | None = None,
+):
+    """Call fn(), retrying on any exception with exponential backoff.
+
+    Returns fn()'s result on the first success. Raises the LAST exception if
+    every attempt fails, so the caller's fail-closed fallback (and the
+    judge-health guard) still fires on a persistent outage.
+
+    `sleep` defaults to time.sleep, resolved at call time so tests can stub
+    time.sleep globally without threading a sleep argument through the judges.
+    """
+    _sleep = sleep if sleep is not None else time.sleep
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 - retry on any transient error
+            last_exc = exc
+            if attempt < attempts - 1:
+                _sleep(base_delay * (2 ** attempt))
+    raise last_exc

--- a/tests/eval/test_quality_judges.py
+++ b/tests/eval/test_quality_judges.py
@@ -40,6 +40,43 @@ def test_haiku_judge_model_env_override(monkeypatch):
     assert haiku_judge_model() == "claude-haiku-custom"
 
 
+def test_score_claims_retries_transient_failure(monkeypatch):
+    # Proves the grounding judge is wrapped in retry_call: a client that fails
+    # once (e.g. a 429) then succeeds must still yield the parsed verdict, not
+    # the error sentinel. A fake anthropic module is injected so no real SDK /
+    # network is touched (CI-safe); time.sleep is stubbed so the backoff is
+    # instant.
+    import sys
+    import types
+    from unittest.mock import MagicMock
+
+    calls = {"n": 0}
+
+    class _FakeMessages:
+        def create(self, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("429 rate limited")
+            msg = MagicMock()
+            msg.content = [MagicMock(text='{"claims": [{"claim": "x", "supported": true}]}')]
+            return msg
+
+    class _FakeAnthropic:
+        def __init__(self, **kwargs):
+            self.messages = _FakeMessages()
+
+    fake_mod = types.ModuleType("anthropic")
+    fake_mod.Anthropic = _FakeAnthropic
+    monkeypatch.setitem(sys.modules, "anthropic", fake_mod)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    from tests.eval.quality_judges import score_claims
+    out = score_claims("Ember's response", ["a retrieved record"])
+
+    assert out == [{"claim": "x", "supported": True}]
+    assert calls["n"] == 2  # failed once, retried, succeeded
+
+
 def test_parse_claim_verdicts_happy_path():
     text = (
         '{"claims": [{"claim": "deadline is Friday", "supported": true}, '

--- a/tests/eval/test_retry_util.py
+++ b/tests/eval/test_retry_util.py
@@ -1,0 +1,55 @@
+"""
+tests/eval/test_retry_util.py
+
+Unit tests for the judge retry helper. Pure - runs in the default Tier-1 suite.
+`sleep` is stubbed so the tests never actually wait.
+"""
+
+import pytest
+
+from tests.eval.retry_util import retry_call
+
+
+def test_returns_first_success_without_retrying():
+    calls = {"n": 0}
+
+    def once():
+        calls["n"] += 1
+        return "ok"
+
+    assert retry_call(once, sleep=lambda s: None) == "ok"
+    assert calls["n"] == 1
+
+
+def test_recovers_after_transient_failures():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("429 rate limited")
+        return "recovered"
+
+    result = retry_call(flaky, attempts=3, sleep=lambda s: None)
+    assert result == "recovered"
+    assert calls["n"] == 3
+
+
+def test_raises_last_exception_after_exhausting_attempts():
+    def always_fail():
+        raise RuntimeError("persistent outage")
+
+    with pytest.raises(RuntimeError, match="persistent outage"):
+        retry_call(always_fail, attempts=3, sleep=lambda s: None)
+
+
+def test_backoff_grows_exponentially():
+    delays = []
+
+    def always_fail():
+        raise RuntimeError("down")
+
+    with pytest.raises(RuntimeError):
+        retry_call(always_fail, attempts=3, base_delay=2.0, sleep=delays.append)
+    # Two waits between three attempts: 2s then 4s.
+    assert delays == [2.0, 4.0]


### PR DESCRIPTION
The register calibration kept hitting `judge_errors` (1, then 2 of 9 calls) even though the judge and key are fine - 7/9 calls returned real scores. The failures are transient: register alone fires ~18 Sonnet calls back-to-back, so some get rate-limited (429) or blip on the network, and each one counted as a judge error and (correctly) blocked the baseline write. Re-running wasn't converging.

## Fix
Retry-with-backoff on every judge API call, so a transient failure self-heals before the fail-closed sentinel is used.

- New `tests/eval/retry_util.py::retry_call` - retries a callable up to 3x with exponential backoff (2s, 4s), raising the last exception if all attempts fail. Dependency-free (no anthropic import) so it stays Tier-1 / CI-safe; `sleep` resolves at call time so tests are instant.
- Wired into both judge paths: `judge.py` (register: flag + dimension calls) and `quality_judges.py` (grounding `score_claims`, drift `score_turn`).
- Fail-closed preserved: a PERSISTENT outage still exhausts retries, falls back to the sentinel, and the judge-health guard still refuses to write a baseline. This only rescues transient blips.

## Tests
- `retry_util`: returns first success, recovers after transient failures, raises after exhausting attempts, exponential backoff sequence.
- Wiring: `score_claims` with a fake anthropic client that 429s once then succeeds returns the parsed verdict (not the error sentinel) and shows exactly one retry - proving the judge call is actually wrapped.
- All pure/mocked; verified green with a dead Ollama host (CI-faithful). 62 eval-subset tests pass.
