### PR TITLE
fix(eval): harden user_expectations runner + add first baseline

### DIFF
--- a/tests/eval/baseline_quality_user_expectations.json
+++ b/tests/eval/baseline_quality_user_expectations.json
@@ -1,0 +1,9 @@
+{
+  "pass_rate": 0.75,
+  "mean_score": 3.4375,
+  "_meta": {
+    "eval": "user_expectations",
+    "judge_model": "claude-sonnet-4-5-20250929",
+    "generated_at": "2026-07-24T10:34:33.917280+00:00"
+  }
+}

--- a/tests/eval/run_quality.py
+++ b/tests/eval/run_quality.py
@@ -59,12 +59,15 @@ def _mean(xs) -> float:
 
 
 def _judge_outage(rep: dict, max_rate: float = MAX_JUDGE_ERROR_RATE) -> bool:
-    """True when an eval's judge-failure rate is high enough to distrust the whole
-    run (a real outage), vs a tolerable handful of transient drops."""
+    """True when an eval's failed-call rate is high enough to distrust the whole
+    run (a real outage), vs a tolerable handful of transient drops. Failed calls
+    are judge failures plus turns that never generated (e.g. the live API timed
+    out), so a slow or unhealthy API aborts cleanly instead of crashing the run."""
     total = rep.get("total_calls", 0)
     if not total:
         return False
-    return (rep.get("judge_errors", 0) / total) > max_rate
+    failed = rep.get("judge_errors", 0) + rep.get("turn_errors", 0)
+    return (failed / total) > max_rate
 
 
 def _baseline_payload(metrics: dict, eval_name: str, judge_model: str,
@@ -236,15 +239,24 @@ def run_register_eval(judge, generate_fn, MultiRunResultCls,
 def run_user_expectations_eval(driver, cases, judge_fn) -> dict:
     """Drive each case through the live pipeline and judge the response against
     its semantic expectation (Sonnet). Gates on pass_rate; mean_score is
-    diagnostic. Judge failures are dropped from the aggregate (tolerance) and
-    counted for the outage guard, matching the other evals."""
+    diagnostic. Judge failures and turns that never generated (e.g. the live API
+    timed out) are both dropped from the aggregate and counted for the outage
+    guard, matching the other evals. A single slow or failed turn must not crash
+    the whole run - it is dropped and the run continues on the remaining cases."""
     driver.new_session("sess_userexp")  # fresh session per run
     case_reports, passes, scores = [], [], []
     judge_errors = 0
+    turn_errors = 0
     total_calls = 0
     for case in cases:
         total_calls += 1
-        response, latency = driver.send_turn(case["prompt"])
+        try:
+            response, latency = driver.send_turn(case["prompt"])
+        except Exception as exc:  # noqa: BLE001 - any transport failure drops the case
+            turn_errors += 1
+            logger.warning("[eval] user_expectations turn error on case %s "
+                           "(dropped from aggregate): %s", case["case_id"], exc)
+            continue
         verdict = judge_fn(case["prompt"], response, case["expectation"])
         if verdict.get("error"):
             judge_errors += 1
@@ -259,7 +271,8 @@ def run_user_expectations_eval(driver, cases, judge_fn) -> dict:
             latency=latency, word_count=len(response.split()),
         ))
     return {"eval": "user_expectations", "cases": case_reports,
-            "judge_errors": judge_errors, "total_calls": total_calls,
+            "judge_errors": judge_errors, "turn_errors": turn_errors,
+            "total_calls": total_calls,
             "metrics": {"pass_rate": _mean(passes), "mean_score": _mean(scores)}}
 
 
@@ -354,18 +367,21 @@ def main(argv=None) -> int:
         # (bad key, unreachable model) where the whole run is untrustworthy - then
         # refuse to write a baseline or pass the gate.
         je = rep.get("judge_errors", 0)
+        te = rep.get("turn_errors", 0)
         total = rep.get("total_calls", 0)
         if _judge_outage(rep):
-            print(f"[eval] {name}: JUDGE OUTAGE - {je}/{total} judge calls failed "
-                  f"(> {MAX_JUDGE_ERROR_RATE:.0%}); results are invalid (check the "
-                  "ANTHROPIC key and that the judge model id is accessible). NOT "
-                  "writing a baseline and NOT passing the gate.")
+            print(f"[eval] {name}: RUN OUTAGE - {je + te}/{total} calls failed "
+                  f"(judge={je}, turn={te}; > {MAX_JUDGE_ERROR_RATE:.0%}); results are "
+                  "invalid (check the ANTHROPIC key and judge model id, and that the "
+                  "live API is healthy and fast enough to answer within --timeout). "
+                  "NOT writing a baseline and NOT passing the gate.")
             overall_ok = False
             reports.append(rep)
             continue
-        if je:
-            print(f"[eval] {name}: {je}/{total} judge call(s) failed transiently and "
-                  "were dropped from the aggregate; proceeding on the rest.")
+        if je or te:
+            print(f"[eval] {name}: {je + te}/{total} call(s) failed transiently "
+                  f"(judge={je}, turn={te}) and were dropped from the aggregate; "
+                  "proceeding on the rest.")
 
         baseline_path = f"{args.baseline_dir}/baseline_quality_{name}.json"
         baseline = load_baseline(baseline_path)

--- a/tests/eval/test_run_quality.py
+++ b/tests/eval/test_run_quality.py
@@ -13,6 +13,7 @@ from tests.eval.run_quality import (
     run_drift_eval,
     run_register_eval,
     run_user_expectations_eval,
+    _judge_outage,
 )
 
 SECRET = "SECRET_DIARY_TOKEN_do_not_leak"
@@ -282,3 +283,44 @@ def test_user_expectations_drops_judge_errors_from_aggregate():
     rep = run_user_expectations_eval(driver, cases, judge)
     assert rep["judge_errors"] == 1 and rep["total_calls"] == 2
     assert rep["metrics"]["pass_rate"] == 1.0   # from the 1 good case only
+
+
+class _TimingOutDriver:
+    """A live driver whose send_turn raises (mimics a per-turn API read timeout)."""
+
+    def __init__(self, fail_on_indices):
+        self._fail = set(fail_on_indices)
+        self._i = -1
+
+    def new_session(self, prefix="sess_eval"):
+        import uuid
+        self.session_id = f"{prefix}_{uuid.uuid4().hex}"
+        return self.session_id
+
+    def send_turn(self, message):
+        self._i += 1
+        if self._i in self._fail:
+            raise TimeoutError("read timed out")
+        return "a fine reply", 0.5
+
+
+def test_user_expectations_drops_timed_out_turn_without_crashing():
+    # A turn that times out must be dropped and counted, not crash the whole run.
+    driver = _TimingOutDriver(fail_on_indices={1})  # 2nd of 3 cases times out
+    cases = [{"case_id": f"c{i}", "prompt": "p", "expectation": "e"} for i in range(3)]
+    rep = run_user_expectations_eval(
+        driver, cases,
+        judge_fn=lambda u, r, e: {"passed": True, "score": 4.0, "error": False})
+    assert rep["turn_errors"] == 1
+    assert rep["total_calls"] == 3
+    assert rep["metrics"]["pass_rate"] == 1.0        # the 2 good cases still aggregate
+    assert len(rep["cases"]) == 2
+
+
+def test_judge_outage_counts_turn_errors_toward_the_rate():
+    # The outage guard must treat un-generated turns like judge failures, so a slow
+    # or unhealthy API aborts cleanly instead of silently baselining a sparse run.
+    assert _judge_outage({"turn_errors": 5, "total_calls": 9}) is True    # 56%
+    assert _judge_outage({"turn_errors": 3, "total_calls": 9}) is False   # 33% tolerated
+    assert _judge_outage({"judge_errors": 2, "turn_errors": 3,
+                          "total_calls": 9}) is True                      # 56% combined


### PR DESCRIPTION
## What

Follow-up to #125. Two changes to the `user_expectations` eval:

1. **Per-turn timeout tolerance.** A single slow or timed-out live-API turn used to raise straight out of `run_user_expectations_eval` and abort the whole calibration. Now the turn is dropped and counted as `turn_errors`, mirroring the existing judge-error tolerance. `_judge_outage` counts `judge_errors + turn_errors`, so a slow/unhealthy API aborts cleanly above the 34% threshold instead of crashing; a handful of transient drops proceed on the remaining cases. New tests cover both paths.

2. **First baseline.** `baseline_quality_user_expectations.json`, calibrated on the test vault: pass_rate 0.75, mean_score 3.44 over 16 cases, judged by claude-sonnet-4-5. Metadata only (no vault content, no response text).

## Context (why the runner needed hardening)

Calibration kept crashing on one slow turn. Root-caused the latency (not the eval): the local `num_ctx` default of 32768 (80% of qwen3:8b's 40960 window) sized a KV cache that spilled the 8GB GPU, forcing ~38% CPU offload and collapsing decode from ~65 to ~4 tok/s; turns were 100-300s. Enabling Ollama KV-cache quantization (q8_0 + flash attention) and a 16384 context window restores full-GPU residency (~57 tok/s), and the clean 16/16 baseline was captured on that config. The 32768 default vs 8GB VRAM, and the per-turn generation fan-out (unmemoized 3x classify_query, unconditional identity-check call, per-turn lodestone re-embedding), are separate product-side items, not addressed here.

## Tests

`tests/eval/test_run_quality.py`: 18 pass, including the two new turn-timeout tests. CI-safe (injected fakes, no Ollama/Anthropic).