### PR TITLE
docs: v0.19.0 research graduation, ADR-037 citation

### DIFF
--- a/docs/Ember2_TDD.md
+++ b/docs/Ember2_TDD.md
@@ -1781,6 +1781,12 @@ Deferred from v0.16.0:
 - ~~CLOUD_MODELS reachable-id fix~~ ✓ - `claude-sonnet-4-5-20250929`
 - ADR-037 classifier SetFit graduation - step A on branch, not yet merged
 
+**v0.19.0: research graduation** (from the v0.19.0 research review; see 50.1 for the underlying watch items)
+- LightRAG architecture investigation - does dual-level entity/relationship retrieval fit a typed append-only vault under the local-first constraint, and what does indexing cost. Investigation only; outcome is an ADR or an explicit discard. Corroborating evidence: Opal (arXiv:2604.02522), +13 percentage points from KG enrichment, hardware-agnostic
+- SWAY counterfactual CoT eval - test counterfactual CoT against the current coaching filter on the manual battery (docs/eval_manual_test_battery.md). Outcome: adopt, reject, or hybridize. Was a watch item through v0.18.0; now an active eval task
+- MemMachine retrieval depth ablation - escalated from v0.18.0, where it was reviewed and deferred but never run. Note the known measurement floor: eval_retrieval.py cannot resolve improvements below 6.67% (one query verdict change), so the ablation needs a measurement plan before it starts. Evaluate RRF fusion (MemX, arXiv:2603.16171) in the same pass
+- SetFit labeling session - 150 examples per intent class from the classifier telemetry log (ADR-034), 0.85 confidence threshold for the Stage 1 / Stage 2 cascade. Threshold evidence: W5H2 + SetFit (arXiv:2602.18922), 91.1% accuracy at 22M parameters. Blocked: ADR-037 does not exist yet and must be written first
+
 **Post-v0.17.1**
 - Multi-user vault isolation
 - Windows/Mac/Linux full parity
@@ -1936,17 +1942,17 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
 
   Nucleus + neighbors: No documented failure pattern in Ember's eval history or KNOWN_ISSUES.md where relevant memory was missed due to fragmentation across adjacent records. The documented failure mode is vague queries producing hallucination on plausibly-matched but wrong records, a scoring problem not a fragmentation problem.
 
-  Decision: both changes deferred. Revisit when a specific failure either change would fix is observed in production.
-  → informs: deferred (no version assigned)
-  → graduation trigger: documented retrieval failure attributable to fixed injection depth or fragmented-context recall
+  Decision (v0.18.0): both changes deferred. Revisit when a specific failure either change would fix is observed in production.
 
-- **FileGram procedural memory paradigm** (Synvo-ai, arXiv:2604.04901, April 2026) — First benchmark treating agent personalization as procedural behavioral memory (workflow traces, file-system patterns) rather than semantic retrieval over text. Relevant if Ember extends beyond conversation records to behavioral memory types.
-  → informs: post-v0.18.0 (behavioral memory types — no version assigned)
-  → graduation trigger: Ember expands memory types beyond conversation, journal, profile, reflection
+  v0.19.0 disposition: the depth ablation was reviewed and deferred in v0.18.0 but never actually run - eval_history.md records no ablation. Item stays open and the ablation is escalated to a v0.19.0 task (see 25.3). Nucleus + neighbors remains deferred on the original reasoning: still no documented fragmentation failure.
+  → informs: v0.19.0 (retrieval depth ablation)
+  → graduation trigger: ablation run and result recorded in eval_history.md
 
-- **SWAY counterfactual CoT sycophancy mitigation** (Bhalla & Gligorić, JHU, arXiv:2604.02423, April 2026) — Explicit anti-sycophancy instruction yields moderate reductions and can backfire; counterfactual CoT mitigation drives sycophancy to near-zero without suppressing genuine responsiveness. Potential upgrade to position_holding and relational_hedging intervention pattern. Conflicts with current coaching filter approach — evaluate before v0.18.0 sycophancy work.
-  → informs: v0.18.0 (sycophancy intervention evaluation)
-  → graduation trigger: counterfactual CoT tested against current coaching filter on 19-question battery
+- **SWAY counterfactual CoT sycophancy mitigation** (Bhalla & Gligorić, JHU, arXiv:2604.02423, April 2026) — Explicit anti-sycophancy instruction yields moderate reductions and can backfire; counterfactual CoT mitigation drives sycophancy to near-zero without suppressing genuine responsiveness. Potential upgrade to position_holding and relational_hedging intervention pattern. Conflicts with current coaching filter approach.
+
+  v0.19.0 disposition: moved out of watch and into an active v0.19.0 eval task - test counterfactual CoT against the coaching filter on the manual battery (see 25.3). No longer research-only.
+  → informs: v0.19.0 (active eval task, not watch)
+  → graduation trigger: eval result recorded; adopt, reject, or hybridize with the coaching filter
 
 - **Neurodivergent-aware AI co-regulation framework** (Piskala, arXiv:2507.06864, 2025) — Privacy-first on-device framework for ADHD professionals using attention-state inference, adaptive nudges, and accountability presence (body doubling). Design principles match Ember's primary deployment context.
   → informs: post-v0.18.0 (proactive/body-doubling mode — no version assigned)
@@ -1956,9 +1962,11 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
   → informs: architectural validation only
   → graduation trigger: n/a — reference only
 
-- **LightRAG graph-based RAG for vault entity linking** (HKUDS, EMNLP 2025, active March 2026 updates) — Dual-level retrieval (entity + relationship) outperforms flat vector RAG. Requires 32B+ parameters for indexing — qwen3:8b is below threshold. Viable only with GPU upgrade (RTX 4060 Ti 16GB) enabling larger model for ingest. Query-time can use smaller model.
-  → informs: post-GPU-upgrade (local model grounding — no version assigned until hardware confirmed)
-  → graduation trigger: GPU upgrade confirmed AND Qwen2.5:14b Q4 runs at acceptable latency
+- **LightRAG graph-based RAG for vault entity linking** (HKUDS, EMNLP 2025, active March 2026 updates) — Dual-level retrieval (entity + relationship) outperforms flat vector RAG. Requires 32B+ parameters for indexing — qwen3:8b is below threshold. Query-time can use a smaller model. Corroborated by Opal (arXiv:2604.02522): knowledge graph enrichment recovers 13 percentage points of retrieval accuracy over semantic search alone, and that finding is hardware-agnostic.
+
+  v0.19.0 disposition: graduated out of watch to a v0.19.0 roadmap item as an architecture investigation (see 25.3). Investigation, not implementation - the question is whether dual-level entity/relationship retrieval fits Ember's typed append-only vault at all, and what the indexing cost is under the local-first constraint.
+  → informs: v0.19.0 (architecture investigation)
+  → graduation trigger: investigation concludes with an ADR or an explicit decision to discard
 
 - **OpenJarvis Learning primitive** (Stanford, github.com/open-jarvis/OpenJarvis, March 2026) — local-first framework for on-device personal AI agents. Five primitives: Intelligence, Engine, Agents, Tools & Memory, Learning. Learning primitive uses local interaction traces to synthesize training data and refine agent behavior. MCP support, semantic indexing for local retrieval. Reference architecture for self-evaluation loops.
   → informs: post-v0.17.0 (self-evaluation and decision-memory loops — deferred until actively using Ember)
@@ -2074,8 +2082,8 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
   → graduation trigger: deliberate decision to ship 4b as a configurable tier alongside 8b
 
 - **MemX local-first memory** (Sun, arXiv:2603.16171, March 2026) — Rust/libSQL implementation with RRF (vector + keyword fusion) and low-confidence rejection gate suppressing spurious recalls. Hit@1 = 91.3% default, 100% high-confusion. RRF fusion pattern relevant to retrieval depth ablation; rejection gate validates ZERO confidence block design.
-  → informs: retrieval depth ablation (deferred, no failure pattern yet)
-  → graduation trigger: retrieval depth ablation scheduled
+  → informs: v0.19.0 retrieval depth ablation (now scheduled - see MemMachine entry and 25.3)
+  → graduation trigger: ablation run; RRF fusion evaluated as part of it
 
 - **Dynamic Affective Memory entropy-minimization** (Lu & Li, arXiv:2510.27418) — Bayesian-inspired memory update using entropy as consolidation signal. Minimizing global memory entropy as vault health metric is more principled than time-based triggers. Relevant to vault knowledge linting design.
   → informs: post-v0.18.0 vault linting
@@ -2089,7 +2097,11 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
 
 - **How RLHF amplifies sycophancy** (Shapira et al., arXiv:2602.01002, January 2026) - Mathematical proof that RLHF optimization causally increases sycophancy. Strongest available citation for the commercial-design-choice argument. No implementation action. Graduation trigger: graduate immediately to paper Section 2.2.
 
-- **W5H2 + SetFit intent classification at agent scale** (arXiv:2602.18922, February 2026) - SetFit at 22M parameters achieves 91.1% accuracy at 2-5ms versus 68.8% zero-shot for a 20B LLM (700x latency advantage confirmed). The 0.85 confidence cascade threshold is now evidence-grounded. Graduation trigger: graduate to the ADR-037 implementation spec.
+- **W5H2 + SetFit intent classification at agent scale** (arXiv:2602.18922, February 2026) - SetFit at 22M parameters achieves 91.1% accuracy at 2-5ms versus 68.8% zero-shot for a 20B LLM (700x latency advantage confirmed). The 0.85 confidence cascade threshold is now evidence-grounded.
+
+  v0.19.0 disposition: the labeling session is now a tracked v0.19.0 task (see 25.3) - 150 examples per intent class, 0.85 confidence threshold for the Stage 1 / Stage 2 cascade. This citation is the evidence base for that threshold and belongs in the ADR-037 rationale; ADR-037 does not exist yet, so the citation is held here until it is written.
+  → informs: v0.19.0 (SetFit labeling session), ADR-034 upgrade path
+  → graduation trigger: ADR-037 written with this citation in the rationale
 
 - **Hybrid retrieval + local cross-encoder reranker** (arXiv:2604.01733, April 2026) - BM25 + dense + RRF + cross-encoder is the 2026 production retrieval stack; the cross-encoder adds +17.4% Recall@5 over RRF alone. Local option: cross-encoder/ms-marco-MiniLM-L-6-v2 (22M params, CPU-compatible). Informs v0.19.0 retrieval phase 2; add after the BM25 + RRF baseline lands. Graduation trigger: BM25 + RRF baseline implemented and ablation confirms improvement.
 
@@ -2110,6 +2122,7 @@ Primary research monitoring sources: arxiv.org ("local LLM memory", "personal AI
 - ~~**Habit-to-identity formation** (Verplanken & Sui, Frontiers in Psychology, 2019)~~ — implemented in ADR-013 reason field requirement; repetition alone does not produce identity, behavior must be noticed and valued
 - ~~**McAdams narrative identity framework**~~ — implemented in monthly reflection prompts (third-person synthesis, narrative arc)
 - ~~**Memory in the Age of AI Agents** (Hu et al., arXiv:2512.13564, Dec 2025)~~ — taxonomy validated against Ember architecture, no changes indicated; hot/warm/cold tiering maps to their Dynamics layer
+- ~~**FileGram procedural memory paradigm** (Synvo-ai, arXiv:2604.04901, April 2026)~~ — discarded at the v0.19.0 research review. Procedural behavioral memory (workflow traces, file-system patterns) got no field traction and is out of scope: Ember's memory types are conversational and reflective, and expanding into behavioral traces is not on any roadmap
 
 ---
 

--- a/docs/adr/ADR-037-intent-classifier-setfit-graduation.md
+++ b/docs/adr/ADR-037-intent-classifier-setfit-graduation.md
@@ -1,0 +1,75 @@
+# ADR-037: Intent Classifier SetFit Graduation
+
+**Status:** Proposed
+**Date:** 2026-08-31
+**Target:** v0.19.0
+
+## Context
+
+ADR-034 (ask-first intent classifier) established the three-tier cascade for classifying every user query as `needs_internet` or `vault_answerable`: Stage 1 structural rules, Stage 2 embedding similarity against a labeled example pool, Stage 3 qwen3:8b fallback with a timeout that defaults to `vault_answerable`. ADR-034's own "Upgrade Path" section already specifies the next step: once 150+ real Ember-2 queries are labeled per class (collected via the mandatory classification log), train a SetFit model (Tunstall et al., 2022) to replace Stage 1 + Stage 2 entirely. `src/llm/intent_classifier.py:20` carries a literal `TODO: SetFit upgrade when 150 labels/class accumulated from logs.` comment placed per that mandate.
+
+`docs/Ember2_TDD.md` tracks this as a blocked v0.19.0 task: the SetFit labeling session (150 examples/class, 0.85 confidence threshold for the Stage 1/Stage 2 cascade) is listed as a tracked v0.19.0 item, explicitly gated on this ADR existing (`Ember2_TDD.md:1788`, `2102-2104`). The threshold evidence — W5H2 + SetFit (arXiv:2602.18922): 91.1% accuracy at 22M parameters, 2-5ms latency versus 68.8% zero-shot for a 20B LLM — is held in the TDD's research log pending this ADR's rationale section (`Ember2_TDD.md:2100-2104`).
+
+A partial implementation ("Step A": 7 new labeled-example buckets — `status_state`, `reflective`, `factual_recall`, `recent_activity`, `recent`, `activity`, `is_identity` — added to `src/llm/classifier_examples.py`) already exists, but only on branch `feat/adr-037-step-a-classifier-examples` (commit `d3c1142`, 2026-04-28). That branch diverged from `main` at `efcea2e` (2026-04-25) and has never been rebased or merged — `main` is now three-plus months and dozens of merges ahead. The branch's own code carries the comment `# Step B; Stage 2 imports EXAMPLES, not MULTICLASS_EXAMPLES.` — the new `MULTICLASS_EXAMPLES` export is data with no consumer. No document (TDD, ADR-034, commit messages) fully enumerates Steps B through E; only Step A's own commit message gestures at what B, C, and D might involve, and Step E is unnamed anywhere in the project's history.
+
+`README.md`'s v0.18.0 section currently states that "ADR-037 classifier migration" shipped in that release. That claim is inaccurate — none of this work is on `main` — and is a documentation correction out of scope for this ADR.
+
+## Decision
+
+Graduate ADR-034's Stage 1 + Stage 2 to a trained SetFit model once 150+ labeled examples per class exist, exactly as ADR-034's own Upgrade Path section specifies. **Stage 3 is explicitly untouched by this ADR** — the qwen3:8b LLM fallback, its JSON grammar constraint, and the timeout-defaults-to-`vault_answerable` behavioral contract remain as ADR-034 defined them. This ADR governs only the SetFit replacement of Stages 1 and 2.
+
+## Scope
+
+**In scope:** `src/llm/intent_classifier.py`, `src/llm/classifier_examples.py`.
+
+**Out of scope:** `src/context/policies.py`'s `classify_query` and its `RELATIONAL_KINSHIP_NOUNS` / `RELATIONAL_IDENTITY_DOMAINS` pattern matching. That logic filters which memory types are eligible for retrieval on relational/identity queries — a distinct concern from the needs_internet/vault_answerable ask-first gate this ADR governs. `classify_query` already calls into the ADR-034 cascade via `classify_intent()`; that integration is unaffected by this ADR.
+
+Step A's `is_identity` bucket was designed, per its own commit message, to eventually absorb pet-possessive and kinship identity routing currently living in `policies.py`, migrating that responsibility into the intent classifier's label space. That migration is **descoped from this ADR**. It would fold a retrieval-filtering concern into the ask-first intent gate, which this ADR does not adopt. If kinship/identity routing consolidation is still wanted, it belongs in a separate future ticket against `policies.py`, not this graduation.
+
+## Steps
+
+| Step | Scope | Status |
+|---|---|---|
+| A | Labeled example buckets in `classifier_examples.py` | Exists but stale and unmerged. Branch `feat/adr-037-step-a-classifier-examples`, commit `d3c1142`, diverged from `main` at `efcea2e` (2026-04-25). Must be rebased onto current `main` and merged before Step B can start. |
+| B | Wire `MULTICLASS_EXAMPLES` into Stage 2 classification | Not started. |
+| C/D | Delete `RELATIONAL_KINSHIP_NOUNS` / identity keyword bags from `policies.py` (per Step A's commit-message intent) | **Descoped from this ADR** — see Scope section. File as a separate future ticket against `policies.py` if still desired. |
+| E | Undefined | No historical record — TDD, commit messages, or ADR-034 — names what Step E was intended to cover. Marked TBD. A future amendment to this ADR should define it if and when scope is identified. |
+
+## Rationale
+
+- ADR-034 already committed to this upgrade path; this ADR formalizes the trigger (150 labels/class) and threshold (0.85 confidence) with citation-backed evidence rather than leaving them as an unwritten TODO.
+- W5H2 + SetFit (arXiv:2602.18922) demonstrates SetFit at 22M parameters reaches 91.1% accuracy at 2-5ms latency, a 700x latency advantage over a 20B-parameter LLM zero-shot baseline — consistent with ADR-034's stated rationale for a cascade design (cheap-fast to expensive-accurate) and directly supports replacing Stages 1+2, which exist for exactly the latency reasons SetFit addresses at higher accuracy.
+- Keeping scope confined to `intent_classifier.py` and `classifier_examples.py` keeps this ADR independent of the unrelated `classify_query` kinship-routing concern, avoiding the scope bleed Step A's own design implied.
+- Marking Steps C/D/E as descoped or undefined, rather than inventing a scope for them now, keeps this ADR's claims honest against what can actually be verified in the codebase and project history.
+
+## Consequences
+
++ Closes the SetFit upgrade path ADR-034 already promised, unblocking the v0.19.0 SetFit labeling session tracked in the TDD.
++ Formalizes the 0.85 confidence threshold and 150-label/class trigger with citation-backed evidence.
++ Scope stays independent of the unrelated `classify_query` / kinship-routing concern in `policies.py`.
+
+- Step A requires a rebase onto current `main` before any further work can proceed — this is real, unstarted effort; the branch is not close to mergeable as-is.
+- Steps C, D, and E remain open questions this ADR deliberately does not resolve. A reader expecting a complete A-E roadmap will not find one here.
+- Stage 3's LLM fallback remains a qwen3:8b round-trip on the ambiguous long tail; this ADR does nothing to reduce that cost, since Stage 3 is out of scope.
+
+## Alternatives Considered
+
+### Fold Steps C/D (kinship keyword-bag removal) into this ADR
+Rejected. `RELATIONAL_KINSHIP_NOUNS`/`RELATIONAL_IDENTITY_DOMAINS` govern memory-type eligibility for retrieval, not the needs_internet/vault_answerable gate. Merging them into the SetFit graduation would make this ADR's "Decision" section describe two unrelated architectural changes, and would make the intent classifier's label space responsible for a retrieval-filtering behavior it was never designed to own.
+
+### Invent a defined scope for Step E
+Rejected. No source — TDD, ADR-034, commit messages, prior PRs — names what Step E was meant to cover. Fabricating scope for it here would misrepresent project history rather than document it.
+
+## Relationship to Other ADRs
+
+- **ADR-034** (ask-first intent classifier) — parent. This ADR executes the Upgrade Path section ADR-034 itself specifies; same upstream/prerequisite citation pattern ADR-034 uses to relate itself to ADR-018.
+- **ADR-018** (intent-aware type gating) — unaffected. Distinct concern (memory-type eligibility, not the ask-first gate).
+
+## References
+
+- `docs/adr/ADR-034-ask-first-intent-classifier.md` — Upgrade Path section (SetFit trigger and replacement scope).
+- Tunstall et al. "Efficient Few-Shot Learning Without Prompts (SetFit)." arXiv:2209.11055, 2022.
+- W5H2 + SetFit intent classification at agent scale. arXiv:2602.18922, February 2026.
+- `docs/Ember2_TDD.md` §25.3 (v0.19.0 research graduation — SetFit labeling session task).
+- Commit `d3c1142`, branch `feat/adr-037-step-a-classifier-examples` (Step A implementation, stale/unmerged).
+- `src/llm/intent_classifier.py:20` — existing TODO marker this ADR resolves.


### PR DESCRIPTION
Applies the v0.19.0 research review dispositions to `docs/Ember2_TDD.md` (sections 25.3 and 50.x).

## Watch item dispositions (50.1)

- **FileGram** - removed from Active Watch Items, recorded in 50.2 Graduated as an explicit discard (no field traction, out of scope). 50.1's own rule is that graduation requires a build item *or an explicit decision to discard*, so the discard is recorded rather than deleted, preserving the audit trail.
- **LightRAG** - graduated to a v0.19.0 roadmap item as an architecture investigation. Also removed the stale hardware precondition (RTX 4060 Ti / Qwen2.5:14b) and replaced the graduation trigger with the Opal corroboration (arXiv:2604.02522, +13pp from KG enrichment, hardware-agnostic).
- **SWAY** - moved out of watch into an active v0.19.0 eval task: counterfactual CoT tested against the coaching filter on the manual battery.
- **MemMachine** - **kept open**, ablation escalated to v0.19.0. See below.
- **Piskala (2025)** and **Specification Trap (2025)** - untouched, triggers unchanged as instructed.
- **MemX** - trigger updated for consistency (it was gated on "retrieval depth ablation scheduled", which is now true).

## MemMachine: reporting which branch was taken

Instruction was to close if the retrieval depth ablation ran in v0.18.0, otherwise escalate and keep open.

**It did not run.** `docs/eval_history.md` contains no ablation entry (last entry is 2026-04-20), and `ablation` appears nowhere in the repo outside the TDD's own forward-looking text. What v0.18.0 actually did was a *pre-implementation review* that deferred both proposed changes without running either. So: item stays open, ablation escalated to v0.19.0.

The v0.19.0 task carries the measurement-floor caveat already recorded in the TDD: `eval_retrieval.py` cannot resolve improvements below 6.67% (one query verdict change), and MemMachine's reported gain is +4.2%. The ablation needs a measurement plan before it starts or it cannot produce a readable result.

## New 25.3 roadmap block

Adds a **v0.19.0: research graduation** block covering the four graduated items above plus the SetFit labeling session.

## ADR-037 - partially blocked

The citation could not be added to ADR-037's rationale: **ADR-037 does not exist.** Verified across `docs/adr/` (which jumps 036 -> 038), every local and remote branch, and the full git history with `--diff-filter=A`. The TDD's claim at 25.3 that it is "step A on branch, not yet merged" does not correspond to any branch in this repo.

What landed instead: the W5H2 + SetFit citation (arXiv:2602.18922) is expanded in 50.1 with an explicit note that it is the evidence base for the 0.85 threshold and is being held there until ADR-037 is written. The v0.19.0 labeling task (150 examples per intent class, 0.85 cascade threshold) is tracked in 25.3 and marked blocked on the ADR.

Writing ADR-037 was not in scope for this commit, so it is not included here.

## Model section

No change, per instruction. qwen3:8b remains the production default; the register ceiling on emotional queries stays documented (50.3 "Template response collapse"). I read "no candidate list, no eval hardware references" as *do not add* them, not *strip the existing ones* - the existing hardware references sit inside recorded eval results (v0.18.0 comparison, the 2026-05-08 attempt, the qwen3:4b comparison), and deleting those would destroy eval history. Say the word if the intent was removal.

Docs only. No code, no behavior change.