### PR TITLE
docs(release): v0.18.0 release notes

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,9 +1,14 @@
 # Ember-2 Release Notes
 
-All releases, newest first.
+All releases, newest first. One file per release, named for its version.
+
+The approved text for a release lands here before the tag is cut, so the notes
+carry the same provenance as the code. v0.11.0 through v0.17.1 predate this
+convention being picked back up and have no entry.
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.18.0](v0.18.0.md) | unreleased | One version number across all three repos, no invented links, honest record ages, WCAG 2.1 AA, Linux installer |
 | [v0.10.0](v0.10.0.md) | 2026-03-27 | Streaming, auto state extraction, project retrieval, typed memory, vault audit |
 | [v0.9.4](v0.9.4.md) | 2026-03-27 | Ember UI served from FastAPI, Open WebUI removed |
 | [v0.9.3](v0.9.3.md) | 2026-03-24 | Projects backend with CRUD and conversation assignment |

--- a/docs/releases/v0.18.0.md
+++ b/docs/releases/v0.18.0.md
@@ -1,0 +1,80 @@
+# Ember-2 v0.18.0
+
+## One version number
+
+Ember-2 is three pieces: the engine, the interface, and the installer. Each had its own version number, so "what version am I on" had three answers. Now they share one. The engine was at 0.17.1, the interface and installer at 0.8.1, and all three are now 0.18.0. Nothing was skipped, and from here they move together.
+
+## What's new
+
+Ember stopped inventing links. Asked about something she had no solid records for, she would sometimes produce a plausible URL that went nowhere, usually a fake GitHub path. Links that aren't backed by a real source now come through as "[unverified link]".
+
+Coaching phrases like "let's work through this" and "give yourself permission" get caught more often now, along with endless follow-up questions. Short replies are left alone, so answers that were already fine stop getting rewritten.
+
+Streaming is steadier. Empty messages, blocked requests, and the onboarding flow don't come back blank anymore. "Searching" and "reviewing" signals reach the interface, and it displays them.
+
+Long conversations hold up. Something you resolved in one turn stops resurfacing later. A conversation that outgrows the model's context window trims the oldest material instead of failing. Starting a new conversation clears the old one's working memory.
+
+Retrieval got honest about time. Ember was reading a stale index that hadn't refreshed since April, so recent conversations could be invisible to search. That index is gone. She also stopped misreporting how old a record is, the bug behind "a record from 345 days ago" about something written minutes earlier.
+
+Web search aims better. Recent sources rank above stale ones. Thinking out loud ("that's what I'm trying to figure out") no longer reads as a search request, and images don't trigger one at all. A one-word message gets a clarifying question instead of a guess.
+
+Ordinary use writes less to disk. Verbose diagnostics sit behind a debug flag.
+
+## Interface
+
+The interface meets WCAG 2.1 AA: 12 fixes across contrast, focus, labelling, and keyboard navigation, with an automated check on every change.
+
+You can see when Ember is reviewing. A breathing dot appears while review runs, so a pause reads as work rather than a hang.
+
+Source badges are correct again. A vault answer no longer gets tagged as though it came from the web.
+
+Assigning a conversation to a project retries once before giving up.
+
+The service status panel closes when you click away from it.
+
+Under the hood: appearance settings moved into their own context, dropping 16 pass-through props. The PIN flow uses explicit props instead of a window-event bus. Colors are tokenized to semantic names. A unit test layer was added, plus a 16-flow end-to-end suite that runs against the real interface.
+
+## Installer
+
+Linux support. Build config, CI, and install paths for Linux, with startup, Docker, reboot, and self-update handling hardened.
+
+A fresh install offers the qwen3 family rather than the older curated set.
+
+Update checks work again. Two faults stacked in one feature. The old check compared version strings for inequality, which gets fragile once numbers reach two digits, and 0.8.1 to 0.18.0 is exactly the jump string comparison gets wrong. Underneath that, the comparison couldn't read the release tags at all after they picked up a repo-name prefix at the end of April, so the update banner has been dead since then without saying so. Tags are back to the plain v0.18.0 form and the comparison is numeric.
+
+Values rendered into the installer window are inserted as text, not markup.
+
+The update panel shows release notes again. They weren't bundled into the build, so it came up empty.
+
+Duplicate install log lines are fixed. A button whose background work fails no longer leaves an unhandled error.
+
+Under the hood: every place the installer shells out to another program goes through one tested helper rather than a dozen hand-rolled call sites.
+
+## Under the hood (engine)
+
+The rest is internal. It doesn't change what you see; it makes the next release easier to build.
+
+- The 1350-line chat request handler was split into named phases: a frozen streaming wire format, an ordered router for the early exits, and a two-phase context pipeline. Behavior is identical. The code is legible.
+
+- Response-quality evals: automated scoring for whether Ember drifts in register over a long conversation, stays grounded in retrieved records, and holds her voice. Baselines are tracked in git, with a release-gate command to run them.
+
+- A UAT runner that walks the release acceptance scenarios from a definition file, so the manual pass before a release is repeatable rather than improvised.
+
+- Resolving a pending item writes a tombstone record instead of editing state in place, which keeps memory append-only.
+
+- The remaining unguarded file reads and writes go through atomic helpers, so a torn write can't leave a truncated record.
+
+- Status frames ship as their own typed frame, reconciling a mismatch between the engine and the interface. The interface side ships here too.
+
+- Constitution v0.8.
+
+- Fixes from the May UAT pass: open-loop suppression, deferred writes, an intent misroute, the status frame, and several detector corrections.
+
+- The cloud model id points at a reachable Sonnet release (claude-sonnet-4-5-20250929). The older dated id returned 404 for some keys.
+
+## Known issues
+
+- Tone on emotional queries still runs below target at this model size. The coaching filter reduces it without eliminating it.
+- Vault-retrieved content is presented with the same confidence regardless of how well it matches or how old it is.
+- The detectors for self-narrative, engagement-closing, and circular dodging match surface patterns, so novel phrasings can slip past. A corpus-driven replacement is targeted for v0.19.0.
+- The fast-streaming path can flash a few unfiltered tokens before review runs, on a deliberately crafted identity-override input.

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,53 +1,51 @@
 # Ember-2 v0.18.0
 
-**TLDR:** v0.18.0 puts Ember, the interface, and the installer on one version number. Ember stopped inventing links, stopped misreading how old her own records are, and holds up better in long conversations. The interface passed an accessibility audit. The installer runs on Linux.
+**TLDR:** Ember, the interface, and the installer now share one version number. Ember stopped inventing links, stopped misreading how old her records are, and holds up better in long conversations. The interface passed an accessibility audit. The installer runs on Linux.
 
 ---
 
 ## One version number
 
-Ember-2 is three pieces: the engine that does the thinking, the interface you talk to, and the installer that sets it all up and keeps it current. Each carried its own version number until now, which made "what version am I on" a question with three answers.
-
-From this release they share one. The engine was at 0.17.1, the interface and installer at 0.8.1, and all three are now 0.18.0. Nothing was skipped. The interface and installer numbers jumped to catch up, and from here the three move together.
+Ember-2 is three pieces: the engine, the interface, and the installer. Each had its own version number, so "what version am I on" had three answers. Now they share one. The engine was at 0.17.1, the interface and installer at 0.8.1, and all three are now 0.18.0. Nothing was skipped, and from here they move together.
 
 ---
 
 ## Character and behavior
 
-- No more invented links. Asked about a project or product she didn't have solid records for, qwen3:8b would sometimes produce a plausible-looking URL that led nowhere, usually a fake GitHub path. A post-generation validator now strips any link that isn't backed by an actual source. What you get instead is `[unverified link]`.
-- Less coaching register. The filter that catches "let's work through this", "give yourself permission", and endless follow-up questions got broader, trained on the exact phrasings that leaked through in testing. It checks intent before firing now, and it leaves very short replies alone, which stops it rewriting answers that were already fine. Still not perfect at qwen3:8b scale. But there's less of it.
+- Ember stopped inventing links. Asked about something she had no solid records for, she would sometimes produce a plausible URL that went nowhere, usually a fake GitHub path. Links that aren't backed by a real source now come through as `[unverified link]`.
+- Coaching phrases like "let's work through this" and "give yourself permission" get caught more often now, along with endless follow-up questions. Short replies are left alone, so answers that were already fine stop getting rewritten.
 
 ## Memory and retrieval
 
-- Recent conversations are findable again. Ember was reading from an index that hadn't refreshed since April, which could make recent conversations invisible to semantic search. That index is retired. Everything reads from the live store.
+- Recent conversations are findable again. Ember was reading a stale index that hadn't refreshed since April, so recent conversations could be invisible to search. That index is gone.
 - Record ages are correct. She stopped reporting something written minutes ago as being from hundreds of days back.
-- Long conversations hold up. A conversation that outgrows the model's context window now trims the oldest material in stages rather than failing the turn. State resolved in one turn stops resurfacing later, and starting a new conversation clears the previous one's working memory.
+- Long conversations hold up. Something you resolved in one turn stops resurfacing later. A conversation that outgrows the model's context window trims the oldest material instead of failing, and starting a new conversation clears the old one's working memory.
 
 ## Web search
 
-- Results carry a publication date signal, so recent sources rank above stale ones.
-- Thinking-out-loud phrases like "that's what I'm trying to figure out" don't read as a search request anymore, and image turns don't trigger a search at all.
-- A one-word or fragment message gets a short clarifying question rather than a guess.
+- Recent sources rank above stale ones.
+- Thinking out loud ("that's what I'm trying to figure out") no longer reads as a search request, and images don't trigger one at all.
+- A one-word message gets a clarifying question instead of a guess.
 
 ## Streaming and privacy
 
-- Early-return responses (an empty message, a blocked request, the onboarding flow) don't occasionally come back blank anymore. Status signals like "searching" and "reviewing" travel on a clean, versioned wire format, and the interface displays them now.
-- Verbose diagnostic output sits behind a debug flag rather than running all the time, so ordinary use writes less about your conversations to disk.
+- Streaming is steadier. Empty messages, blocked requests, and the onboarding flow don't come back blank anymore. "Searching" and "reviewing" signals reach the interface, and it displays them.
+- Ordinary use writes less to disk. Verbose diagnostics sit behind a debug flag.
 
 ## Interface
 
-- WCAG 2.1 AA pass: 12 fixes across contrast, focus handling, labelling, and keyboard navigation. An automated accessibility check runs on every change to keep it from quietly regressing.
-- A breathing dot appears while constitutional review runs on a draft, so a pause reads as work rather than a hang.
-- Vault-sourced and web-sourced answers are told apart properly again. A vault answer doesn't get tagged as though it came from the web.
-- Smaller fixes: assigning a conversation to a project retries once before giving up, and the service status panel closes when you click away from it.
+- The interface meets WCAG 2.1 AA: 12 fixes across contrast, focus, labelling, and keyboard navigation, with an automated check on every change.
+- A breathing dot appears while Ember is reviewing a draft, so a pause reads as work rather than a hang.
+- Source badges are correct again. A vault answer no longer gets tagged as though it came from the web.
+- Assigning a conversation to a project retries once before giving up, and the service status panel closes when you click away from it.
 
 ## Installer
 
-- Linux support: build configuration, CI, and platform-gated install paths, with startup task, Docker, reboot, and self-update handling hardened for Linux.
+- Linux support: build config, CI, and install paths, with startup, Docker, reboot, and self-update handling hardened.
 - Update checks work again. Two faults in one feature. The comparison was string-based, which breaks once a version number reaches two digits, and 0.8.1 to 0.18.0 is exactly that jump. Underneath that, it couldn't read the release tags at all after they picked up a repo-name prefix at the end of April, which had left the update banner dead since then. Tags go back to the plain `v0.18.0` form and the comparison is numeric.
-- Release notes render again. The notes file wasn't being bundled into the build, so the update panel came up empty.
+- The update panel shows release notes again. They weren't bundled into the build, so it came up empty.
 - A fresh install offers the qwen3 family rather than the older curated set.
-- Security and logs: values rendered into the installer window are inserted as text, not markup. Duplicate install log lines are fixed, and a button whose background work fails no longer leaves an unhandled error.
+- Values rendered into the installer window are inserted as text, not markup. Duplicate install log lines are fixed, and a button whose background work fails no longer leaves an unhandled error.
 
 ---
 
@@ -55,23 +53,23 @@ From this release they share one. The engine was at 0.17.1, the interface and in
 
 The rest is internal. It doesn't change what you see; it makes the next release easier to build.
 
-- **chat_completions decomposition** (issue #93, three parts): the ~1350-line request handler was broken into named phases. Part (a) consolidated the streaming wire format and froze it as a contract (ADR-040). Part (b) pulled the terminal short-circuits (empty / override / onboarding) into an ordered router (ADR-041). Part (c) extracted a GenerationContext and a two-phase enrichment pipeline, migrating the clarification path onto it (ADR-042). Behavior is identical. The code is now legible.
-- **Response-quality eval framework:** automated scoring on whether register and honesty drift over a long conversation, whether Ember stays grounded in retrieved records or confabulates, and whether she holds her voice. Built on a Claude judge with retry and transient-failure tolerance, provenance-stamped baselines tracked in git, and a local release-gate command. Register, grounding, drift, and user-expectation baselines are established.
-- **UAT acceptance runner:** an interactive script that walks the release acceptance scenarios from a YAML definition. The manual pass before a release is now repeatable rather than improvised.
-- **Append-only state resolution** (A2, ADR-038): resolving a pending item writes a tombstone record instead of mutating state in place, which preserves the append-only guarantee.
-- **Safe JSON I/O** (A3, ADR-039): the remaining unguarded file read/write sites route through atomic, corruption-aware helpers. A torn write can't leave a truncated record behind.
-- **SSE wire contract v2** (ADR-040): status frames ship as a top-level typed frame, reconciling a backend/interface mismatch under a documented change procedure. The interface side of that reconciliation ships in this release too.
-- **Constitution v0.8.**
-- **UAT workstream B fixes:** open-loop suppression (B-STATE-001), deferred I/O sites (B-IO-001), a Stage-2 intent misroute (B-CTX-001), the SSE status frame (B-SSE-001), and several self-narrative, engagement-closing, and circular-dodge detector fixes from the 2026-05-11 UAT pass.
-- **CLOUD_MODELS** points at a reachable Sonnet id (`claude-sonnet-4-5-20250929`). The older dated id returned 404 for some keys.
-- **Interface internals:** appearance settings moved into their own context (dropping 16 pass-through props), the PIN flow replaced a window-event bus with explicit props, colors were tokenized to semantic names, a Vitest unit layer was added, and a 16-flow end-to-end user journey suite now runs against the real interface.
-- **Installer internals:** every place the installer shells out to another program now goes through one tested helper rather than a dozen hand-rolled call sites.
+- The 1350-line chat request handler was split into named phases: a frozen streaming wire format, an ordered router for the early exits, and a two-phase context pipeline. Behavior is identical. The code is legible.
+- Response-quality evals: automated scoring for whether Ember drifts in register over a long conversation, stays grounded in retrieved records, and holds her voice. Baselines are tracked in git, with a release-gate command to run them.
+- A UAT runner that walks the release acceptance scenarios from a definition file, so the manual pass before a release is repeatable rather than improvised.
+- Resolving a pending item writes a tombstone record instead of editing state in place, which keeps memory append-only.
+- The remaining unguarded file reads and writes go through atomic helpers, so a torn write can't leave a truncated record.
+- Status frames ship as their own typed frame, reconciling a mismatch between the engine and the interface. The interface side ships here too.
+- Constitution v0.8.
+- Fixes from the May UAT pass: open-loop suppression, deferred writes, an intent misroute, the status frame, and several detector corrections.
+- The cloud model id points at a reachable Sonnet release (`claude-sonnet-4-5-20250929`). The older dated id returned 404 for some keys.
+- Interface internals: appearance settings moved into their own context, dropping 16 pass-through props. The PIN flow uses explicit props instead of a window-event bus. Colors are tokenized to semantic names. A unit test layer was added, plus a 16-flow end-to-end suite that runs against the real interface.
+- Installer internals: every place the installer shells out to another program goes through one tested helper rather than a dozen hand-rolled call sites.
 
 ---
 
 ## Known issues
 
-- Register and tone at qwen3:8b scale stay below target on emotional queries (M-001, A-001). Documented model-scale ceiling. The coaching filter mitigates it but doesn't eliminate it.
-- Vault-retrieved content is presented with uniform confidence regardless of match quality or age. No uncertainty signal yet.
-- The self-narrative, engagement-closing, and circular-dodge detectors are surface-pattern matchers. Novel phrasings can slip past until a corpus-driven detector lands (targeted v0.19.0).
-- The fast-streaming path can flash a few unfiltered tokens before constitutional review runs on a deliberately crafted identity-override input.
+- Tone on emotional queries still runs below target at this model size. The coaching filter reduces it without eliminating it.
+- Vault-retrieved content is presented with the same confidence regardless of how well it matches or how old it is.
+- The detectors for self-narrative, engagement-closing, and circular dodging match surface patterns, so novel phrasings can slip past. A corpus-driven replacement is targeted for v0.19.0.
+- The fast-streaming path can flash a few unfiltered tokens before review runs, on a deliberately crafted identity-override input.

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,74 +4,74 @@
 
 ---
 
-## One Version Number
+## One version number
 
-Ember-2 is three pieces: the engine that does the thinking, the interface you talk to, and the installer that sets it all up and keeps it current. Until now each carried its own version number, which made "what version am I on" a question with three answers.
+Ember-2 is three pieces: the engine that does the thinking, the interface you talk to, and the installer that sets it all up and keeps it current. Each carried its own version number until now, which made "what version am I on" a question with three answers.
 
-From this release they share one. The engine was at 0.17.1, the interface and installer were at 0.8.1, and all three are now 0.18.0. Nothing was skipped and nothing is missing. The interface and installer numbers jumped to catch up, and from here the three move together.
+From this release they share one. The engine was at 0.17.1, the interface and installer at 0.8.1, and all three are now 0.18.0. Nothing was skipped. The interface and installer numbers jumped to catch up, and from here the three move together.
 
 ---
 
-## Character and Behavior
+## Character and behavior
 
-- **No more invented links:** Asked about a project or product she did not have solid records for, qwen3:8b would sometimes produce a plausible-looking URL that led nowhere (a fake GitHub path, for example). A post-generation validator now strips any link not backed by an actual source, so a made-up link becomes `[unverified link]`.
-- **Less coaching register:** The filter that catches "let's work through this", "give yourself permission", and endless follow-up questions got broader, trained on the exact phrasings that leaked through in testing. It now checks intent before firing and leaves very short replies alone, so it stops rewriting answers that were already fine. Not perfect at qwen3:8b scale, but there is less of it.
+- No more invented links. Asked about a project or product she didn't have solid records for, qwen3:8b would sometimes produce a plausible-looking URL that led nowhere, usually a fake GitHub path. A post-generation validator now strips any link that isn't backed by an actual source. What you get instead is `[unverified link]`.
+- Less coaching register. The filter that catches "let's work through this", "give yourself permission", and endless follow-up questions got broader, trained on the exact phrasings that leaked through in testing. It checks intent before firing now, and it leaves very short replies alone, which stops it rewriting answers that were already fine. Still not perfect at qwen3:8b scale. But there's less of it.
 
-## Memory and Retrieval
+## Memory and retrieval
 
-- **Recent conversations are findable again:** Ember was reading from an index that had not refreshed since April, so recent conversations could be invisible to semantic search. That index is retired and everything now reads from the live store.
-- **Correct record ages:** She no longer reports something written minutes ago as being from hundreds of days back.
-- **Long conversations hold up:** Conversations that outgrow the model's context window now trim the oldest material in stages instead of failing the turn. State resolved in one turn stops resurfacing in later turns, and starting a new conversation clears the previous one's working memory.
+- Recent conversations are findable again. Ember was reading from an index that hadn't refreshed since April, which could make recent conversations invisible to semantic search. That index is retired. Everything reads from the live store.
+- Record ages are correct. She stopped reporting something written minutes ago as being from hundreds of days back.
+- Long conversations hold up. A conversation that outgrows the model's context window now trims the oldest material in stages rather than failing the turn. State resolved in one turn stops resurfacing later, and starting a new conversation clears the previous one's working memory.
 
-## Web Search
+## Web search
 
-- **Freshness ranking:** Results carry a publication date signal, so recent sources rank above stale ones.
-- **Fewer wrong triggers:** Thinking-out-loud phrases like "that's what I'm trying to figure out" no longer read as a search request, and image turns no longer trigger a search.
-- **Clarification on fragments:** A one-word or fragment message now gets a short clarifying question instead of a guess.
+- Results carry a publication date signal, so recent sources rank above stale ones.
+- Thinking-out-loud phrases like "that's what I'm trying to figure out" don't read as a search request anymore, and image turns don't trigger a search at all.
+- A one-word or fragment message gets a short clarifying question rather than a guess.
 
-## Streaming and Privacy
+## Streaming and privacy
 
-- **Steadier streaming:** Early-return responses (an empty message, a blocked request, the onboarding flow) no longer occasionally come back blank. Status signals like "searching" and "reviewing" travel on a clean, versioned wire format, and the interface now displays them.
-- **Quieter logging:** Verbose diagnostic output sits behind a debug flag rather than running all the time, so ordinary use writes less about your conversations to disk.
+- Early-return responses (an empty message, a blocked request, the onboarding flow) don't occasionally come back blank anymore. Status signals like "searching" and "reviewing" travel on a clean, versioned wire format, and the interface displays them now.
+- Verbose diagnostic output sits behind a debug flag rather than running all the time, so ordinary use writes less about your conversations to disk.
 
 ## Interface
 
-- **Accessibility:** WCAG 2.1 AA pass. 12 fixes across contrast, focus handling, labelling, and keyboard navigation, with an automated accessibility check on every change so it does not quietly regress.
-- **Review is visible:** A breathing dot appears while constitutional review runs on a draft, so a pause reads as work rather than a hang.
-- **Correct source badges:** Vault-sourced and web-sourced answers are told apart properly, so a vault answer no longer gets tagged as though it came from the web.
-- **Smaller fixes:** Assigning a conversation to a project retries once instead of silently dropping, and the service status panel closes when you click away from it.
+- WCAG 2.1 AA pass: 12 fixes across contrast, focus handling, labelling, and keyboard navigation. An automated accessibility check runs on every change to keep it from quietly regressing.
+- A breathing dot appears while constitutional review runs on a draft, so a pause reads as work rather than a hang.
+- Vault-sourced and web-sourced answers are told apart properly again. A vault answer doesn't get tagged as though it came from the web.
+- Smaller fixes: assigning a conversation to a project retries once before giving up, and the service status panel closes when you click away from it.
 
 ## Installer
 
-- **Linux support:** Build configuration, CI, and platform-gated install paths, with startup task, Docker, reboot, and self-update handling hardened for Linux.
-- **Update checks compare numbers:** Version comparison was string-based, which is fragile once numbers reach two digits. That is exactly the jump this release makes.
-- **Release notes render again:** The notes file was not being bundled into the build, so the update panel came up empty.
-- **Current model lineup:** A fresh install offers the qwen3 family rather than the older curated set.
-- **Security and logs:** Values rendered into the installer window are inserted as text, not markup. Duplicate install log lines are fixed, and a button whose background work fails no longer leaves an unhandled error.
+- Linux support: build configuration, CI, and platform-gated install paths, with startup task, Docker, reboot, and self-update handling hardened for Linux.
+- Update checks work again. Two faults in one feature. The comparison was string-based, which breaks once a version number reaches two digits, and 0.8.1 to 0.18.0 is exactly that jump. Underneath that, it couldn't read the release tags at all after they picked up a repo-name prefix at the end of April, which had left the update banner dead since then. Tags go back to the plain `v0.18.0` form and the comparison is numeric.
+- Release notes render again. The notes file wasn't being bundled into the build, so the update panel came up empty.
+- A fresh install offers the qwen3 family rather than the older curated set.
+- Security and logs: values rendered into the installer window are inserted as text, not markup. Duplicate install log lines are fixed, and a button whose background work fails no longer leaves an unhandled error.
 
 ---
 
-## Under the Hood
+## Under the hood
 
-Most of the rest of this release is internal, the kind of work that does not change what you see but makes everything more reliable and easier to build on.
+The rest is internal. It doesn't change what you see; it makes the next release easier to build.
 
-- **chat_completions decomposition** (issue #93, three parts): the ~1350-line request handler was broken into named phases. Part (a) consolidated the streaming wire format and froze it as a contract (ADR-040). Part (b) pulled the terminal short-circuits (empty / override / onboarding) into an ordered router (ADR-041). Part (c) extracted a GenerationContext and a two-phase enrichment pipeline, migrating the clarification path onto it (ADR-042). Behavior is identical; the code is now legible.
+- **chat_completions decomposition** (issue #93, three parts): the ~1350-line request handler was broken into named phases. Part (a) consolidated the streaming wire format and froze it as a contract (ADR-040). Part (b) pulled the terminal short-circuits (empty / override / onboarding) into an ordered router (ADR-041). Part (c) extracted a GenerationContext and a two-phase enrichment pipeline, migrating the clarification path onto it (ADR-042). Behavior is identical. The code is now legible.
 - **Response-quality eval framework:** automated scoring on whether register and honesty drift over a long conversation, whether Ember stays grounded in retrieved records or confabulates, and whether she holds her voice. Built on a Claude judge with retry and transient-failure tolerance, provenance-stamped baselines tracked in git, and a local release-gate command. Register, grounding, drift, and user-expectation baselines are established.
-- **UAT acceptance runner:** an interactive script that walks the release acceptance scenarios from a YAML definition, so the manual pass before a release is repeatable rather than improvised.
-- **Append-only state resolution** (A2, ADR-038): resolving a pending item writes a tombstone record instead of mutating state in place, preserving the append-only guarantee.
-- **Safe JSON I/O** (A3, ADR-039): the remaining unguarded file read/write sites route through atomic, corruption-aware helpers, so a torn write cannot leave a truncated record behind.
+- **UAT acceptance runner:** an interactive script that walks the release acceptance scenarios from a YAML definition. The manual pass before a release is now repeatable rather than improvised.
+- **Append-only state resolution** (A2, ADR-038): resolving a pending item writes a tombstone record instead of mutating state in place, which preserves the append-only guarantee.
+- **Safe JSON I/O** (A3, ADR-039): the remaining unguarded file read/write sites route through atomic, corruption-aware helpers. A torn write can't leave a truncated record behind.
 - **SSE wire contract v2** (ADR-040): status frames ship as a top-level typed frame, reconciling a backend/interface mismatch under a documented change procedure. The interface side of that reconciliation ships in this release too.
 - **Constitution v0.8.**
 - **UAT workstream B fixes:** open-loop suppression (B-STATE-001), deferred I/O sites (B-IO-001), a Stage-2 intent misroute (B-CTX-001), the SSE status frame (B-SSE-001), and several self-narrative, engagement-closing, and circular-dodge detector fixes from the 2026-05-11 UAT pass.
-- **CLOUD_MODELS** points at a reachable Sonnet id (`claude-sonnet-4-5-20250929`); the older dated id returned 404 for some keys.
+- **CLOUD_MODELS** points at a reachable Sonnet id (`claude-sonnet-4-5-20250929`). The older dated id returned 404 for some keys.
 - **Interface internals:** appearance settings moved into their own context (dropping 16 pass-through props), the PIN flow replaced a window-event bus with explicit props, colors were tokenized to semantic names, a Vitest unit layer was added, and a 16-flow end-to-end user journey suite now runs against the real interface.
-- **Installer internals:** every place the installer shells out to another program now goes through one tested helper instead of a dozen hand-rolled call sites.
+- **Installer internals:** every place the installer shells out to another program now goes through one tested helper rather than a dozen hand-rolled call sites.
 
 ---
 
-## Known Issues
+## Known issues
 
-- Register and tone at qwen3:8b scale stay below target on emotional queries (M-001, A-001). Documented model-scale ceiling; the coaching filter mitigates but does not eliminate it.
-- Vault-retrieved content is presented with uniform confidence regardless of match quality or age. There is no uncertainty signal yet.
-- The self-narrative, engagement-closing, and circular-dodge detectors are surface-pattern matchers; novel phrasings can slip past until a corpus-driven detector lands (targeted v0.19.0).
+- Register and tone at qwen3:8b scale stay below target on emotional queries (M-001, A-001). Documented model-scale ceiling. The coaching filter mitigates it but doesn't eliminate it.
+- Vault-retrieved content is presented with uniform confidence regardless of match quality or age. No uncertainty signal yet.
+- The self-narrative, engagement-closing, and circular-dodge detectors are surface-pattern matchers. Novel phrasings can slip past until a corpus-driven detector lands (targeted v0.19.0).
 - The fast-streaming path can flash a few unfiltered tokens before constitutional review runs on a deliberately crafted identity-override input.


### PR DESCRIPTION
Editing pass on the v0.18.0 release notes, plus a correction to one claim.

**Tightened.** Cut mechanism wind-ups in favour of the user-visible effect, dropped the qwen3:8b hedge that Known Issues already covers, and pulled internal vocabulary off the surface: ADR numbers, issue and workstream references, and the bug codes in Known Issues. The under-the-hood section keeps its substance for engineers, minus the identifiers. 1248 words to 1013.

**Corrected the update-check claim.** It read as though numeric comparison was the whole fix. It was half. The comparator also could not parse a component-prefixed release tag, which had disabled the in-app update banner outright since 2026-04-30. Both halves are described now, and both land in this release:

- niansahc/ember-2-installer#TBD - parser fix plus regression tests
- niansahc/ember-2-ui#TBD - bare release tags

Approved text.