### PR TITLE
fix(eval): raise live-driver timeout + add grounding/drift baselines

### DIFF
--- a/tests/eval/baseline_quality_drift.json
+++ b/tests/eval/baseline_quality_drift.json
@@ -1,0 +1,8 @@
+{
+  "min_window_delta": 0.0,
+  "_meta": {
+    "eval": "drift",
+    "judge_model": "claude-haiku-4-5-20251001",
+    "generated_at": "2026-07-21T19:22:54.647131+00:00"
+  }
+}

--- a/tests/eval/baseline_quality_grounding.json
+++ b/tests/eval/baseline_quality_grounding.json
@@ -1,0 +1,9 @@
+{
+  "supported_ratio": 1.0,
+  "pass_rate": 1.0,
+  "_meta": {
+    "eval": "grounding",
+    "judge_model": "claude-sonnet-4-5-20250929",
+    "generated_at": "2026-07-21T18:28:06.839139+00:00"
+  }
+}

--- a/tests/eval/live_driver.py
+++ b/tests/eval/live_driver.py
@@ -44,7 +44,7 @@ class EmberLiveDriver:
 
     def __init__(self, base_url: str = "http://127.0.0.1:8000",
                  api_key: str | None = None, session_id: str = "sess_eval_quality",
-                 timeout: float = 120.0):
+                 timeout: float = 300.0):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.session_id = session_id

--- a/tests/eval/run_quality.py
+++ b/tests/eval/run_quality.py
@@ -250,6 +250,9 @@ def main(argv=None) -> int:
     parser.add_argument("--base-url", default="http://127.0.0.1:8000")
     parser.add_argument("--runs", type=int, default=5, help="register multi-run count")
     parser.add_argument("--max-drop", type=float, default=0.05)
+    parser.add_argument("--timeout", type=float, default=300.0,
+                        help="per-turn live-API timeout in seconds (grounded "
+                             "generation is slow)")
     parser.add_argument("--report", default="logs/eval_quality/latest.json")
     parser.add_argument("--baseline-dir", default="tests/eval")
     parser.add_argument("--update-baseline", action="store_true",
@@ -270,7 +273,7 @@ def main(argv=None) -> int:
     from tests.eval.quality_report import write_report, load_baseline
 
     api_key = os.environ.get("EMBER_API_KEY")
-    driver = EmberLiveDriver(base_url=args.base_url, api_key=api_key)
+    driver = EmberLiveDriver(base_url=args.base_url, api_key=api_key, timeout=args.timeout)
 
     def _ollama_generate(prompt: str) -> str:
         import requests


### PR DESCRIPTION
Follow-on to #119. While running grounding + drift end-to-end against a throwaway API instance on the test vault, I hit one more real operational flaw and generated the remaining baselines.

## Fix
- **Live-driver per-turn timeout 120s -> 300s** (and a `--timeout` CLI flag). Grounded generation through the full pipeline takes ~65s/turn here with variance; the old 120s timeout would intermittently kill a turn. This is the last live-path flaw - drift (20 turns) needs the headroom.

## Baselines added (generated by me, test vault, metadata-only)
- **grounding**: `supported_ratio 1.0`, `pass_rate 1.0` - Ember retrieved the seeded synthetic records and stayed fully grounded (no confabulation). The vault-alignment guard from #119 passed, confirming the instance was on the test vault.
- **drift**: `min_window_delta 0.0` - no register/honesty/self-narrative degradation across the canned 20-turn script. Zero judge errors.

All three quality baselines (register/grounding/drift) are now committed and provenance-stamped.

## How these were produced
Stood up a throwaway API on port 8010 with `PRIVATE_VAULT_PATH` pinned to the test vault (a shell env var can't be overridden by .env), seeded the synthetic corpus, ran grounding then drift, and tore the instance down. No real vault content involved; output is metadata only.

68 eval-subset tests pass (dead-Ollama / CI-faithful).
