### PR TITLE
feat(eval): baseline provenance + git-tracked baselines (overwrite, not versioned files)

### DIFF
--- a/tests/eval/baseline_quality_register.json
+++ b/tests/eval/baseline_quality_register.json
@@ -1,0 +1,7 @@
+{
+  "directness": 1.777777777777778,
+  "low_ceremony": 1.5555555555555556,
+  "non_therapeutic": 1.7777777777777777,
+  "no_ai_cliche": 1.4444444444444444,
+  "pass_rate": 0.0
+}

--- a/tests/eval/run_quality.py
+++ b/tests/eval/run_quality.py
@@ -57,6 +57,21 @@ def _judge_outage(rep: dict, max_rate: float = MAX_JUDGE_ERROR_RATE) -> bool:
     return (rep.get("judge_errors", 0) / total) > max_rate
 
 
+def _baseline_payload(metrics: dict, eval_name: str, judge_model: str,
+                      generated_at: str) -> dict:
+    """Wrap baseline metrics with provenance so each committed baseline version is
+    self-describing in git history (which model/judge/date produced it). The
+    `_meta` key is ignored by compare_to_baseline, so it does not affect gating.
+    """
+    payload = dict(metrics)
+    payload["_meta"] = {
+        "eval": eval_name,
+        "judge_model": judge_model,
+        "generated_at": generated_at,
+    }
+    return payload
+
+
 def _reasoning_has_judge_error(reasoning) -> bool:
     """True if a judge result's reasoning carries a fail-closed error marker."""
     if not isinstance(reasoning, dict):
@@ -211,7 +226,7 @@ def main(argv=None) -> int:
     from tests.eval.harness import MultiRunResult
     from tests.eval.live_driver import EmberLiveDriver
     from tests.eval.quality_judges import (
-        score_claims, score_turn, sonnet_judge_model,
+        score_claims, score_turn, sonnet_judge_model, haiku_judge_model,
     )
     from tests.eval.quality_report import write_report, load_baseline
 
@@ -263,7 +278,13 @@ def main(argv=None) -> int:
         baseline = load_baseline(baseline_path)
         _gate(rep, baseline, args.max_drop)
         if args.update_baseline:
-            write_report(baseline_path, rep["metrics"])
+            from datetime import datetime, timezone
+            judge_model = haiku_judge_model() if name == "drift" else sonnet_judge_model()
+            payload = _baseline_payload(
+                rep["metrics"], name, judge_model,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            write_report(baseline_path, payload)
             print(f"[eval] {name}: baseline updated (calibration)")
         else:
             bc = rep["baseline_check"]

--- a/tests/eval/test_quality_report.py
+++ b/tests/eval/test_quality_report.py
@@ -65,3 +65,13 @@ def test_compare_to_baseline_first_run_is_calibration_not_failure():
 def test_compare_to_baseline_improvement_passes():
     result = compare_to_baseline({"score": 3.9}, {"score": 3.5}, max_drop=0.05)
     assert result["passed"] is True
+
+
+def test_compare_to_baseline_ignores_meta_provenance_key():
+    # Baselines carry a _meta provenance block; it must not be treated as a
+    # metric (it is not numeric and never appears in current metrics).
+    baseline = {"score": 3.5, "_meta": {"judge_model": "claude-sonnet-4-5-20250929",
+                                        "generated_at": "2026-07-21T14:36:00+00:00"}}
+    result = compare_to_baseline({"score": 3.5}, baseline, max_drop=0.05)
+    assert result["passed"] is True
+    assert result["regressions"] == {}

--- a/tests/eval/test_run_quality.py
+++ b/tests/eval/test_run_quality.py
@@ -153,6 +153,20 @@ def test_drift_flow_counts_judge_failures():
     assert rep["total_calls"] == 20
 
 
+def test_baseline_payload_stamps_provenance():
+    from tests.eval.run_quality import _baseline_payload
+    payload = _baseline_payload({"directness": 3.2, "pass_rate": 0.5},
+                                "register", "claude-sonnet-4-5-20250929",
+                                "2026-07-21T14:36:00+00:00")
+    # metrics preserved flat (so the gate still reads them)
+    assert payload["directness"] == 3.2
+    assert payload["pass_rate"] == 0.5
+    # provenance under _meta
+    assert payload["_meta"]["eval"] == "register"
+    assert payload["_meta"]["judge_model"] == "claude-sonnet-4-5-20250929"
+    assert payload["_meta"]["generated_at"] == "2026-07-21T14:36:00+00:00"
+
+
 def test_judge_outage_helper_distinguishes_blips_from_outages():
     from tests.eval.run_quality import _judge_outage
     assert _judge_outage({"judge_errors": 1, "total_calls": 9}) is False   # 11% - blip


### PR DESCRIPTION
Decision from chat: baselines OVERWRITE a single file per eval and are git-tracked, so git is the version history (diff/blame/rollback) - rather than reinventing versioning with timestamped files. This adds provenance so each committed baseline version is self-describing, and starts tracking the register baseline.

## Changes
- `_baseline_payload` stamps each written baseline with a `_meta` block: `eval`, `judge_model`, `generated_at` (UTC ISO). Metrics stay flat so the gate still reads them; `compare_to_baseline` ignores `_meta` (it is never a current metric).
- `--update-baseline` now writes the stamped payload (judge model resolved per eval: Haiku for drift, Sonnet for register/grounding).
- Commits the initial register baseline (`baseline_quality_register.json`, calibration v1) so git starts tracking it. Metadata only - scores, no vault content, no response text.

## Why this shape
- One current baseline per eval is all the gate needs; timestamped files would clutter and duplicate what git already does.
- Matches the existing `baseline_scores.json` convention (tracked + overwritten).
- Every future `--update-baseline` is now a reviewable git diff: which dimension moved, by how much, and (via `_meta`) which model/judge/date produced it.

## Tests
- `_baseline_payload` stamps provenance and preserves flat metrics.
- `compare_to_baseline` ignores the `_meta` key (no false regression).
- 66 eval-subset tests pass (dead-Ollama / CI-faithful).

Note: the committed register baseline is a single calibration run and its scores are low (qwen3:8b genuinely weak on register under pressure). It is a starting reference; recalibrate over a few runs and re-commit when you want a sturdier v2 - each will be a clean diff.
