### PR TITLE
fix(eval): gate on stable aggregates, guard grounding vault alignment, stabilize register baseline

### DIFF
--- a/tests/eval/baseline_quality_register.json
+++ b/tests/eval/baseline_quality_register.json
@@ -1,7 +1,12 @@
 {
-  "directness": 1.777777777777778,
-  "low_ceremony": 1.5555555555555556,
-  "non_therapeutic": 1.7777777777777777,
-  "no_ai_cliche": 1.4444444444444444,
-  "pass_rate": 0.0
+  "directness": 1.8,
+  "low_ceremony": 1.7333333333333334,
+  "non_therapeutic": 2.0,
+  "no_ai_cliche": 1.6,
+  "pass_rate": 0.0,
+  "_meta": {
+    "eval": "register",
+    "judge_model": "claude-sonnet-4-5-20250929",
+    "generated_at": "2026-07-21T16:57:51.259574+00:00"
+  }
 }

--- a/tests/eval/quality_report.py
+++ b/tests/eval/quality_report.py
@@ -43,20 +43,32 @@ def build_case_report(
 
 
 def compare_to_baseline(
-    current: dict, baseline: dict, max_drop: float = 0.05
+    current: dict, baseline: dict, max_drop: float = 0.05,
+    metrics_to_check: list | None = None,
 ) -> dict:
     """Compare current scalar metrics to a baseline; fail on a drop > max_drop.
 
     A missing/empty baseline means this is a calibration run: it passes and is
     flagged `calibration` so the caller records a baseline instead of gating on
     one that does not exist yet.
+
+    metrics_to_check restricts gating to specific metric keys. This matters
+    because the metrics dict mixes scales: 0-1 aggregates (pass_rate,
+    supported_ratio) are stable and gate-worthy, while the 1-4 per-dimension
+    scores are noisy (judge variance ~0.4 run-to-run) and would false-trigger a
+    0.05 gate. The caller passes only the stable aggregates; the dimensions stay
+    in the baseline as diagnostics but do not gate. When None, all metrics gate
+    (back-compatible). Keys starting with "_" (e.g. _meta provenance) are always
+    skipped.
     """
     if not baseline:
         return {"passed": True, "calibration": True, "regressions": {}}
 
     regressions = {}
     for metric, base_val in baseline.items():
-        if metric not in current:
+        if metric.startswith("_") or metric not in current:
+            continue
+        if metrics_to_check is not None and metric not in metrics_to_check:
             continue
         drop = base_val - current[metric]
         if drop > max_drop:

--- a/tests/eval/run_quality.py
+++ b/tests/eval/run_quality.py
@@ -42,6 +42,15 @@ _JUDGE_ERROR_MARKERS = ("score_parse_error", "flag_parse_error")
 # fraction the run aborts instead of writing a baseline.
 MAX_JUDGE_ERROR_RATE = 0.34
 
+# Only the stable 0-1 aggregate metrics gate a run. The 1-4 per-dimension scores
+# are kept in the baseline as diagnostics but are too noisy (judge variance ~0.4
+# run-to-run) to gate on a tight threshold. Drift gates on its window-delta.
+GATE_METRICS = {
+    "register": ["pass_rate"],
+    "grounding": ["supported_ratio", "pass_rate"],
+    "drift": ["min_window_delta"],
+}
+
 
 def _mean(xs) -> float:
     xs = list(xs)
@@ -84,10 +93,33 @@ def _reasoning_has_judge_error(reasoning) -> bool:
     return False
 
 
+def _seed_visible(rec: dict, retrieved_texts: list) -> bool:
+    """True if a seeded record is actually retrievable through the live API.
+
+    Records are stored verbatim, so a distinctive chunk of the seed text should
+    appear in what retrieval returned. Used to catch vault misalignment (the API
+    serving a different vault than the one the corpus was seeded into).
+    """
+    needle = rec["text"][:40].strip().lower()
+    return any(needle in (t or "").lower() for t in retrieved_texts)
+
+
 def run_grounding_eval(driver, seed_fn, judge_claims, ratio_threshold=0.8) -> dict:
     """Seed a synthetic corpus, drive each query live, judge response claims
     against the ACTUALLY retrieved records."""
     corpus = seed_fn()
+
+    # Vault-alignment guard. The corpus is seeded into THIS process's vault, but
+    # the live API retrieves from ITS vault. If they differ (API not pointed at
+    # the seeded test vault), grounding would silently test the wrong corpus - or
+    # the real vault. Verify a seeded record is retrievable through the API and
+    # abort loudly if not, instead of reporting garbage.
+    if corpus:
+        probe = corpus[0]
+        if not _seed_visible(probe, driver.fetch_retrieved_texts(probe["query"])):
+            return {"eval": "grounding", "cases": [], "judge_errors": 0,
+                    "total_calls": 0, "metrics": {}, "vault_misaligned": True}
+
     cases, ratios, passes = [], [], []
     judge_errors = 0
     total_calls = 0
@@ -156,7 +188,7 @@ def run_drift_eval(driver, score_turn_fn, script=DRIFT_SCRIPT,
 
 
 def run_register_eval(judge, generate_fn, MultiRunResultCls,
-                      cases=REGISTER_CASES, runs=3) -> dict:
+                      cases=REGISTER_CASES, runs=5) -> dict:
     """Generate register-pressure responses (raw Ollama) and score voice with the
     Sonnet judge + multi-run fire-rate thresholds."""
     case_reports, pass_flags = [], []
@@ -199,8 +231,15 @@ def run_register_eval(judge, generate_fn, MultiRunResultCls,
 
 
 def _gate(report: dict, baseline: dict, max_drop: float) -> dict:
-    """Attach a baseline-regression verdict to an eval report."""
-    report["baseline_check"] = compare_to_baseline(report["metrics"], baseline, max_drop)
+    """Attach a baseline-regression verdict to an eval report.
+
+    Gates only on the eval's stable aggregate metrics (GATE_METRICS); the noisy
+    per-dimension scores are diagnostic and do not gate.
+    """
+    report["baseline_check"] = compare_to_baseline(
+        report["metrics"], baseline, max_drop,
+        metrics_to_check=GATE_METRICS.get(report["eval"]),
+    )
     return report
 
 
@@ -209,7 +248,7 @@ def main(argv=None) -> int:
     parser.add_argument("--evals", default="register,grounding,drift",
                         help="comma list: register,grounding,drift")
     parser.add_argument("--base-url", default="http://127.0.0.1:8000")
-    parser.add_argument("--runs", type=int, default=3, help="register multi-run count")
+    parser.add_argument("--runs", type=int, default=5, help="register multi-run count")
     parser.add_argument("--max-drop", type=float, default=0.05)
     parser.add_argument("--report", default="logs/eval_quality/latest.json")
     parser.add_argument("--baseline-dir", default="tests/eval")
@@ -253,6 +292,19 @@ def main(argv=None) -> int:
                                     _ollama_generate, MultiRunResult, runs=args.runs)
         else:
             print(f"[eval] unknown eval '{name}', skipping")
+            continue
+
+        # Vault-alignment guard (grounding): the seeded corpus was not retrievable
+        # through the API, so it is serving a different vault. Abort loudly rather
+        # than report garbage or touch the real vault.
+        if rep.get("vault_misaligned"):
+            print(f"[eval] {name}: VAULT MISALIGNED - the seeded corpus is not "
+                  "retrievable through the API, so it is not serving the seeded "
+                  "test vault. Point the API at PRIVATE_VAULT_PATH="
+                  "<test vault> (the same path this eval seeds into) and re-run. "
+                  "NOT writing a baseline.")
+            overall_ok = False
+            reports.append(rep)
             continue
 
         # Judge-health guard. A handful of judge calls fail transiently; those

--- a/tests/eval/test_quality_report.py
+++ b/tests/eval/test_quality_report.py
@@ -67,6 +67,18 @@ def test_compare_to_baseline_improvement_passes():
     assert result["passed"] is True
 
 
+def test_compare_to_baseline_gates_only_specified_metrics():
+    # A noisy 1-4 dimension can swing far; gating only the stable aggregate
+    # (pass_rate) must ignore that swing.
+    baseline = {"pass_rate": 0.8, "no_ai_cliche": 1.8}
+    current = {"pass_rate": 0.8, "no_ai_cliche": 1.0}  # dimension dropped 0.8 (noise)
+    gated = compare_to_baseline(current, baseline, max_drop=0.05,
+                                metrics_to_check=["pass_rate"])
+    assert gated["passed"] is True                       # dimension drop ignored
+    # Without the restriction, the dimension drop would (wrongly) trip the gate.
+    assert compare_to_baseline(current, baseline, max_drop=0.05)["passed"] is False
+
+
 def test_compare_to_baseline_ignores_meta_provenance_key():
     # Baselines carry a _meta provenance block; it must not be treated as a
     # metric (it is not numeric and never appears in current metrics).

--- a/tests/eval/test_run_quality.py
+++ b/tests/eval/test_run_quality.py
@@ -37,8 +37,10 @@ def test_grounding_flow_fails_on_confabulation_and_never_leaks_text():
         # Response claimed Monday; records say Friday -> unsupported.
         return [{"claim": "deadline is Monday", "supported": False}]
 
-    rep = run_grounding_eval(driver, seed_fn=lambda: [{"query": "when is the deadline?"}],
-                             judge_claims=judge_claims, ratio_threshold=0.8)
+    rep = run_grounding_eval(
+        driver,
+        seed_fn=lambda: [{"query": "when is the deadline?", "text": "the deadline is Friday"}],
+        judge_claims=judge_claims, ratio_threshold=0.8)
     assert rep["eval"] == "grounding"
     assert rep["cases"][0]["passed"] is False
     assert rep["metrics"]["supported_ratio"] == 0.0
@@ -50,11 +52,22 @@ def test_grounding_flow_passes_when_grounded():
     driver = FakeDriver(response="Your deadline is Friday.",
                         retrieved=["the deadline is Friday"])
     rep = run_grounding_eval(
-        driver, seed_fn=lambda: [{"query": "when?"}],
+        driver, seed_fn=lambda: [{"query": "when?", "text": "the deadline is Friday"}],
         judge_claims=lambda r, ret: [{"claim": "Friday", "supported": True}],
         ratio_threshold=0.8)
     assert rep["cases"][0]["passed"] is True
     assert rep["metrics"]["supported_ratio"] == 1.0
+
+
+def test_grounding_aborts_when_seed_not_retrievable_through_api():
+    # The seeded record is NOT in what the API retrieved -> the API is serving a
+    # different vault. The run must abort (vault_misaligned), not report garbage.
+    driver = FakeDriver(response="whatever", retrieved=["totally unrelated record"])
+    rep = run_grounding_eval(
+        driver, seed_fn=lambda: [{"query": "q", "text": "the seeded fact about Atlas"}],
+        judge_claims=lambda r, ret: [{"claim": "x", "supported": True}])
+    assert rep["vault_misaligned"] is True
+    assert rep["cases"] == []
 
 
 def test_drift_flow_fails_on_declining_scores():
@@ -134,9 +147,9 @@ def test_register_flow_counts_judge_failures():
 
 def test_grounding_flow_counts_judge_failures():
     from tests.eval.quality_judges import GROUNDING_ERROR_CLAIM
-    driver = FakeDriver(response="a reply", retrieved=["some record"])
+    driver = FakeDriver(response="a reply", retrieved=["some record text"])
     rep = run_grounding_eval(
-        driver, seed_fn=lambda: [{"query": "q"}],
+        driver, seed_fn=lambda: [{"query": "q", "text": "some record text"}],
         judge_claims=lambda r, ret: [{"claim": GROUNDING_ERROR_CLAIM, "supported": False}])
     assert rep["judge_errors"] == 1
 


### PR DESCRIPTION
One-pass audit + fix of the response-quality framework's operational flaws, instead of discovering them one run at a time. Register calibration was also re-run here (runs=5) to land a stabilized baseline.

## Root cause of the "noise" problem
The gate compared EVERY metric against a single `max_drop=0.05`, including the 1-4 per-dimension scores. On a 1-4 scale, 0.05 is 1.25% of range - far tighter than real judge variance (~0.4 run-to-run), so normal noise looked like a regression.

## Fixes
1. **Gate only on stable aggregates.** `GATE_METRICS` per eval - register: `pass_rate`; grounding: `supported_ratio`/`pass_rate`; drift: `min_window_delta`. `compare_to_baseline` takes `metrics_to_check`; the 1-4 dimensions stay in the baseline as diagnostics but no longer gate. (Also skips `_` keys like `_meta`.)
2. **Grounding vault-alignment guard.** The corpus is seeded into this process's vault, but the live API retrieves from ITS vault. If they differ, grounding silently tested the wrong (or the real) vault. Now: after seeding, verify a seeded record is retrievable through the API; if not, abort with `VAULT MISALIGNED - point the API at the test vault` and write no baseline.
3. **Register runs default 3 -> 5** for steadier diagnostic dimensions.

## Verified OK (not a flaw)
`/debug-context` returns `content` on items and the packet cleaner preserves it, so the retrieval extractor is correct.

## Baseline
Included register baseline v2 (runs=5): dimensions steadier than the single-run v1 (e.g. no_ai_cliche 1.6 vs a 1.0-1.44 swing). pass_rate remains 0.0 - qwen3:8b genuinely fails register under pressure (real signal, not tooling).

## Tests
- Gate restricts to specified metrics (a noisy-dimension drop no longer trips it).
- Grounding aborts (`vault_misaligned`) when the seed is not retrievable through the API.
- Existing grounding fixtures updated for the guard.
- 68 eval-subset tests pass (dead-Ollama / CI-faithful).
