### PR TITLE
docs(readme,tdd): v0.18.0 boundary sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Logs are intended to support debugging, tuning, and evaluation rather than act a
 - Multi-record state categories for open_loop and next_action (capped at 5)
 - Commitment detection — post-generation detector writes open_loop state records
 - Daily, weekly, and session reflection generation
-- Constitutional review (9 principles, constitution v0.7, streaming-compatible — MVR prompt optimization)
+- Constitutional review (9 principles, constitution v0.8, streaming-compatible — MVR prompt optimization)
 - Conversation sessions with projects, rename, soft-delete, auto-title
 - Task layer — create and track tasks through conversation or direct request
 - Task sidebar tray in the UI with checkbox completion
@@ -409,7 +409,7 @@ Logs are intended to support debugging, tuning, and evaluation rather than act a
 - Web search accuracy eval (30 questions, 5 categories, latency tracking)
 - Model selection guide with real eval data (docs/model_guide.md)
 - Vault health audit (7 checks, GREEN/YELLOW/RED health score)
-- 1733 pytest tests collected (20 deselected)
+- 2277 pytest tests collected (70 deselected)
 
 **Running the eval suite:**
 ```bash
@@ -429,7 +429,7 @@ pytest tests/eval/ -m eval --runs 3   # 3-run minimum for signal
 **v0.16.0** — Stability & UAT cycle: autonomous web search default, vision pipeline fix, vault badge fixes, constitutional review blank response fix, style pack system, self-hosted fonts, appearance tab ✓
 **v0.17.0** — Smarter search routing, anti-sycophancy, ChatGPT import fixes: ask-first intent classifier (ADR-034), StateExtractor gated to live conversation turns (ADR-033), coaching filter expansion, UAT suite rewrite (25 behavioral acceptance tests), CI pytest workflow ✓
 **v0.17.1** — Retrieval quality, vision, and routing fixes: SafetyReviewContext extension (ADR-035), cross-session pattern detection (ADR-021), Lodestone path 2 (inferred records), vision pipeline env var configurability, ask-first UI toggle re-enabled ✓
-**v0.18.0** — Coaching filter maturation, date-arithmetic bug fix, eval privacy fix, post-gen URL scanner, token-overflow guardrail, web search freshness, ADR-037 classifier migration, StateExtractor coverage, review SSE UX (in progress)
+**v0.18.0** — UAT response cycle, chat_completions decomposition, and response-quality evals: append-only state resolution (ADR-038, A2), safe JSON I/O helpers (A3), streaming early-return fix (A1); chat_completions decomposition (issue #93 a/b/c) with SSE wire contract v2 (ADR-040), PreGeneration terminal router (ADR-041), GenerationContext two-phase enrichment pipeline (ADR-042); response-quality eval framework (multi-turn drift, grounding fidelity, register consistency; judge retry and transient-failure tolerance; provenance-stamped baselines); constitution v0.8; coaching filter maturation, date-arithmetic fix, eval privacy fix, post-gen URL scanner, token-overflow guardrail, web search freshness, ADR-037 classifier migration; UAT workstream B fixes (B-STATE-001, B-IO-001, B-CTX-001, B-SSE-001, narrative/dodge/loop). Landed on main; release pending.
 **Post-v0.18.0** — Multi-user vault isolation, full platform parity
 
 ---

--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -1558,7 +1558,7 @@ It should be possible to explain:
 - ~~vector index caching~~ — complete (v0.10.0): module-level dict cache in vector_index.py; auto-invalidation on save_index(); eliminated 2-4s disk reads per query
 - improve trigger coverage without coupling to one test case
 - ~~add ADR for constitutional review at inference time~~ — resolved (ADR-001, ADR-010)
-- ~~cloud model provider support~~ — complete (v0.10.2): LLMAdapter dispatches by model prefix (claude-* → Anthropic API, else → Ollama); _get_provider_api_key() reads keyring then falls back to env var (ANTHROPIC_API_KEY); POST/GET /provider-key endpoints; GET /model returns cloud models alongside Ollama; claude-sonnet-4-20250514 and claude-haiku-4-5-20251001 available
+- ~~cloud model provider support~~ — complete (v0.10.2): LLMAdapter dispatches by model prefix (claude-* → Anthropic API, else → Ollama); _get_provider_api_key() reads keyring then falls back to env var (ANTHROPIC_API_KEY); POST/GET /provider-key endpoints; GET /model returns cloud models alongside Ollama; claude-sonnet-4-5-20250929 and claude-haiku-4-5-20251001 available
 - ~~cloud model evaluation~~ — complete (v0.10.2): Haiku 4.5 scored 8.7/10, Sonnet 4.6 scored 8.5/10 (18/18 passed, same harness, same vault); memory grounding jumped from 2.3 (local) to 8.7; constitutional behavior from 2.3 to 9.0
 - ~~default model switch~~ — complete (v0.10.2): qwen3:8b replaces qwen2.5:14b (5.4/10 vs 4.7/10, half the size, faster)
 - ~~model selection guide~~ — complete (v0.10.2): docs/model_guide.md with real eval data for 8 models, linked from installer Done screen
@@ -1756,7 +1756,7 @@ Deferred from v0.16.0:
 - BUG-STOP-001 — stop button latency: still open (carried forward as v0.17.x open issue)
 - Yes/No ask-first buttons (G+M coordination): UI side complete, backend toggle wired
 
-**v0.17.1 — Retrieval quality, vision, and routing fixes** (in progress)
+**v0.17.1 — Retrieval quality, vision, and routing fixes** (shipped 2026-04-29)
 - Constitutional review context signal (ADR-035) — `SafetyReviewContext` carries `is_vault_grounded` and `t2_pattern_category`; two-step review prompt for T2-triggered cases
 - Cross-session pattern detection (ADR-021) — `PatternSignal`, `detect_t2_pattern()`, `contains_named_third_party` flag at write time, `<cross_session_pattern>` prompt injection
 - Lodestone path 2 — three-stage reflection synthesis produces inferred vault records (`acquisition_path: "inferred"`, `confirmed: false`); monthly cadence; confirmed-only injection gate unchanged
@@ -1768,6 +1768,18 @@ Deferred from v0.16.0:
 - ChatGPT import: `create_time` Unix epoch → ISO 8601 at ingestion; renderer epoch fallback for existing records
 - Vision pipeline structured logging to `logs/vision/YYYY-MM-DD.log`
 - UAT runner `--ids` flag for targeted re-run
+
+**v0.18.0: UAT response cycle, chat_completions decomposition, response-quality evals** (landed on main; release pending)
+- ~~Streaming early-return fix (A1)~~ ✓ - every early-return path returns `StreamingResponse` when `stream=True`
+- ~~Append-only state resolution (A2, ADR-038)~~ ✓ - pending/open_loop resolution writes tombstones, never mutates in place
+- ~~Safe JSON I/O helpers (A3, B-IO-001)~~ ✓ - deferred JSON read/write routed through safe helpers
+- ~~chat_completions decomposition, issue #93 (a/b/c)~~ ✓ - SSE serializer consolidation + wire contract v2 (ADR-040), PreGeneration terminal router (ADR-041), GenerationContext two-phase enrichment pipeline (ADR-042)
+- ~~Response-quality eval framework~~ ✓ - multi-turn drift, grounding fidelity, register consistency; ClaudeJudge retry + transient-failure tolerance; provenance-stamped, git-versioned baselines; local Tier-4 release-gate command
+- ~~Constitution v0.8~~ ✓
+- ~~UAT workstream B fixes~~ ✓ - B-STATE-001 (open_loop suppression), B-IO-001, B-CTX-001 (stage-2 misroute), B-SSE-001 (SSE status frame), B-NARR-001/002, B-DODGE-001, B-LOOP-001
+- ~~Coaching filter maturation, deviation detector and self-narrative check fixes~~ ✓ - 2026-05-11 UAT findings (B1-B7)
+- ~~CLOUD_MODELS reachable-id fix~~ ✓ - `claude-sonnet-4-5-20250929`
+- ADR-037 classifier SetFit graduation - step A on branch, not yet merged
 
 **Post-v0.17.1**
 - Multi-user vault isolation


### PR DESCRIPTION
Task 2 of release-prep sweep.

**README:**
- Test count `1733 (20 deselected)` -> `2277 (70 deselected)` (badly stale)
- Constitution `v0.7` -> `v0.8` in the current-capabilities line (v0.15.0 historical roadmap mention of v0.7 left correct)
- v0.18.0 roadmap line expanded from '(in progress)' stub to the actual shipped set (A1/A2/A3, #93 a/b/c, ADR-040/041/042, eval framework, constitution v0.8, workstream B fixes); marked 'landed on main, release pending'. Current-version header NOT bumped (still Working (v0.17.1)).

**TDD:**
- v0.17.1 version section '(in progress)' -> '(shipped 2026-04-29)' (it had graduated)
- Added a v0.18.0 version section (none existed) recording the boundary work, accurate to git + CLAUDE.md. ADR-037 noted as not-yet-merged (its branch is unmerged).
- Fixed a stale current-availability claim (`claude-sonnet-4-20250514` -> `claude-sonnet-4-5-20250929`) to match CLOUD_MODELS.

**Verified, no change needed:** state-category count is 10 (README + TDD both correct); the vision-pipeline watch item is already marked RESOLVED (ADR-032, v0.17.1). Docs only.