### PR TITLE
docs: deployment boundary policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,18 @@ These decisions are locked. Do not undermine them:
 
 ---
 
+## Deployment Boundary
+
+Ember-2 ships for a single personal computer. Reference deployment: one user, local model via Ollama, default model per version.json era.
+
+Multi-user, voice, smart home, and server-class deployments are downstream consumers built outside this repo (e.g. ember-voice-gateway). The only in-repo support for such deployments is generic API capability: `caller_identity`, `access_tier`, and `modality` fields, ignorable by default.
+
+**Gate for any change: if a PC-only user's install changes at all, it does not ship in ember-2.**
+
+Nothing hardware-specific or deployment-specific enters defaults, docs, or the installer. Models are swappable components selected per release by eval, never an architectural dependency.
+
+---
+
 ## System Layers
 
 ```


### PR DESCRIPTION
Adds a **Deployment Boundary** section to `CLAUDE.md`, placed immediately after the Core Architectural Rules and before System Layers.

States the reference deployment (single personal computer, one user, local model via Ollama, default model per the version.json era) and draws the line between this repo and downstream consumers.

Multi-user, voice, smart home, and server-class deployments are built outside ember-2 (e.g. ember-voice-gateway). In-repo support for them is limited to generic API capability: `caller_identity`, `access_tier`, and `modality` fields, ignorable by default.

The operative gate: if a PC-only user's install changes at all, it does not ship in ember-2. Nothing hardware-specific or deployment-specific enters defaults, docs, or the installer, and models stay swappable components selected per release by eval rather than architectural dependencies.

Docs only. No code, no behavior change.