### PR TITLE
fix(ci): use PAT for release-please to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Uses a PAT, not the default GITHUB_TOKEN. GitHub does not create
+      # workflow runs from events raised by GITHUB_TOKEN, so with the default
+      # the release PR gets no CI gate and the published release builds no
+      # installer artifacts. Secret setup and scopes: docs/RELEASE_WORKFLOW.md
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -18,6 +18,88 @@ ember-2 is the backend. It versions independently but must be pinned by ember-2-
 
 Release Please runs on `ember-2`, `ember-2-ui`, and `ember-2-installer`. Conventional Commits drive changelog generation and version bumps. Release-please opens a release PR on each repo; a human merges the PR to cut the release. The cross-repo build coordination still requires the manual checklist above (version pinning, ember-2-ui tag selection, installer bundling) — Release Please handles per-repo release mechanics, not cross-repo orchestration.
 
+## RELEASE_PLEASE_TOKEN (required secret)
+
+### Why it exists
+
+GitHub deliberately does not create workflow runs from events raised by the
+default `GITHUB_TOKEN`. `googleapis/release-please-action@v4` defaults to
+`token: ${{ github.token }}`, so every event release-please raises -- the
+release PR it opens, the tag it pushes, the GitHub Release it publishes -- is a
+dead end. Two gates were silently skipped as a result:
+
+- **pytest gate (ember-2)** -- `.github/workflows/tests.yml` runs on
+  `pull_request` into `main`. The release PR is opened by `github-actions[bot]`,
+  so no `pull_request` event fires and the gate never runs on the one PR that
+  ships to users. Confirmed on the v0.18.0 release PR: zero checks.
+- **artifact workflow (ember-2-installer)** -- `.github/workflows/release.yml`
+  runs on `release: [published]`. release-please publishes the release, so no
+  `release` event fires and the Windows / macOS / Linux installers are never
+  built. The v0.18.0 installer artifacts existed only because a human
+  republished the release by hand.
+
+Passing an explicit PAT attributes those events to a real user, which does fire
+workflows.
+
+### Scope
+
+`RELEASE_PLEASE_TOKEN` must be set as a repository secret in **all three**
+repos, because each runs its own release-please:
+
+- `niansahc/ember-2`
+- `niansahc/ember-2-ui`
+- `niansahc/ember-2-installer`
+
+One token, added three times. GitHub rejects secret names beginning with
+`GITHUB_`, which is why the name is not `GITHUB_PAT`.
+
+### Token type and permissions
+
+Fine-grained personal access token. GitHub Settings -> Developer settings ->
+Personal access tokens -> Fine-grained tokens.
+
+| Field | Value |
+|---|---|
+| Resource owner | `niansahc` |
+| Repository access | Only select repositories: `ember-2`, `ember-2-ui`, `ember-2-installer` |
+| Contents | Read and write (commits, branches, tags, releases) |
+| Pull requests | Read and write (open and update the release PR) |
+| Metadata | Read-only (mandatory, auto-selected) |
+
+Nothing else. Do not grant Workflows, Actions, Administration, or Secrets.
+
+`Workflows: Read and write` would only be needed if a release commit ever
+modified a file under `.github/workflows/`. The `extra-files` entry in
+`release-please-config.json` is `version.json` (plus `CHANGELOG.md`), so it is
+not needed today. If that changes, the failure is explicit: `refusing to allow a
+Personal Access Token to create or update workflow ... without workflow scope`.
+
+### Expiry and renewal
+
+Fine-grained PATs cap at 1 year. Created 2026-08-01, so it expires
+**2027-08-01**. Set a renewal reminder for **2027-07-24**, one week ahead.
+
+On expiry the `Release Please` job fails with `401 Bad credentials`. No release
+PR is opened or updated until the secret is replaced in all three repos.
+
+### Fallback behavior if the secret is missing
+
+There is deliberately no `|| github.token` fallback. If `RELEASE_PLEASE_TOKEN`
+is unset, the expression resolves to an empty string, which explicitly
+overrides the action's default, and the `Release Please` job fails with a
+credentials error on the next push to `main`.
+
+This is intentional. Silent degradation back to `GITHUB_TOKEN` is exactly the
+failure mode that hid this bug across several releases. A red job is the point.
+
+Nothing is lost when it fails: no commits, no tags, no partial release. Add the
+secret and re-run the job, or push any commit to `main`, and release-please
+picks up from the same place.
+
+**Sequencing:** add the secret to all three repos *before* merging the workflow
+change. If the change merges first, `Release Please` stays red until the secret
+exists.
+
 ## release-please Auto-Merge Prohibition
 
 Release-please PRs (title format: `chore(main): release X.Y.Z`) must NEVER have auto-merge enabled. These PRs require explicit human approval and manual merge only. All other PR types may use auto-merge as normal.


### PR DESCRIPTION
## Problem

GitHub does not create workflow runs from events raised by the default `GITHUB_TOKEN`. `googleapis/release-please-action@v4` defaults to `token: ${{ github.token }}`, so every event release-please raises is a dead end.

Two gates were silently skipped:

- **pytest gate (this repo)** - `tests.yml` runs on `pull_request` into `main`. The release PR is opened by `github-actions[bot]`, so no `pull_request` event fires. Verified on release PR #45 (`chore(main): release 0.18.0`): `statusCheckRollup` was empty. Zero checks ran on the PR that shipped v0.18.0.
- **artifact workflow (ember-2-installer)** - `release.yml` runs on `release: [published]`. release-please publishes the release, so no `release` event fires and the installers are never built. The v0.18.0 installer artifacts existed only because the release was republished by hand 15 minutes later.

## Change

Pass an explicit PAT (`RELEASE_PLEASE_TOKEN`) to the action. Events attributed to a real user do fire workflows. Companion PRs apply the same one-line change to ember-2-ui and ember-2-installer.

`docs/RELEASE_WORKFLOW.md` documents the secret: three-repo scope, fine-grained permissions (Contents RW, Pull requests RW, Metadata Read), expiry and renewal date, and the missing-secret failure behavior.

## No fallback, by design

There is no `|| github.token` fallback. A missing or expired token fails the `Release Please` job loudly with a credentials error. Silent degradation back to `GITHUB_TOKEN` is the exact failure mode that hid this across several releases.

The `RELEASE_PLEASE_TOKEN` secret is already set in all three repos, so this is safe to merge.

## Verification

Static:
- `tests.yml` is `on: pull_request: branches: [main]`; the release PR targets `main`. Fires.
- installer `release.yml` is `on: release: types: [published]` and `release-please-config.json` sets `"draft": false`, so the release is published at creation. Fires.
- `business-hours-check.yml` is `on: push: branches: [main]`. release-please pushes tags and a PR branch, never `main`, so it does not start firing on tag pushes.
- `Release Please` is itself `on: push: branches: [main]`. In PR mode release-please never pushes to `main`, so there is no self-trigger loop.

Live, at the next release cycle:
1. `gh pr view <release-pr> --json statusCheckRollup` must be non-empty and include `Tests`. Baseline: PR #45 was `[]`.
2. After merge, `gh run list --workflow=release.yml` in ember-2-installer must show a run with event `release` within ~1 min of release creation, with no manual republish.
3. `gh release view <tag> --json assets` must list the Windows `.exe` + `.blockmap`, macOS `.dmg`, Linux `.AppImage`, and `latest.yml`.

Not considered verified until step 1-3 produce that behavior on a real release.