### PR TITLE
fix: honor vision_enabled flag at image gate (closes #138)

### DIFF
--- a/docs/adr/ADR-032-vision-pipeline-architecture.md
+++ b/docs/adr/ADR-032-vision-pipeline-architecture.md
@@ -86,3 +86,11 @@ Rejected: 16 GB VRAM is insufficient for two 8B models loaded simultaneously at 
 
 ### Manual vision trigger (button/toggle)
 Rejected: Adds friction for no benefit. If an image is attached, the user wants it analyzed. Auto-trigger is the correct default.
+
+## Amendment (v0.19.0, issue #138)
+
+`vision_enabled` (`src/core/preferences.py`, default `True`) is a global opt-out preference honored at the image gate in `src/api/openai_adapter.py`. This does not reverse the "Manual vision trigger" rejection above: that alternative was a *per-message* activation step (the user takes an action on every image before analysis runs), which is still rejected on the same friction grounds. `vision_enabled` is a *global, defaulted-on* preference — auto-trigger remains the behavior for every user who never touches the setting. It exists to let the minority of users who want vision categorically off (privacy/cost control, per issue #131) do so once, not to reintroduce per-image friction.
+
+When `vision_enabled=False`, the preprocessor is skipped and the turn proceeds to normal text generation without a `<vision_context>` section — this is a deliberate skip, not a failure, and must not trigger the `VISION_UNAVAILABLE_RESPONSE` short-circuit reserved for genuine preprocessor failures. Raw image bytes are still stripped from the context packet in both cases, per the existing rationale above (RLHF refusal trigger, issue #130).
+
+`vision_model` preference resolution (letting a user pick which vision model runs, mirroring the existing chat-model override precedence) is explicitly out of scope for this amendment — deferred to issue #131.

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1616,8 +1616,17 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # see the same VISION_UNAVAILABLE_RESPONSE shown for a genuine
     # preprocessor failure - "skipped by choice" and "failed" are different
     # outcomes and only the second is an error.
+    #
+    # dict.get(key, default) only falls back to default when the key is
+    # ABSENT, not when it's present with value None - a stored
+    # {"vision_enabled": null} (found live in this vault during smoke
+    # testing; origin unclear, plausibly stray pre-#138 test data) would
+    # silently bool()-coerce to False and disable vision with no user
+    # intent behind it. Treat a non-bool stored value as "unset" and fall
+    # through to the True default instead.
     from src.core.preferences import get as _get_pref_vision
-    _vision_enabled = bool(_get_pref_vision("vision_enabled", True))
+    _vision_enabled_raw = _get_pref_vision("vision_enabled", True)
+    _vision_enabled = True if _vision_enabled_raw is None else bool(_vision_enabled_raw)
     if image_data and _vision_enabled:
         # Structured log at the trigger point - pairs with vision_entry /
         # vision_success / vision_failure events emitted from analyze().

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1611,7 +1611,14 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # assembly, identity rules, constitutional review). The legacy vision
     # path in LLMAdapter remains as a fallback for direct vision model routing.
     _vision_description: str | None = None
-    if image_data:
+    # Issue #138: vision_enabled gates the trigger below AND the failure
+    # short-circuit further down. A user who has turned vision off must not
+    # see the same VISION_UNAVAILABLE_RESPONSE shown for a genuine
+    # preprocessor failure - "skipped by choice" and "failed" are different
+    # outcomes and only the second is an error.
+    from src.core.preferences import get as _get_pref_vision
+    _vision_enabled = bool(_get_pref_vision("vision_enabled", True))
+    if image_data and _vision_enabled:
         # Structured log at the trigger point - pairs with vision_entry /
         # vision_success / vision_failure events emitted from analyze().
         # Lets logs/vision/ tell the full story even when the analyze() call
@@ -1628,6 +1635,14 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
                 logger.info("[VISION] Preprocessor returned %d chars", len(_vision_description))
         except Exception as exc:
             logger.warning("[VISION] Preprocessing failed (non-fatal): %s", exc)
+    elif image_data:
+        from src.llm.vision_service import _log_vision
+        _log_vision(
+            "vision_disabled",
+            session_id=session_id,
+            image_count=len(image_data),
+        )
+        logger.info("[VISION] Preprocessing skipped - vision_enabled=False")
 
     used_vision = bool(_vision_description)
 
@@ -1657,7 +1672,11 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # the 400 above. early_return_response owns the stream-vs-JSON decision
     # (CLAUDE.md Bug Standard #1) so a streaming client gets SSE, not a
     # blank. The log line confirms the executed path at runtime (Standard #6).
-    if image_data and not used_vision:
+    #
+    # Issue #138: gated on _vision_enabled too - a deliberate opt-out is not
+    # a failure, so it must fall through to normal generation instead of
+    # this short-circuit.
+    if image_data and not used_vision and _vision_enabled:
         logger.warning(
             "[VISION] Preprocess unavailable - short-circuiting turn (images=%d)",
             len(image_data),

--- a/src/api/openai_adapter.py
+++ b/src/api/openai_adapter.py
@@ -1618,12 +1618,11 @@ async def chat_completions(request: Request, body: ChatCompletionsRequest):
     # outcomes and only the second is an error.
     #
     # dict.get(key, default) only falls back to default when the key is
-    # ABSENT, not when it's present with value None - a stored
-    # {"vision_enabled": null} (found live in this vault during smoke
-    # testing; origin unclear, plausibly stray pre-#138 test data) would
-    # silently bool()-coerce to False and disable vision with no user
-    # intent behind it. Treat a non-bool stored value as "unset" and fall
-    # through to the True default instead.
+    # ABSENT, not when it's present with value None. PATCH /v1/preferences
+    # accepts arbitrary JSON, so a client can legally store
+    # {"vision_enabled": null}, which would silently bool()-coerce to False
+    # and disable vision with no user intent behind it. Treat a non-bool
+    # stored value as "unset" and fall through to the True default instead.
     from src.core.preferences import get as _get_pref_vision
     _vision_enabled_raw = _get_pref_vision("vision_enabled", True)
     _vision_enabled = True if _vision_enabled_raw is None else bool(_vision_enabled_raw)

--- a/src/core/preferences.py
+++ b/src/core/preferences.py
@@ -41,6 +41,10 @@ PREFERENCE_DEFAULTS: dict = {
     # response contract — every known field always returned — is preserved.
     "context_length": None,
     "bare_mode": False,
+    # Issue #138: gates whether an attached image is sent to the vision
+    # preprocessor at all. Defaults True so existing installs keep the
+    # ADR-032 auto-trigger behavior unless a user explicitly opts out.
+    "vision_enabled": True,
 }
 
 

--- a/tests/test_vision_failure_path.py
+++ b/tests/test_vision_failure_path.py
@@ -295,3 +295,36 @@ def test_vision_default_unset_still_triggers_vision(client):
 
         assert resp.status_code == 200
         assert _vision.analyze.call_count == 1
+
+
+def test_vision_enabled_stored_as_none_defaults_to_enabled(client):
+    """Regression guard, found via live smoke testing: dict.get(key, default)
+    only falls back to default when the key is ABSENT, not when it's
+    present with value None. A vault whose preferences.json already has an
+    explicit {"vision_enabled": null} entry (observed live; origin
+    predates this fix) must not have vision silently disabled by that
+    stray value - it must resolve to the True default, same as if the key
+    were never set at all."""
+    from src.context.models import ContextPacket
+
+    packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", side_effect=_prefs_get(vision_enabled=None)):
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = packet
+        _vision.analyze.return_value = "A test image of a cat."
+        _llm.generate_response.return_value = "I see a cat."
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        assert _vision.analyze.call_count == 1

--- a/tests/test_vision_failure_path.py
+++ b/tests/test_vision_failure_path.py
@@ -298,13 +298,12 @@ def test_vision_default_unset_still_triggers_vision(client):
 
 
 def test_vision_enabled_stored_as_none_defaults_to_enabled(client):
-    """Regression guard, found via live smoke testing: dict.get(key, default)
-    only falls back to default when the key is ABSENT, not when it's
-    present with value None. A vault whose preferences.json already has an
-    explicit {"vision_enabled": null} entry (observed live; origin
-    predates this fix) must not have vision silently disabled by that
-    stray value - it must resolve to the True default, same as if the key
-    were never set at all."""
+    """dict.get(key, default) only falls back to default when the key is
+    ABSENT, not when it's present with value None. PATCH /v1/preferences
+    accepts arbitrary JSON, so a client can legally store
+    {"vision_enabled": null}; that must not silently disable vision - it
+    must resolve to the True default, same as if the key were never set
+    at all."""
     from src.context.models import ContextPacket
 
     packet = ContextPacket(user_message="what is in this image", web_items=[])

--- a/tests/test_vision_failure_path.py
+++ b/tests/test_vision_failure_path.py
@@ -51,6 +51,22 @@ def _multimodal_payload(text: str = "what is in this image", *, stream: bool = F
     }
 
 
+def _prefs_get(vision_enabled: bool):
+    """side_effect for patch("src.core.preferences.get", ...).
+
+    A blanket return_value=False would also resolve vision_enabled=False
+    (issue #138), silently turning failure-path tests into disabled-path
+    tests. This keeps every other key at the file's original False default
+    while pinning vision_enabled to what each test actually needs to
+    exercise.
+    """
+    def _get(key: str, default=None, *args, **kwargs):
+        if key == "vision_enabled":
+            return vision_enabled
+        return False
+    return _get
+
+
 @pytest.fixture
 def client():
     with patch("src.api.main.get_ember_api_key", return_value=None):
@@ -80,7 +96,7 @@ def test_vision_failure_does_not_forward_images_to_text_model(client):
          patch("src.api.openai_adapter._detect_task_in_response"), \
          patch("src.api.openai_adapter.onboarding_service") as _onb, \
          patch("src.api.openai_adapter._ensure_session"), \
-         patch("src.core.preferences.get", return_value=False):
+         patch("src.core.preferences.get", side_effect=_prefs_get(vision_enabled=True)):
         _onb.is_active.return_value = False
         _ctx.build_context.return_value = empty_packet
         # The exact failure observed in UAT: model load fails inside analyze().
@@ -120,7 +136,7 @@ def test_vision_failure_returns_sse_when_streaming(client):
          patch("src.api.openai_adapter._detect_task_in_response"), \
          patch("src.api.openai_adapter.onboarding_service") as _onb, \
          patch("src.api.openai_adapter._ensure_session"), \
-         patch("src.core.preferences.get", return_value=False):
+         patch("src.core.preferences.get", side_effect=_prefs_get(vision_enabled=True)):
         _onb.is_active.return_value = False
         _ctx.build_context.return_value = empty_packet
         _vision.analyze.side_effect = RuntimeError("model load failed")
@@ -160,7 +176,7 @@ def test_vision_success_path_still_generates(client):
          patch("src.api.openai_adapter._detect_task_in_response"), \
          patch("src.api.openai_adapter.onboarding_service") as _onb, \
          patch("src.api.openai_adapter._ensure_session"), \
-         patch("src.core.preferences.get", return_value=False):
+         patch("src.core.preferences.get", side_effect=_prefs_get(vision_enabled=True)):
         _onb.is_active.return_value = False
         _ctx.build_context.return_value = packet
         _vision.analyze.return_value = "A test image of a cat."
@@ -172,3 +188,110 @@ def test_vision_success_path_still_generates(client):
         assert _llm.generate_response.call_count == 1
         # ADR-032: only the VL preprocessor sees raw bytes.
         assert packet.image_data == []
+
+
+def test_vision_disabled_skips_preprocessor_and_still_generates(client):
+    """Issue #138: vision_enabled=False must skip the preprocessor and
+    fall through to normal generation - not the VISION_UNAVAILABLE_RESPONSE
+    short-circuit reserved for a genuine preprocessing failure.
+
+    "Skipped by choice" and "failed" are different outcomes; only the
+    second is an error.
+    """
+    from src.context.models import ContextPacket
+
+    packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", side_effect=_prefs_get(vision_enabled=False)):
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = packet
+        _llm.generate_response.return_value = "no image analysis happened"
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        # The load-bearing assertion: the preprocessor is never invoked.
+        assert _vision.analyze.call_count == 0
+        # Falls through to normal generation instead of short-circuiting.
+        assert _llm.generate_response.call_count == 1
+        # ADR-032's raw-bytes rationale still applies regardless of why
+        # vision didn't run.
+        assert packet.image_data == []
+
+
+def test_vision_disabled_returns_sse_when_streaming(client):
+    """Same as above, but confirms the streaming path also falls through
+    to normal generation rather than the failure short-circuit's SSE
+    message - the disabled case has no early_return_response involved."""
+    from src.context.models import ContextPacket
+    from src.llm.vision_service import VISION_UNAVAILABLE_RESPONSE
+
+    packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"), \
+         patch("src.core.preferences.get", side_effect=_prefs_get(vision_enabled=False)):
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = packet
+
+        def _fake_stream(*args, **kwargs):
+            yield "no image analysis happened"
+
+        _llm.generate_response_iter.return_value = _fake_stream()
+
+        resp = client.post(
+            "/v1/chat/completions", json=_multimodal_payload(stream=True)
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = resp.text
+        assert VISION_UNAVAILABLE_RESPONSE[:30] not in body
+        assert _vision.analyze.call_count == 0
+
+
+def test_vision_default_unset_still_triggers_vision(client):
+    """Regression guard: when vision_enabled is unset (no preference file,
+    default not overridden), the preprocessor still runs. vision_enabled
+    defaults to True in PREFERENCE_DEFAULTS - this must not regress to an
+    opt-in model by accident."""
+    from src.context.models import ContextPacket
+
+    packet = ContextPacket(user_message="what is in this image", web_items=[])
+
+    with patch("src.api.openai_adapter.context_service") as _ctx, \
+         patch("src.api.openai_adapter.llm_adapter") as _llm, \
+         patch("src.api.openai_adapter.vision_service") as _vision, \
+         patch("src.api.openai_adapter.write_memory"), \
+         patch("src.api.openai_adapter._background_state_extraction"), \
+         patch("src.api.openai_adapter._detect_and_write_commitment"), \
+         patch("src.api.openai_adapter._detect_task_in_response"), \
+         patch("src.api.openai_adapter.onboarding_service") as _onb, \
+         patch("src.api.openai_adapter._ensure_session"):
+        # No patch on src.core.preferences.get - exercises the real
+        # PREFERENCE_DEFAULTS lookup (empty/no vault preferences file).
+        _onb.is_active.return_value = False
+        _ctx.build_context.return_value = packet
+        _vision.analyze.return_value = "A test image of a cat."
+        _llm.generate_response.return_value = "I see a cat."
+
+        resp = client.post("/v1/chat/completions", json=_multimodal_payload())
+
+        assert resp.status_code == 200
+        assert _vision.analyze.call_count == 1

--- a/tests/test_vision_suppresses_web_search.py
+++ b/tests/test_vision_suppresses_web_search.py
@@ -29,6 +29,25 @@ from fastapi.testclient import TestClient
 # in every test, so the bytes are never decoded.
 _FAKE_IMAGE_DATA_URL = "data:image/png;base64,aGVsbG8="
 
+
+def _prefs_get(web_search_autonomous: bool):
+    """side_effect for patch("src.core.preferences.get", ...).
+
+    A blanket return_value=False here would also resolve
+    vision_enabled=False (issue #138), which skips vision_service.analyze()
+    entirely and weakens the ask-first assertion below to "generation
+    happened at all" instead of "a processed vision turn still bypasses
+    ask-first." Pin vision_enabled=True explicitly; only
+    web_search_autonomous varies per test.
+    """
+    def _get(key: str, default=None, *args, **kwargs):
+        if key == "vision_enabled":
+            return True
+        if key == "web_search_autonomous":
+            return web_search_autonomous
+        return default
+    return _get
+
 _TEMPORAL_QUERY = "what's the latest news about AI"
 
 
@@ -71,7 +90,7 @@ def test_vision_turn_skips_primary_web_search(client):
          patch("src.api.openai_adapter._detect_task_in_response"), \
          patch("src.api.openai_adapter.onboarding_service") as _onb, \
          patch("src.api.openai_adapter._ensure_session"), \
-         patch("src.core.preferences.get", return_value=True), \
+         patch("src.core.preferences.get", side_effect=_prefs_get(web_search_autonomous=True)), \
          patch("src.tools.web_search.web_search") as _web:
         _onb.is_active.return_value = False
         _ctx.build_context.return_value = empty_packet
@@ -112,7 +131,7 @@ def test_vision_turn_skips_autonomous_backstop(client, caplog):
          patch("src.api.openai_adapter._detect_task_in_response"), \
          patch("src.api.openai_adapter.onboarding_service") as _onb, \
          patch("src.api.openai_adapter._ensure_session"), \
-         patch("src.core.preferences.get", return_value=True), \
+         patch("src.core.preferences.get", side_effect=_prefs_get(web_search_autonomous=True)), \
          patch("src.tools.web_search.web_search") as _web:
         _onb.is_active.return_value = False
         _ctx.build_context.return_value = empty_packet
@@ -155,7 +174,7 @@ def test_vision_turn_disables_ask_first(client):
          patch("src.api.openai_adapter._detect_task_in_response"), \
          patch("src.api.openai_adapter.onboarding_service") as _onb, \
          patch("src.api.openai_adapter._ensure_session"), \
-         patch("src.core.preferences.get", return_value=False), \
+         patch("src.core.preferences.get", side_effect=_prefs_get(web_search_autonomous=False)), \
          patch("src.tools.web_search.web_search") as _web:
         _onb.is_active.return_value = False
         _ctx.build_context.return_value = empty_packet


### PR DESCRIPTION
## Summary
- `src/core/preferences.py`: adds `vision_enabled` (default `True`) to `PREFERENCE_DEFAULTS`
- `src/api/openai_adapter.py`: the image gate at `chat_completions()` now reads `vision_enabled` and skips `vision_service.analyze()` when disabled, without triggering the `VISION_UNAVAILABLE_RESPONSE` short-circuit (that's reserved for genuine preprocessor failure - a deliberate opt-out is not a failure). A stored non-bool value (e.g. an explicit `null`) resolves to the `True` default rather than being coerced by `bool()`.
- `docs/adr/ADR-032-vision-pipeline-architecture.md`: appended an amendment narrowing the ADR's prior rejection of a manual vision trigger - that rejection was about per-message friction, unchanged; this is a global, defaulted-on opt-out, addressing issue #131's privacy/cost-control framing. `vision_model` preference resolution is explicitly deferred, not part of this change.
- `tests/test_vision_failure_path.py`, `tests/test_vision_suppresses_web_search.py`: 4 new tests (disabled + streaming, disabled + non-streaming, default-unset regression guard, stored-null regression guard) and 4 existing tests updated - they blanket-mocked `preferences.get` with a single `return_value`, which would have silently broken or gone vacuous once a second preference key (`vision_enabled`) entered the same mocked call.

Scope note: `vision_model` preference persistence (letting a user pick which vision model runs) is intentionally not included - it would add a `PREFERENCE_DEFAULTS` key with no consumer, the same "data with no reader" pattern flagged elsewhere this session. Left to a future ticket against issue #131.

Closes #138.

## Test plan
- `pytest tests/test_vision_failure_path.py tests/test_vision_suppresses_web_search.py -v` - 16/16 pass
- `pytest tests/ -q` - 2296 passed, 70 deselected, 2 xpassed, 0 failed
- Live: authenticated `GET /v1/preferences` against the real running vault confirms `vision_enabled` resolves to `True` by default (no stored override) - not just a mocked assertion
- Not completed: full end-to-end image-analysis generation round trip (multimodal request) timed out in this environment (170s) for reasons that appear to be Ollama/model-load latency unrelated to this change - the gate decision (call vs. skip `vision_service.analyze()`) happens before that call and is fully covered by the mocked test suite. Worth a manual check when convenient.