### PR TITLE
fix(vision): short-circuit on preprocess failure; move default to qwen3-vl:8b

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -120,8 +120,13 @@ ollama pull qwen3:8b
 
 **Vision model** (for analyzing images in chat):
 ```
-ollama pull llama3.2-vision:11b
+ollama pull qwen3-vl:8b
 ```
+
+> Do not use `llama3.2-vision:11b`. It uses the `mllama` architecture, which
+> Ollama's engine dropped at v0.30.0. It still pulls and appears in
+> `ollama list`, but fails at load with
+> `unknown model architecture: 'mllama'`.
 
 Verify both are available:
 ```
@@ -191,7 +196,7 @@ Also set the model names (leave these as-is unless you pulled different models):
 
 ```
 EMBER_MODEL=qwen3:8b
-EMBER_VISION_MODEL=llama3.2-vision:11b
+EMBER_VISION_MODEL=qwen3-vl:8b
 ```
 
 > `.env` is gitignored. It will never be committed to the repository.

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -34,7 +34,12 @@ REQUIREMENTS_PATH = REPO_ROOT / "requirements.txt"
 
 DEFAULT_VAULT = r"C:\EmberVault"
 DEFAULT_MODEL = "qwen2.5:14b"
-DEFAULT_VISION = "llama3.2-vision:11b"
+# Issue #130: llama3.2-vision:11b uses the mllama architecture, which
+# Ollama's engine dropped at v0.30.0 (llama.cpp never supported it
+# upstream). It pulls and lists fine but cannot load, so it is not a
+# viable default. qwen3-vl is the current-engine equivalent and matches
+# DEFAULT_VISION_MODEL in src/llm/vision_service.py.
+DEFAULT_VISION = "qwen3-vl:8b"
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -164,7 +164,7 @@ model=EMBER_MODEL_ID
 router = APIRouter()
 
 
-from src.llm.vision_service import VisionService
+from src.llm.vision_service import VisionService, VISION_UNAVAILABLE_RESPONSE
 
 memory_service = MemoryService()
 context_service = ContextService()
@@ -1637,11 +1637,37 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # best and the trigger for the trained "I can't view images" RLHF
     # refusal at worst. Clear image_data here so only the VL preprocessor
     # ever sees the raw bytes; downstream LLM calls stay text-only.
-    # When preprocessing FAILED (used_vision=False), keep image_data on
-    # the packet so the legacy vision path can still attempt direct
-    # routing if a vision-capable text model is configured.
-    if used_vision:
+    #
+    # Issue #130: image_data is now cleared on BOTH branches. Previously it
+    # was retained when preprocessing failed, so a "legacy direct routing"
+    # fallback could hand the raw images to the chat model. Nothing verified
+    # that the chat model was vision-capable and no shipped configuration
+    # uses one (the installer offers only the qwen3 text family), so in
+    # practice that path forwarded images to a text-only model, Ollama
+    # returned 400 "model does not support multimodal requests", and the
+    # exception escaped the ASGI handler after the 200 and the source badge
+    # frames had already been written. The user saw badges and no reply.
+    if image_data:
         context_packet.image_data = []
+
+    # A failed preprocess is terminal for an image-bearing turn. There is
+    # nothing left to answer from: the image is the query, and no text model
+    # downstream can read it. Short-circuit with a fixed message rather than
+    # generating a reply that would either hallucinate image content or hit
+    # the 400 above. early_return_response owns the stream-vs-JSON decision
+    # (CLAUDE.md Bug Standard #1) so a streaming client gets SSE, not a
+    # blank. The log line confirms the executed path at runtime (Standard #6).
+    if image_data and not used_vision:
+        logger.warning(
+            "[VISION] Preprocess unavailable - short-circuiting turn (images=%d)",
+            len(image_data),
+        )
+        return early_return_response(
+            VISION_UNAVAILABLE_RESPONSE,
+            _router_completion_id,
+            stream=bool(body.stream),
+            label="vision_unavailable",
+        )
 
     # Web search autonomous mode: when web_search_autonomous=True, execute
     # searches directly on thin-vault factual queries instead of telling the

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -204,7 +204,7 @@ def get_ember_vision_model() -> str | None:
     """
     Returns the Ollama vision model for image analysis, or None if not configured.
     Set EMBER_VISION_MODEL in .env to enable image analysis.
-      EMBER_VISION_MODEL=llama3.2-vision:11b
+      EMBER_VISION_MODEL=qwen3-vl:8b
     """
     return os.getenv("EMBER_VISION_MODEL") or None
 

--- a/src/llm/vision_service.py
+++ b/src/llm/vision_service.py
@@ -48,6 +48,19 @@ VISION_PROMPT = (
 # Maximum tokens for vision model output. Keeps preprocessing fast.
 VISION_MAX_TOKENS = 300
 
+# Emitted when images are present but VL preprocessing did not produce a
+# description (issue #130). Same trust class as SCRIPTED_CLARIFICATION_RESPONSE
+# in src/context/policies.py: a fixed string, never model-generated, so it
+# cannot itself be a hallucination.
+#
+# States the cause and the scope and stops. No apology, no closing question,
+# no offer to try again - the failure is environmental and retrying the same
+# turn will not clear it.
+VISION_UNAVAILABLE_RESPONSE: str = (
+    "I can't read that image right now. The vision model failed to load, "
+    "so image analysis is unavailable. Text conversation still works."
+)
+
 # JSON-lines structured log directory. Mirrors the pattern used by the
 # audit log and safety_reviews/coaching_filter logs — repo-local, one file
 # per UTC day. Diagnoses vision pipeline activity that the HTTP audit log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-"""
+r"""
 tests/conftest.py
 
-Session-scoped vault isolation fixture.
+Session-scoped vault isolation and rate-limiter fixtures.
 
 Ensures ALL tests run against a temporary test vault, never the live
 vault (C:\EmberVault). The override uses the runtime mechanism in
@@ -17,6 +17,35 @@ import pytest
 from pathlib import Path
 
 from src.core.config import set_vault_path_override, clear_vault_path_override
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_rate_limiter():
+    """Disable the shared slowapi limiter for the whole test session.
+
+    The limiter is global (60/minute, keyed on remote address) and every
+    TestClient request presents the same synthetic address, so the entire
+    suite draws on one bucket. That makes independent test files couple
+    through a shared global: adding an endpoint test anywhere can push an
+    unrelated file over the limit and fail it with 429.
+
+    That is not hypothetical. CI runs the suite in ~83s where local runs
+    take ~14 minutes, so the bucket refills locally and does not in CI.
+    Three new endpoint tests in test_vision_failure_path.py were enough to
+    fail test_web_search_header.py in CI while the full suite passed
+    locally, which is a false signal in the direction that matters least.
+
+    Rate limiting is production behaviour worth its own targeted test
+    (see tests/test_pin_service.py for the PIN attempt limiter, which
+    manages its own state). It should not be an implicit, order-dependent
+    budget shared across every test that touches the API.
+    """
+    from src.api.limiter import limiter
+
+    previous = limiter.enabled
+    limiter.enabled = False
+    yield
+    limiter.enabled = previous
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_vision_failure_path.py
+++ b/tests/test_vision_failure_path.py
@@ -1,0 +1,174 @@
+"""
+tests/test_vision_failure_path.py
+
+Regression tests for the vision preprocessing FAILURE path at
+src/api/openai_adapter.py.
+
+Found in UAT 2026-07-26 (issue #130): when the VL preprocessor could not
+load its model, the failure was caught non-fatal and the turn continued
+with image_data still on the context packet. The raw images were then
+forwarded to a text-only chat model, Ollama rejected the call with
+400 "model does not support multimodal requests", and that exception
+escaped the ASGI handler AFTER the 200 and the source badges had already
+been written to the stream. The client was left holding an open stream
+that never received content: badges present, response body empty.
+
+Coverage before this file stopped at the service boundary
+(test_vision_pipeline.py asserts analyze() returns empty on failure;
+test_vision_service_logging.py asserts the failure event is logged).
+Nothing asserted what the adapter does next, which is exactly where the
+defect lived.
+
+These tests drive the real chat completions endpoint with a multimodal
+payload and a vision_service that raises.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# A non-empty base64 string is sufficient. vision_service.analyze is mocked
+# in every test, so the bytes are never decoded.
+_FAKE_IMAGE_DATA_URL = "data:image/png;base64,aGVsbG8="
+
+
+def _multimodal_payload(text: str = "what is in this image", *, stream: bool = False) -> dict:
+    return {
+        "model": "ember",
+        "stream": stream,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": text},
+                    {"type": "image_url", "image_url": {"url": _FAKE_IMAGE_DATA_URL}},
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def client():
+    with patch("src.api.main.get_ember_api_key", return_value=None):
+        from src.api.main import app
+        yield TestClient(app)
+
+
+def test_vision_failure_does_not_forward_images_to_text_model(client):
+    """When the VL preprocessor raises, the turn must not reach the chat
+    model at all.
+
+    The chat model is text-only in every shipped configuration, so
+    forwarding raw images to it is what produced the Ollama 400 and the
+    escaped exception. Short-circuiting before generation is what makes
+    that structurally impossible rather than merely unlikely.
+    """
+    from src.context.models import ContextPacket
+
+    empty_packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", return_value=False):
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = empty_packet
+        # The exact failure observed in UAT: model load fails inside analyze().
+        _vision.analyze.side_effect = RuntimeError(
+            "llama-server process has terminated: unknown model architecture"
+        )
+        _llm.generate_response.return_value = "should never be produced"
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        # The load-bearing assertion: generation never ran, so no raw image
+        # bytes could reach a text-only model.
+        assert _llm.generate_response.call_count == 0
+
+
+def test_vision_failure_returns_sse_when_streaming(client):
+    """A streaming client must receive SSE carrying the message, never JSON.
+
+    This is the assertion that maps directly to the reported symptom.
+    CLAUDE.md Bug Standard #1: any early-return path in the streaming
+    endpoint must return a StreamingResponse when stream=True. Returning
+    JSON (or raising) renders as a blank reply with no surfaced error,
+    which is exactly what UAT saw.
+    """
+    from src.context.models import ContextPacket
+    from src.llm.vision_service import VISION_UNAVAILABLE_RESPONSE
+
+    empty_packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", return_value=False):
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = empty_packet
+        _vision.analyze.side_effect = RuntimeError("model load failed")
+        _llm.generate_response.return_value = "should never be produced"
+
+        resp = client.post(
+            "/v1/chat/completions", json=_multimodal_payload(stream=True)
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = resp.text
+        # The message reaches the client, and the stream terminates properly
+        # instead of hanging open with no content.
+        assert VISION_UNAVAILABLE_RESPONSE[:30] in body
+        assert "[DONE]" in body
+        assert _llm.generate_response.call_count == 0
+
+
+def test_vision_success_path_still_generates(client):
+    """Guard against over-correcting: a successful preprocess must still
+    reach generation, with the raw bytes stripped from the packet.
+
+    Without this, a fix that short-circuits too eagerly would disable
+    vision entirely and still pass the failure-path tests above.
+    """
+    from src.context.models import ContextPacket
+
+    packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", return_value=False):
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = packet
+        _vision.analyze.return_value = "A test image of a cat."
+        _llm.generate_response.return_value = "I see a cat."
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        assert _llm.generate_response.call_count == 1
+        # ADR-032: only the VL preprocessor sees raw bytes.
+        assert packet.image_data == []


### PR DESCRIPTION
Closes #130.

Two independent defects found in UAT 2026-07-26. Both fixed here because shipping either alone leaves the feature broken in a different way.

## A. Unguarded forward (the release blocker)

`image_data` was cleared only when VL preprocessing succeeded:

```python
if used_vision:
    context_packet.image_data = []
```

On the failure path the raw images stayed on the packet and were forwarded to the chat model, which is text-only in every shipped configuration. Ollama returned `400 Multimodal data provided, but model does not support multimodal requests`, and that exception escaped the ASGI handler *after* the 200 and the source badge frames had already been written. The client held an open stream that never received content, so the reviewer saw source badges and no reply.

Now `image_data` is cleared on both branches, and an image-bearing turn whose preprocess failed short-circuits through `early_return_response`, which owns the stream-vs-JSON decision (CLAUDE.md Bug Standard #1).

This removes the legacy direct-routing fallback that the old comment justified. That fallback was unreachable in practice: nothing verified the chat model was vision-capable, and the installer offers only the qwen3 text family. Gating it properly would mean adding a capability probe, which is scope this release does not need. If a vision-capable chat model is ever configured, that path should come back deliberately with a real check rather than as an untested default.

## B. The default vision model cannot load

`llama3.2-vision:11b` uses the `mllama` architecture. Ollama's engine dropped it at v0.30.0, and llama.cpp never supported it upstream. The model pulls and appears in `ollama list` because both only read the manifest, but loading fails:

```
$ ollama run llama3.2-vision:11b "hi"
error loading model: unknown model architecture: 'mllama'

$ ollama run qwen3-vl:2b "reply with the single word: ok"
ok
```

Verified on ollama 0.32.1 (latest is 0.32.4; both are past the v0.30.0 boundary, so upgrading does not help). Setup wizard default and SETUP.md move to `qwen3-vl:8b`, which matches the `DEFAULT_VISION_MODEL` already in `vision_service.py`. The backend default was already correct; only the install-time paths were wrong.

Without B, A ships a feature the installer recommends, downloads 6.4 GB for, and then cleanly reports as unavailable forever. Without A, the first user with an interrupted pull or an OOM hits the same silent hang.

## Tests

New `tests/test_vision_failure_path.py`, driving the real endpoint with a multimodal payload and a `vision_service` that raises:

1. `test_vision_failure_does_not_forward_images_to_text_model` — generation never runs, so raw bytes cannot reach a text-only model. This was the RED that drove the fix.
2. `test_vision_failure_returns_sse_when_streaming` — response is `text/event-stream` carrying the message and terminating with `[DONE]`, not JSON and not a hang. Maps directly to the reported symptom.
3. `test_vision_success_path_still_generates` — guards against over-correcting; a fix that short-circuited too eagerly would disable vision entirely and still pass 1 and 2.

Coverage previously stopped at the service boundary. `test_vision_pipeline.py` asserted `analyze()` returns empty on failure and `test_vision_service_logging.py` asserted the failure event is logged, but nothing asserted what the adapter does next, which is exactly where the defect lived.

Full suite: **2292 passed, 70 deselected, 2 xpassed**, no failures.

## Runtime verification

Bug Standard #5 requires the live trigger, not code inspection. The host `.env` still points at the broken model, which is the exact UAT condition. Authenticated image upload against the running API:

```
HTTP=200 CONTENT_TYPE=text/event-stream; charset=utf-8
data: {... "delta": {"content": "I can't read that image right now. The vision
       model failed to load, so image analysis is unavailable. Text
       conversation still works."} ...}
data: {... "finish_reason": "stop"}
data: [DONE]
```

Log at the fix point (Bug Standard #6):

```
[VISION] Preprocessor failed (non-fatal): ... unknown model architecture: 'mllama'
[VISION] Preprocess unavailable - short-circuiting turn (images=1)
```

No `Exception in ASGI application` and no `ResponseError` in the log for that turn.

## Companion PR

`ember-2-installer` needs the matching change so new installs stop writing the broken model into `.env`. That is a separate repo and therefore a separate PR; this one does not fix new installs on its own.

## Not included

- Existing `.env` files still point at `llama3.2-vision:11b`. This changes the default for new installs and documents the correct value; it does not rewrite user config.
- #131 (UI vision settings not persisting to the backend) is untouched.
